### PR TITLE
Fix/trust constr

### DIFF
--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -68,7 +68,7 @@ class OptimizerBase(metaclass=StructMeta):
     cv_tol = UnsignedFloat(default=1e-6)
     similarity_tol = UnsignedFloat()
 
-    _options = ['progress_frequency', 'n_cores', 'cv_tol', 'similarity_tol']
+    _general_options = ['progress_frequency', 'n_cores', 'cv_tol', 'similarity_tol']
 
     def optimize(
             self,
@@ -470,7 +470,18 @@ class OptimizerBase(metaclass=StructMeta):
     @property
     def options(self):
         """dict: Optimizer options."""
-        return {opt: getattr(self, opt) for opt in self._options}
+        return {
+            opt: getattr(self, opt)
+            for opt in (self._general_options + self._specific_options)
+        }
+
+    @property
+    def specific_options(self):
+        """dict: Optimizer spcific options."""
+        return {
+            opt: getattr(self, opt)
+            for opt in (self._specific_options)
+        }
 
     def __str__(self):
         return self.__class__.__name__

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -34,7 +34,7 @@ class PymooInterface(OptimizerBase):
     ftol = UnsignedFloat(default=0.0025)
     n_max_gen = UnsignedInteger()
     n_max_evals = UnsignedInteger(default=100000)
-    _options = OptimizerBase._options + [
+    _specific_options = [
         'seed', 'pop_size', 'xtol', 'cvtol', 'ftol', 'n_max_gen', 'n_max_evals',
     ]
 

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -88,7 +88,7 @@ class SciPyInterface(OptimizerBase):
                 tol=self.tol,
                 jac=self.jac,
                 constraints=self.get_constraint_objects(optimization_problem),
-                options=self.options,
+                options=self.specific_options,
                 callback=callback_function,
             )
 
@@ -280,7 +280,8 @@ class TrustConstr(SciPyInterface):
     maxiter = UnsignedInteger(default=1000)
     verbose = UnsignedInteger(default=0)
     disp = Bool(default=False)
-    _options = OptimizerBase._options + [
+
+    _specific_options = [
         'gtol', 'xtol', 'barrier_tol', 'finite_diff_rel_step',
         'initial_constr_penalty',
         'initial_tr_radius', 'initial_barrier_parameter',
@@ -313,7 +314,8 @@ class COBYLA(SciPyInterface):
     disp = Bool(default=False)
     catol = UnsignedFloat(default=0.0002)
     cv_tol = catol
-    _options = OptimizerBase._options + ['rhobeg', 'maxiter', 'disp', 'catol']
+
+    _specific_options = ['rhobeg', 'maxiter', 'disp', 'catol']
 
 
 class NelderMead(SciPyInterface):
@@ -326,7 +328,7 @@ class NelderMead(SciPyInterface):
     xatol = UnsignedFloat(default=0.01)
     fatol = UnsignedFloat(default=0.01)
     adaptive = Bool(default=True)
-    _options = OptimizerBase._options + [
+    _specific_options = [
         'maxiter', 'maxfev', 'initial_simplex', 'xatol', 'fatol', 'adaptive'
     ]
 
@@ -350,4 +352,4 @@ class SLSQP(SciPyInterface):
     ftol = UnsignedFloat(default=1e-2)
     eps = UnsignedFloat(default=1e-6)
     disp = Bool(default=False)
-    _options = OptimizerBase._options + ['ftol', 'eps', 'disp']
+    _specific_options = ['ftol', 'eps', 'disp']

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -88,6 +88,7 @@ class SciPyInterface(OptimizerBase):
                 tol=self.tol,
                 jac=self.jac,
                 constraints=self.get_constraint_objects(optimization_problem),
+                bounds=self.get_bounds(optimization_problem),
                 options=self.specific_options,
                 callback=callback_function,
             )

--- a/docs/source/user_guide/optimization/optimizer.md
+++ b/docs/source/user_guide/optimization/optimizer.md
@@ -23,7 +23,7 @@ It is responsible for converting the {class}`~CADETProcess.optimization.Optimiza
 Currently, adapters to {class}`Pymoo <CADETProcess.optimization.PymooInterface>` {cite}`pymoo2020` and {class}`Scipy's <CADETProcess.optimization.SciPyInterface>` optimization suite {cite}`SciPyContributors2020` are implemented, all of which are published under open source licenses that allow for academic as well as commercial use.
 
 Before the optimization can be run, the optimizer needs to be initialized and configured.
-All implementations share the following
+All implementations share the following options:
 
 - {attr}`~CADETProcess.optimization.OptimizerBase.progress_frequency`: Number of generations after which optimizer reports progress.
 - {attr}`~CADETProcess.optimization.OptimizerBase.n_cores`: The number of cores that the optimizer should use.


### PR DESCRIPTION
Fixes issue where unknown (internal) optimizer options raise exception in `scipy.minimize(method='trust_constr')`.

See also post in forum: https://forum.cadet-web.de/t/trustconstr-optimizer-scipy-in-cadet-process/689/4