### PR TITLE
Fix parallelization error 'Cadet' object has no attribute '_is_file_class'

### DIFF
--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -254,7 +254,7 @@ class Cadet(SimulatorBase):
             raise TypeError('Expected Process')
 
         if cadet is None:
-            cadet = CadetAPI()
+            cadet = self.get_new_cadet_instance()
 
         cadet.root = self.get_process_config(process)
 
@@ -295,14 +295,22 @@ class Cadet(SimulatorBase):
 
         return results
 
-    def save_to_h5(self, process, file_path):
+    def get_new_cadet_instance(self):
         cadet = CadetAPI()
+        # Because the initialization in __init__ isn't guaranteed to be called in multiprocessing
+        #  situations, ensure that the cadet_path has actually been set.
+        if not hasattr(cadet, "cadet_path"):
+            cadet.cadet_path = self.install_path
+        return cadet
+
+    def save_to_h5(self, process, file_path):
+        cadet = self.get_new_cadet_instance()
         cadet.root = self.get_process_config(process)
         cadet.filename = file_path
         cadet.save()
 
     def run_h5(self, file_path):
-        cadet = CadetAPI()
+        cadet = self.get_new_cadet_instance()
         cadet.filename = file_path
         cadet.load()
         cadet.run_load(timeout=self.timeout)
@@ -310,7 +318,7 @@ class Cadet(SimulatorBase):
         return cadet
 
     def load_from_h5(self, file_path):
-        cadet = CadetAPI()
+        cadet = self.get_new_cadet_instance()
         cadet.filename = file_path
         cadet.load()
 


### PR DESCRIPTION
In a single-threaded case (and also apparently in some multi-threaded cases) the [line 160](https://github.com/fau-advanced-separations/CADET-Process/blob/29eb5cc463892b4e969dcd07f3cd9fb968bcce23/CADETProcess/simulator/cadetAdapter.py#LL160C1-L160C47)

``` Python 
if install_path.exists():
    self._install_path = install_path
    CadetAPI.cadet_path = install_path
    self.logger.info(f"CADET was found here: {install_path}")
```

sets the cadet_path for the class object CadetAPI, which in turn sets _is_file_class and _is_file. In some multi-threaded cases on windows, this change to CadetAPI isn't inherited into the spawned threads.

This PR adds a check if this assignment occurred in the local thread and, if not, sets the cadet_path.

