### PR TITLE
Fix indexing for Events and OptimizationVariables

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,12 @@ repos:
   rev: v1.14.5
   hooks:
   - id: jupytext
-    files: './examples'
-    exclude: 'README.md|^index.md'
-    args: [--from, md, --to, "py:percent", './examples/*/*.md']
+    files: 'examples/[^/]+/'
+    types_or: [markdown, python]
+    exclude: |
+        (?x)^(
+            README.md|
+            examples/[^/]+/index.md|
+            examples/[^/]+/index.py
+        )$
+    args: [--sync]

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -7,13 +7,13 @@ import matplotlib.pyplot as plt
 
 from CADETProcess import CADETProcessError
 from CADETProcess import plotting
-from CADETProcess.dataStructure import StructMeta, String
+from CADETProcess.dataStructure import Structure, String
 from CADETProcess.dataStructure import get_nested_value
 from CADETProcess.solution import SolutionBase
 from CADETProcess.comparison import DifferenceBase
 
 
-class Comparator(metaclass=StructMeta):
+class Comparator(Structure):
     """
     Class for comparing simulation results against reference data.
 

--- a/CADETProcess/dataStructure/__init__.py
+++ b/CADETProcess/dataStructure/__init__.py
@@ -25,6 +25,7 @@ References
     :toctree: generated/
 
     dataStructure
+    aggregator
     parameter
     parameter_group
     cache
@@ -34,6 +35,7 @@ References
 """
 
 from .dataStructure import *
+from .aggregator import *
 from .parameter import *
 from .parameter_group import *
 from .cache import *

--- a/CADETProcess/dataStructure/__init__.py
+++ b/CADETProcess/dataStructure/__init__.py
@@ -9,8 +9,8 @@ This module provides datastructures to simplify defining setters and getters for
 (model) parameters.
 It is mostly based on the data model introduced in [1]_
 
-Note
-----
+Notes
+-----
 
 At some point it might be considered to switch to attrs
 (see `#15 <https://github.com/fau-advanced-separations/CADET-Process/issues/15>`_).

--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+from .dataStructure import Aggregator
+
+
+class SizedAggregator(Aggregator):
+    """Aggregator for sized parameters."""
+
+    def _parameter_shape(self, instance):
+        values = self._get_parameter_values_from_container(instance)
+        shapes = [np.array(el, ndmin=1).shape for el in values]
+
+        if len(set(shapes)) > 1:
+            raise ValueError("Inconsistent parameter shapes.")
+
+        if len(shapes) == 0:
+            return ()
+
+        return shapes[0]
+
+    def _expected_shape(self, instance):
+        return (self._n_instances(instance), ) + self._parameter_shape(instance)
+
+    def _get_parameter_values_from_container(self, instance):
+        value = super()._get_parameter_values_from_container(instance)
+
+        if value is None or len(value) == 0:
+            return
+
+        value = np.array(value, ndmin=2).T
+        return value
+
+    def _check(self, instance, value, recursive=False):
+        expected_shape = self._expected_shape(instance)
+        if value.shape != expected_shape:
+            raise ValueError(
+                f"Expected a array with shape {expected_shape}, got {value.shape}"
+            )
+
+        if recursive:
+            super()._check(instance, value, recursive)
+
+    def _prepare(self, instance, value, recursive=False):
+        value = np.array(value)
+
+        if recursive:
+            value = super()._prepare(instance, value, recursive)
+
+        return value
+
+
+class ClassDependentAggregator(Aggregator):
+    """Aggregator where parameter name changes depending on instance type."""
+
+    def __init__(self, *args, mapping, **kwargs):
+        """
+        Initialize the Aggregator descriptor.
+
+        Parameters
+        ----------
+        mapping : dict
+            Mapping of instance types and parameter names.
+        *args : tuple, optional
+            Additional positional arguments.
+        **kwargs : dict, optional
+            Additional keyword arguments.
+
+        """
+        self.mapping = mapping
+
+        super().__init__(*args, **kwargs)
+
+    def _get_parameter_values_from_container(self, instance):
+        container = self._container_obj(instance)
+
+        values = []
+        for el in container:
+            if type(el) in self.mapping:
+                attr = self.mapping[type(el)]
+            else:
+                attr = self.mapping[None]
+                if attr is None:
+                    continue
+
+            value = getattr(el, attr)
+            values.append(value)
+
+        if len(values) == 0:
+            return
+
+        return values
+
+class SizedClassDependentAggregator(SizedAggregator, ClassDependentAggregator):
+    pass

--- a/CADETProcess/dataStructure/cache.py
+++ b/CADETProcess/dataStructure/cache.py
@@ -1,4 +1,4 @@
-from .dataStructure import StructMeta
+from .dataStructure import Structure
 from .parameter import Bool
 
 
@@ -22,7 +22,7 @@ class cached_property_if_locked(property):
         return self.fget.__name__
 
 
-class CachedPropertiesMixin(metaclass=StructMeta):
+class CachedPropertiesMixin(Structure):
     lock = Bool(default=False)
 
     def __init__(self, *args, **kwargs):

--- a/CADETProcess/dataStructure/cache.py
+++ b/CADETProcess/dataStructure/cache.py
@@ -23,8 +23,17 @@ class cached_property_if_locked(property):
 
 
 class CachedPropertiesMixin(Structure):
-    lock = Bool(default=False)
+    _lock = Bool(default=False)
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
+        self.cached_properties = {}
+
+    @property
+    def lock(self):
+        return self._lock
+
+    @lock.setter
+    def lock(self, lock):
+        self._lock = lock
         self.cached_properties = {}

--- a/CADETProcess/dataStructure/dataStructure.py
+++ b/CADETProcess/dataStructure/dataStructure.py
@@ -2,71 +2,12 @@ from abc import ABC
 from collections import OrderedDict
 from inspect import Parameter, Signature
 from functools import wraps
+from warnings import warn
+
+from addict import Dict
 
 
-def make_signature(names):
-    return Signature(
-            Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
-            for name in names)
-
-
-class StructMeta(type):
-    """Base class for classes that use Descriptors.
-
-    See Also
-    --------
-    Descriptor
-    Parameters
-
-    """
-    @classmethod
-    def __prepare__(cls, name, bases):
-        return OrderedDict()
-
-    def __new__(cls, clsname, bases, clsdict):
-        descriptors = [
-            key for key, val in clsdict.items()
-            if isinstance(val, Descriptor)
-        ]
-
-        for name in descriptors:
-            clsdict[name].name = name
-
-        clsdict['descriptors'] = descriptors
-
-        clsobj = super().__new__(cls, clsname, bases, dict(clsdict))
-
-        parameters = []
-
-        try:
-            parameters += clsobj._parameters
-        except AttributeError:
-            pass
-
-        # Collect parameters and descriptors from parent classes
-        for base in bases:
-            try:
-                parameters += base._parameters
-            except AttributeError:
-                pass
-            try:
-                descriptors += base.descriptors
-            except AttributeError:
-                pass
-
-        # Register all parameters
-        if len(parameters) > 1:
-            clsobj._parameters = parameters
-
-        # Register descriptor fields as arguments in __init__.
-        # The order matters here, the list(dict.fromkeys(descriptors)) procecure.
-        args = list(dict.fromkeys(descriptors))
-        sig = make_signature(args)
-        setattr(clsobj, '__signature__', sig)
-
-        return clsobj
-
-
+# %% Descriptors
 class Descriptor(ABC):
     """Base class for descriptors.
 
@@ -106,17 +47,244 @@ class Descriptor(ABC):
         del instance.__dict__[self.name]
 
 
+def make_signature(names):
+    return Signature(
+            Parameter(name, Parameter.POSITIONAL_OR_KEYWORD)
+            for name in names)
+
+
+class StructMeta(type):
+    """
+    Metaclass for creating classes that use Descriptors.
+
+    This metaclass enables classes to have ordered descriptors and provides
+    additional functionality related to descriptor management. The underlying
+    structure uses an OrderedDict to maintain the order of class attributes.
+
+    The metaclass mainly interacts with the `Descriptor` class, and classes
+    that use this metaclass can benefit from this specialized handling of descriptors.
+
+    Attributes
+    ----------
+    _descriptors : list
+        List of descriptors associated with a class.
+    _parameters : list
+        List of parameters aggregated from the class and its bases.
+    _sized_parameters : list
+        List of parameters that have a `size` attribute.
+    _polynomial_parameters : list
+        List of parameters with `fill_values` attribute.
+    _required_parameters : list
+        List of parameters that have a default value of None.
+
+    See Also
+    --------
+    Structure : Base class that typically uses this metaclass.
+    Descriptor : Class that represents the descriptors this metaclass operates on.
+    Parameters : Base class for model parameters with e.g. type or bound constraints.
+
+
+    Methods
+    -------
+    __prepare__(name, bases) -> OrderedDict
+        Prepares the namespace for the class body to be executed.
+    """
+
+    @classmethod
+    def __prepare__(cls, name, bases):
+        return OrderedDict()
+
+    def __new__(cls, clsname, bases, clsdict):
+        # Extract descriptor keys
+        descriptors = [
+            key for key, val in clsdict.items()
+            if isinstance(val, Descriptor)
+        ]
+
+        # Assign name attribute for each descriptor
+        for name in descriptors:
+            clsdict[name].name = name
+
+        clsdict['_descriptors'] = descriptors
+
+        # Create the new class object
+        clsobj = super().__new__(cls, clsname, bases, dict(clsdict))
+
+        # Aggregate parameters from the current class and its bases
+        parameters = []
+        try:
+            parameters += clsobj._parameters
+        except AttributeError:
+            pass
+
+        for base in bases:
+            base_parameters = getattr(base, '_parameters', [])
+            parameters += base_parameters
+
+        setattr(clsobj, '_parameters', parameters)
+
+        # Categorize parameters based on their attributes
+        sized_parameters = []
+        polynomial_parameters = []
+        required_parameters = []
+
+        for param in parameters:
+            descriptor = getattr(clsobj, param)
+
+            # Skip if it's not an instance of Descriptor
+            if not isinstance(descriptor, Descriptor):
+                continue
+
+            if hasattr(descriptor, 'size'):
+                sized_parameters.append(param)
+            if hasattr(descriptor, 'fill_values'):
+                polynomial_parameters.append(param)
+            if descriptor.default is None:
+                required_parameters.append(param)
+
+        setattr(clsobj, '_sized_parameters', sized_parameters)
+        setattr(clsobj, '_polynomial_parameters', polynomial_parameters)
+        setattr(clsobj, '_required_parameters', required_parameters)
+
+        # Collect descriptors from base classes
+        for base in bases:
+            descriptors += getattr(base, '_descriptors', [])
+
+        # Remove duplicates from the descriptors list
+        args = list(dict.fromkeys(descriptors))
+
+        # Register descriptor fields as arguments in __init__
+        sig = make_signature(args)
+        setattr(clsobj, '__signature__', sig)
+
+        return clsobj
+
+
+# %% Stucture / ParameterHandler
 class Structure(metaclass=StructMeta):
+    """
+    A class representing a structured data entity.
+
+    This class is designed to work in conjunction with the `StructMeta` metaclass
+    to handle descriptors and related parameters.
+
+    Attributes
+    ----------
+    _parameters : dict
+        Dictionary of parameters associated with the instance.
+    _sized_parameters : list
+        List of parameters that have a `size` attribute.
+    _polynomial_parameters : list
+        List of parameters with `fill_values` attribute.
+    _required_parameters : list
+        List of parameters that have a default value of None.
+    """
+
     def __init__(self, *args, **kwargs):
+        """
+        Initialize a Structure instance.
+
+        Parameters are bound to the instance based on the `__signature__`
+        defined by the metaclass.
+
+        Parameters
+        ----------
+        *args
+            Positional arguments representing parameters.
+        **kwargs
+            Keyword arguments representing parameters.
+        """
+        self._parameters = Dict({
+            param: getattr(self, param)
+            for param in self._parameters
+        })
+
         bound = self.__signature__.bind_partial(*args, **kwargs)
         for name, val in bound.arguments.items():
             setattr(self, name, val)
 
+    @property
+    def parameters(self):
+        """dict: Parameters of the instance."""
+        return self._parameters
+
+    @parameters.setter
+    def parameters(self, parameters):
+        """Set parameters for the instance.
+
+        Parameters
+        ----------
+        parameters : dict
+            A dictionary of parameters to set.
+
+        Raises
+        ------
+        ValueError
+            If any of the provided parameters is not valid.
+        """
+        for param, value in parameters.items():
+            if param not in self._parameters:
+                raise ValueError('Not a valid parameter.')
+            if value is not None:
+                setattr(self, param, value)
+
+    @property
+    def sized_parameters(self):
+        """dict: Sized parameters of the instance."""
+        parameters = {
+            key: value for key, value in self.parameters.items()
+            if key in self._sized_parameters
+        }
+        return Dict(parameters)
+
+    @property
+    def polynomial_parameters(self):
+        """dict: Polynomial parameters of the instance."""
+        parameters = {
+            key: value for key, value in self.parameters.items()
+            if key in self._polynomial_parameters
+        }
+        return Dict(parameters)
+
+    @property
+    def required_parameters(self):
+        """list: Parameters that have no default value."""
+        return self._required_parameters
+
+    @property
+    def missing_parameters(self):
+        """list: Parameters that are required but not set."""
+        missing_parameters = []
+        for param in self.required_parameters:
+            if getattr(self, param) is None:
+                missing_parameters.append(param)
+
+        return missing_parameters
+
+    def check_required_parameters(self):
+        """
+        Verify if all required parameters are set.
+
+        Returns
+        -------
+        bool
+            True if all required parameters are set. False otherwise.
+
+        Raises
+        ------
+        Warning
+            If any of the required parameters are missing.
+        """
+        if len(self.missing_parameters) == 0:
+            return True
+        else:
+            for param in self.missing_parameters:
+                warn(f'Missing parameter "{param}".')
+            return False
+
 
 def frozen_attributes(cls):
-    """Decorate classes to prevent setting attributes after the init method.
-
-    """
+    """Decorate classes to prevent setting attributes after the init method."""
     cls._is_frozen = False
 
     def frozensetattr(self, key, value):

--- a/CADETProcess/dataStructure/dataStructure.py
+++ b/CADETProcess/dataStructure/dataStructure.py
@@ -1,3 +1,4 @@
+from abc import ABC
 from collections import OrderedDict
 from inspect import Parameter, Signature
 from functools import wraps
@@ -66,7 +67,7 @@ class StructMeta(type):
         return clsobj
 
 
-class Descriptor():
+class Descriptor(ABC):
     """Base class for descriptors.
 
     Descriptors are used to efficiently implement class attributes that
@@ -88,11 +89,17 @@ class Descriptor():
         pass
 
     def __get__(self, instance, cls):
-        if instance is None:
-            return self
         return instance.__dict__[self.name]
 
     def __set__(self, instance, value):
+        if value is None:
+            try:
+                del instance.__dict__[self.name]
+            except KeyError:
+                pass
+
+            return
+
         instance.__dict__[self.name] = value
 
     def __delete__(self, instance):

--- a/CADETProcess/dataStructure/nested_dict.py
+++ b/CADETProcess/dataStructure/nested_dict.py
@@ -100,3 +100,16 @@ def set_nested_attribute(obj, attr_string, value):
     for attr in attributes[:-1]:
         obj = getattr(obj, attr)
     setattr(obj, attributes[-1], value)
+
+
+def get_nested_list_value(ls, idx_tuple):
+    return reduce(lambda l, i: l[i], idx_tuple, ls)
+
+
+def set_nested_list_value(ls, idx_tuple, value):
+    # Navigate through the nested list to the second last index
+    for idx in idx_tuple[:-1]:
+        ls = ls[idx]
+
+    # Set the value using the last index
+    ls[idx_tuple[-1]] = value

--- a/CADETProcess/dataStructure/nested_dict.py
+++ b/CADETProcess/dataStructure/nested_dict.py
@@ -15,7 +15,7 @@ def check_nested(nested_dict, path):
 
     Returns
     -------
-    True, if item exists, False otherwise.
+    True if item exists and isn't a dictionary, False otherwise.
 
     """
     if isinstance(path, str):
@@ -26,7 +26,7 @@ def check_nested(nested_dict, path):
         if isinstance(value, dict):
             return False
         return True
-    except:
+    except (KeyError, TypeError):
         return False
 
 
@@ -53,20 +53,13 @@ def insert_path(nested_dict, path, value):
 
 
 def get_leaves(nested_dict):
-    """Generator for returing leaves of nested dictionary in dot notation."""
+    """Return leaves of nested dictionary in dot notation."""
     for key, value in nested_dict.items():
         if not isinstance(value, dict):
             yield key
         else:
             for subpath in get_leaves(value):
                 yield ".".join((key, subpath))
-
-
-def get_nested_value(nested_dict, path):
-    if isinstance(path, str):
-        path = path.split('.')
-    """Access a value in a nested dict using path in dot notation."""
-    return reduce(getitem, path, nested_dict)
 
 
 def set_nested_value(nested_dict, path, value):
@@ -76,11 +69,34 @@ def set_nested_value(nested_dict, path, value):
     get_nested_value(nested_dict, path[:-1])[path[-1]] = value
 
 
+def get_nested_value(nested_dict, path):
+    """Access a value in a nested dict using path in dot notation."""
+    if isinstance(path, str):
+        path = path.split('.')
+    return reduce(getitem, path, nested_dict)
+
+
 def update(d, u):
-    """Recursively update dictionary d with u"""
+    """Recursively update dictionary d with u."""
     for k, v in u.items():
         if isinstance(v, collections.abc.Mapping):
             d[k] = update(d.get(k, {}), v)
         else:
             d[k] = v
     return d
+
+
+def get_nested_attribute(obj, path):
+    """Access a nested attribute using path in dot notation."""
+    attributes = path.split('.')
+    for attr in attributes:
+        obj = getattr(obj, attr)
+    return obj
+
+
+def set_nested_attribute(obj, attr_string, value):
+    """Set a nested attribute using path in dot notation."""
+    attributes = attr_string.split('.')
+    for attr in attributes[:-1]:
+        obj = getattr(obj, attr)
+    setattr(obj, attributes[-1], value)

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -1,4 +1,5 @@
 from abc import abstractmethod
+import copy
 import math
 import operator
 
@@ -7,27 +8,60 @@ import numpy as np
 from .dataStructure import Descriptor
 
 
-class Parameter(Descriptor):
-    """Class for defining model parameters.
+class ParameterBase(Descriptor):
+    """
+    Base class for model parameters with potential constraints or type-casting.
 
-    Parameters
+    Unlike mere data members, parameters can have default values, support type
+    constraints, and cast from certain types to their target type.
+
+    Attributes
     ----------
-    default : NoneType
-        Default value of the object with None as default.
+    default : Any
+        Default value of the parameter.
     unit : str
-        Units of the parameter.
+        Unit of the parameter.
     description : str
-        Description of the parameter.
+        Description or context of the parameter.
+
+    Notes
+    -----
+    1. Supports deep copying of default values, allowing mutable defaults without side effects.
+    2. Subclasses can further specify type constraints (like `Typed`).
+    3. They can also define immutable parameters (like `Constant`) and options-based parameters (`Switch`).
 
     See Also
     --------
     Descriptor
-    StructMeta
-
+    Structure
+    Constant
+    Switch
+    Typed
+    Bool
+    Integer
+    Tuple
+    Float
+    String
+    Dict
     """
 
-    def __init__(
-            self, *args, default=None, unit=None, description=None, **kwargs):
+    def __init__(self, *args, default=None, unit=None, description=None, **kwargs):
+        """
+        Initialize a Parameter instance.
+
+        Parameters
+        ----------
+        *args : Any
+            Variable length argument list.
+        default : Any, optional
+            Default value for the parameter. Defaults to None.
+        unit : str, optional
+            Unit of the parameter. Defaults to None.
+        description : str, optional
+            Description of the parameter. Defaults to None.
+        **kwargs : Any
+            Arbitrary keyword arguments.
+        """
         self.default = default
         self.unit = unit
         self.description = description
@@ -35,285 +69,657 @@ class Parameter(Descriptor):
 
     @property
     def default(self):
-        return self._default
+        """Any: Get or set the default value of the parameter."""
+        return copy.deepcopy(self._default)
 
     @default.setter
     def default(self, value):
+        """
+        Set the default value of the parameter.
+
+        Parameters
+        ----------
+        value : Any
+            Value to set as default.
+        """
         if value is not None:
-            self._check(value, recursive=True)
+            val = self._prepare(None, value, recursive=True)
+            self._check(None, val, recursive=True)
+
         self._default = value
 
+    def get_default_value(self, instance):
+        """
+        Return default values if necessary.
+
+        Override this method if type-casting for default values is necessary.
+
+        Parameters
+        ----------
+        value : Any
+            Value to cast.
+
+        Returns
+        -------
+        Any
+            Default value.
+        """
+        default = self.default
+
+        if default is not None:
+            default = self._prepare(instance, default, recursive=True)
+            self._check(instance, default, recursive=True)
+
+        return default
+
     def __get__(self, instance, cls):
+        """
+        Retrieve the descriptor value for the given instance.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        cls : Type[Any]
+            Class to which the descriptor belongs.
+
+        Returns
+        -------
+        Any
+            Descriptor value or the default value if the descriptor value isn't set.
+        """
+        if instance is None:
+            return self
+
         try:
-            return Descriptor.__get__(self, instance, cls)
+            value = Descriptor.__get__(self, instance, cls)
         except KeyError:
-            return self.default
+            value = self.get_default_value(instance)
+
+        if value is not None:
+            self._check(instance, value, recursive=True)
+
+        return value
 
     def __set__(self, instance, value):
-        super().__set__(instance, value)
+        """
+        Set the descriptor value for the given instance.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to set the descriptor value for.
+        value : Any
+            Value to set.
+        """
+        if value is None:
+            value = self.get_default_value(instance)
+
+        if value is not None:
+            value = self._prepare(instance, value, recursive=True)
+            self._check(instance, value, recursive=True)
+
         try:
-            if self.name in instance._parameter_names:
+            if self.name in instance._parameters:
                 instance._parameters[self.name] = value
         except AttributeError:
             pass
 
-    def _check(self, value, recursive=False):
-        return True
+        super().__set__(instance, value)
+
+    def _prepare(self, instance, value, recursive=False):
+        """
+        Prepare value for setting if necessary.
+
+        Override this method if type-casting or other operations are necessary.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to cast.
+
+        Returns
+        -------
+        Any
+            Prepared value.
+        """
+        return value
+
+    def _check(self, instance, value, recursive=False):
+        """
+        Check the given value.
+
+        Override this method for specific checks.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
+
+        """
+        return
 
 
-class Constant(Parameter):
+# %% Constant Parameters
+
+class Constant(ParameterBase):
+    """
+    Parameter that is immutable once set.
+
+    Attributes
+    ----------
+    value : Any
+        The immutable value of the parameter.
+
+    Notes
+    -----
+    Once set, the value of a Constant parameter cannot be modified.
+    """
+
     def __init__(self, value, *args, **kwargs):
+        """
+        Initialize a Constant instance.
+
+        Parameters
+        ----------
+        value : Any
+            Constant value for the parameter.
+        *args : Any
+            Variable length argument list.
+        **kwargs : Any
+            Arbitrary keyword arguments.
+        """
         super().__init__(*args, default=value, **kwargs)
 
     def __set__(self, instance, value):
+        """
+        Disallow modification of the value of a Constant parameter.
+
+        Raises
+        ------
+        ValueError
+            If trying to modify the constant parameter.
+        """
         raise ValueError("Cannot modify constant parameter.")
 
 
-class Callable(Parameter):
-    def __set__(self, instance, value):
-        if value is None:
-            try:
-                del(instance.__dict__[self.name])
-            except KeyError:
-                pass
-            return
+class Switch(ParameterBase):
+    """
+    Parameter that can be set to one of several predefined options.
 
-        if not callable(value):
-            raise TypeError("Expected object to be callable")
+    Attributes
+    ----------
+    valid : list
+        List of valid options for the parameter.
 
-        super().__set__(instance, value)
+    Notes
+    -----
+    Assign a value to this parameter from the `valid` list.
+    """
 
+    def __init__(self, *args, valid, **kwargs):
+        """
+        Initialize a Switch instance.
 
-class Typed(Parameter):
-    def __init__(self, *args, ty=None, **kwargs):
-        if ty is not None:
-            self.ty = ty
+        Parameters
+        ----------
+        *args : Any
+            Variable length argument list.
+        valid : list
+            List of valid options for the parameter.
+        **kwargs : Any
+            Arbitrary keyword arguments.
+
+        Raises
+        ------
+        TypeError
+            If `valid` is not a list.
+        ValueError
+            If the `valid` list is empty.
+        """
+        if not isinstance(valid, list):
+            raise TypeError("Expected a list for valid entries")
+        if not valid:
+            raise ValueError("The valid options list cannot be empty.")
+        self.valid = valid
+
         super().__init__(*args, **kwargs)
 
-    def __set__(self, instance, value):
-        if value is None:
-            try:
-                del instance.__dict__[self.name]
-            except KeyError:
-                pass
-            return
+    def _check(self, instance, value, recursive=False):
+        """
+        Verify if the value belongs to the valid options.
 
-        if Typed._check(self, value):
-            super().__set__(instance, value)
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            The value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
 
-    def _check(self, value, recursive=False):
+        Returns
+        -------
+        bool
+            True if the value is among the valid options, otherwise raises an exception.
+
+        Raises
+        ------
+        ValueError
+            If the value isn't one of the valid options.
+        """
+        if value not in self.valid:
+            raise ValueError(f"Value must be one of {self.valid}")
+
+        if recursive:
+            super()._check(instance, value, recursive)
+
+
+# %% Typed Parameters
+
+class Typed(ParameterBase):
+    """
+    Mixin for parameters constrained to a specific type.
+
+    `Typed` extends the base `Parameter` class with type constraints. When instantiated
+    with a specific type (`ty`), it ensures values are of that type or can be cast
+    to that type. If `ty` is not specified during instantiation and is not predefined
+    by a subclass, an error is raised.
+
+    Attributes
+    ----------
+    ty : type
+        Desired type for the parameter. Defaults to accepting any type. Subclasses
+        can directly set this attribute.
+
+    Methods
+    -------
+    cast_value(value) -> Any:
+        Attempts to cast the value to the target type. By default, returns the value
+        as is. Subclasses can override for specific casting behavior.
+    _prepare(instance, value, recursive=False) -> Any:
+        Prepares and optionally type-casts the value before checking its type. This
+        method uses `cast_value` to attempt to cast the value to the required type.
+    _check(instance, value, recursive=False) -> bool:
+        Validates if the value matches the desired type (`ty`). Raises a TypeError if
+        validation fails.
+
+    Notes
+    -----
+    - If `ty` is specified during instantiation, any value assigned to this parameter
+      undergoes validation against this type.
+    - Override `cast_value` in subclasses for custom casting logic.
+    - Assigning `None` to the parameter removes its current value from the instance.
+    - An error is raised during instantiation if `ty` is neither provided nor predefined
+      by a subclass.
+
+    See Also
+    --------
+    Parameter
+    Bool
+    Integer
+    Tuple
+    Float
+    String
+    Dict
+    """
+
+    def __init__(self, *args, ty=None, **kwargs):
+        """
+        Initialize a Typed instance.
+
+        Parameters
+        ----------
+        *args : Any
+            Variable length argument list.
+        ty : type, optional
+            The desired type for the parameter.
+        **kwargs : Any
+            Arbitrary keyword arguments.
+        """
+        if ty is not None:
+            self.ty = ty
+        elif not hasattr(self, 'ty'):
+            raise ValueError(
+                "Type must be provided either in a subclass or during instantiation."
+            )
+
+        super().__init__(*args, **kwargs)
+
+    def cast_value(self, value):
+        """
+        Cast the type of the given value.
+
+        This method is a placeholder. Override it if type-casting is necessary.
+
+        Parameters
+        ----------
+        value : Any
+            Value to cast.
+
+        Returns
+        -------
+        Any
+            The unmodified value.
+        """
+        return value
+
+    def _prepare(self, instance, value, recursive=False):
+        """
+        Prepare and optionally type-cast the value before type validation.
+
+        This method is called before `_check` to provide an opportunity to
+        process or type-cast the value. By default, it uses the `cast_value`
+        method to attempt casting the value to the desired type.
+
+        Parameters
+        ----------
+        instance : Any
+            The instance to which this descriptor belongs.
+        value : Any
+            The value to be prepared or type-cast.
+        recursive : bool, optional
+            If True, the preparation is done recursively by calling the parent's
+            _prepare method. This can be useful if `Typed` is combined with other
+            descriptor classes that might also need to process the value.
+            Defaults to False.
+
+        Returns
+        -------
+        Any
+            The potentially type-cast value, ready for type validation.
+        """
+        value = self.cast_value(value)
+
+        if recursive:
+            value = super()._prepare(instance, value, recursive)
+
+        return value
+
+    def _check(self, instance, value, recursive=False):
+        """
+        Validate the value's type against `ty`.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
+
+        Returns
+        -------
+        bool
+            True if value's type matches, else raises an exception.
+
+        Raises
+        ------
+        TypeError
+            If the value's type doesn't match `ty`.
+        """
         if not isinstance(value, self.ty):
-            raise TypeError(f"Expected {self.ty}")
+            raise TypeError(f"Expected type {self.ty}, got {type(value)}")
 
         if recursive:
-            return super()._check(value, recursive)
-
-        return True
-
-
-class Container(Typed):
-    @abstractmethod
-    def check_content_range():
-        return
-
-    @abstractmethod
-    def check_content_size():
-        return
-
-    @abstractmethod
-    def get_default_values():
-        return
-
-    def _check(self, value, recursive=False):
-        if isinstance(value, (int, float)):
-            value = self.ty((value,))
-
-        if recursive:
-            return super()._check(value, recursive)
-
-        return True
+            super()._check(instance, value, recursive)
 
 
 class Bool(Typed):
+    """
+    Parameter descriptor constrained to boolean values.
+
+    Notes
+    -----
+    This class also supports casting integers 0 and 1 to their boolean equivalents.
+    """
+
     ty = bool
 
-    def __set__(self, instance, value):
+    def cast_value(self, value):
+        """
+        Convert integers 0 and 1 to their respective boolean values.
+
+        Parameters
+        ----------
+        value : Any
+            Value to be cast.
+
+        Returns
+        -------
+        Union[bool, Any]
+            Boolean equivalent if value is 0 or 1; otherwise, the original value.
+        """
         if isinstance(value, int) and value in [0, 1]:
             value = bool(value)
-
-        super().__set__(instance, value)
+        return value
 
 
 class Integer(Typed):
+    """Parameter descriptor constrained to integer values."""
+
     ty = int
 
 
-class Tuple(Typed):
-    ty = tuple
-
-
 class Float(Typed):
-    """Cast ints to float"""
+    """
+    Parameter descriptor constrained to float values.
+
+    Notes
+    -----
+    This class also supports casting integers and numpy numbers to floats.
+    """
+
     ty = float
 
-    def __set__(self, instance, value):
+    def cast_value(self, value):
+        """
+        Convert integers and numpy numbers to float.
+
+        Parameters
+        ----------
+        value : Any
+            Value to be cast.
+
+        Returns
+        -------
+        Union[float, Any]
+            Float equivalent if value is an integer or numpy number;
+            otherwise, the original value.
+        """
         if isinstance(value, (int, np.number)):
             value = float(value)
-
-        super().__set__(instance, value)
-
-    def _check(self, value, recursive=False):
-        if isinstance(value, int):
-            value = float(value)
-
-        if recursive:
-            return super()._check(value, recursive)
-
-        return True
+        return value
 
 
 class String(Typed):
+    """Parameter descriptor constrained to string values."""
+
     ty = str
 
 
-class List(Container):
+class Tuple(Typed):
+    """Parameter descriptor constrained to tuple values."""
+
+    ty = tuple
+
+
+class List(Typed):
+    """Parameter descriptor constrained to list values."""
+
     ty = list
-
-    def check_content_range(self, value):
-        if any(self.lb_op(i, self.lb) for i in value):
-            raise ValueError("Value exceeds lower bound")
-        elif any(self.ub_op(i, self.ub) for i in value):
-            raise ValueError("Value exceeds upper bound")
-
-    def check_content_size(self, instance, value, mod=False):
-        value_length = len(value)
-        shape = [getattr(instance, dep) for dep in self.dep]
-        expected_length = np.prod(shape)
-
-        if mod:
-            value_length %= expected_length
-            expected_length = 0
-
-        if value_length != expected_length:
-            raise ValueError(f"Expected size {expected_length}")
-
-    def get_default_values(self, instance):
-        if super().default is None:
-            return None
-
-        shape = [getattr(instance, dep) for dep in self.dep]
-
-        return int(np.prod(shape)) * [super().default]
 
 
 class Dict(Typed):
     """
+    Parameter descriptor constrained to dictionary (`dict`) values.
+
     Notes
     -----
-    !!! Name might collide with addict.Dict!
-
+    When integrating with libraries like `addict`, be cautious about potential
+    name collisions with `addict.Dict`.
     """
+
     ty = dict
 
 
-class NdArray(Container):
+class NdArray(Typed):
+    """
+    Parameter descriptor constrained to np.ndarray values.
+
+    Notes
+    -----
+    The `cast_value` method automatically converts lists to numpy arrays and
+    wraps scalars (int or float) into single-element numpy arrays.
+    """
+
     ty = np.ndarray
 
-    def __set__(self, instance, value):
+    def cast_value(self, value):
+        """
+        Cast lists or scalars (int or float) to numpy arrays.
+
+        Parameters
+        ----------
+        value : Any
+            The value to be casted.
+
+        Returns
+        -------
+        np.ndarray or Any
+            If the value is a list or scalar (int or float),
+            it returns its numpy array equivalent.
+            Otherwise, it returns the value unchanged.
+        """
         if isinstance(value, list):
             value = np.array(value)
         elif isinstance(value, (int, float)):
             value = np.array((value,))
 
-        super().__set__(instance, value)
+        return value
 
-    def _check(self, value, recursive=False):
-        if isinstance(value, list):
-            value = np.array(value)
-        elif isinstance(value, (int, float)):
-            value = np.array((value,))
+
+class Callable(ParameterBase):
+    """
+    Parameter descriptor constrained to callable objects.
+
+    Designed to ensure a given parameter is callable. This is distinct from using a type
+    constraint since built-in functions (e.g., those implemented in C) won't be captured
+    by `types.FunctionTypes`.
+
+    Examples
+    --------
+    Here's how you might use the `Callable` class:
+
+    >>> class MyModel:
+    ...     func = Callable()
+    ...
+    >>> model = MyModel()
+    >>> model.func = print  # This is fine as print is callable
+    >>> model.func = "not_callable"  # This will raise a TypeError
+
+    See Also
+    --------
+    Parameter
+    Typed
+    """
+
+    def _check(self, instance, value, recursive=False):
+        """
+        Check if the given value is callable.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
+
+        Raises
+        ------
+        TypeError
+            If the value is not callable.
+        """
+        if not callable(value):
+            raise TypeError("Expected object to be callable")
 
         if recursive:
-            return super()._check(value, recursive)
-
-        return True
-
-    def check_content_range(self, value):
-        if np.any(self.lb_op(value, self.lb)):
-            raise ValueError("Value exceeds lower bound")
-        elif np.any(self.ub_op(value, self.ub)):
-            raise ValueError("Value exceeds upper bound")
-
-    def get_expected_shape(self, instance):
-        expected_shape = []
-
-        for dep in self.dep:
-            if isinstance(dep, str):
-                dim = getattr(instance, dep)
-                if isinstance(dim, np.ndarray):
-                    dim = list(dim.shape)
-                elif isinstance(dim, int):
-                    dim = [dim]
-            elif isinstance(dep, int):
-                dim = [dep]
-            else:
-                raise AttributeError("Cannot find dependency")
-            expected_shape += dim
-
-        expected_shape = tuple(expected_shape)
-
-        return expected_shape
-
-    def check_content_size(self, instance, value):
-        expected_shape = self.get_expected_shape(instance)
-
-        if value.shape != expected_shape:
-            raise ValueError(f"Expected shape {expected_shape}")
-
-    def get_default_values(self, instance):
-        expected_shape = self.get_expected_shape(instance)
-
-        if super().default is None:
-            return
-        else:
-            return super().default * np.ones(expected_shape)
+            super()._check(instance, value, recursive)
 
 
-class Dimensionalized(Parameter):
-    """Only works for NdArrays"""
+# %% Ranged Parameters
 
-    n_dim = None
+class Ranged(ParameterBase):
+    """Descriptor for parameters within specified bounds.
 
-    def __init__(self, *args, **kwargs):
-        if not isinstance(self, NdArray):
-            raise Exception('Only NdArrays can have dimensions.')
+    Allows setting values constrained by provided lower and upper bounds. The actual comparisons
+    against the bounds can be customized using the `lb_op` and `ub_op` comparison functions.
 
-        super().__init__(*args, **kwargs)
+    Attributes
+    ----------
+    lb : numeric
+        The lower bound of the parameter. Default is negative infinity.
+    lb_op : callable
+        A callable that defines the comparison operation against the lower bound.
+        Default is less than (<).
+    ub : numeric
+        The upper bound of the parameter. Default is positive infinity.
+    ub_op : callable
+        A callable that defines the comparison operation against the upper bound.
+        Default is greater than (>).
 
-    def __set__(self, instance, value):
-        if value is None:
-            del(instance.__dict__[self.name])
-            return
+    Examples
+    --------
+    Constraining a parameter between 0 and 10:
 
-        if self.n_dim != value.ndim:
-            raise ValueError(f"Expected dimensions {self.n_dim}")
-        super().__set__(instance, value)
+    >>> class MyClass:
+    ...     value = Ranged(lb=0, ub=10)
+    ...
+    >>> obj = MyClass()
+    >>> obj.value = 5  # This is valid
+    >>> obj.value = -5  # Raises an error
 
+    Notes
+    -----
+    - By default, values are checked to be strictly within the bounds (exclusive).
+      To change this behavior, use the `lb_op` and `ub_op` parameters.
+    - The `check_range` method can be overridden for custom range validation logic,
+      especially if the data structure isn't a simple scalar value
+      (e.g. for np.ndarrays).
 
-class Vector(NdArray, Dimensionalized):
-    n_dim = 1
-
-
-class Matrix(NdArray, Dimensionalized):
-    n_dim = 2
-
-
-class Ranged(Parameter):
-    """Base class for Parameters with value bounds."""
+    See Also
+    --------
+    ParameterBase
+    """
 
     def __init__(
-            self, *args, lb=-math.inf, lb_op=operator.lt,
-            ub=math.inf, ub_op=operator.gt, **kwargs):
+            self, *args,
+            lb=-math.inf, lb_op=operator.lt,
+            ub=math.inf, ub_op=operator.gt,
+            **kwargs):
+        """
+        Initialize the Ranged descriptor.
+
+        Parameters
+        ----------
+        lb : numeric, optional
+            Lower bound. Defaults to negative infinity.
+        lb_op : callable, optional
+            Comparison for the lower bound. Defaults to less than.
+        ub : numeric, optional
+            Upper bound. Defaults to positive infinity.
+        ub_op : callable, optional
+            Comparison for the upper bound. Defaults to greater than.
+        """
         self.lb = lb
         self.lb_op = lb_op
         self.ub = ub
@@ -321,276 +727,798 @@ class Ranged(Parameter):
 
         super().__init__(*args, **kwargs)
 
-    def __set__(self, instance, value):
-        if value is None:
-            del(instance.__dict__[self.name])
-            return
+    def check_range(self, value):
+        """
+        Validate if the value is within the defined range.
 
-        if Ranged._check(self, value):
-            super().__set__(instance, value)
+        Override this method if other methods for checking ranges are required
+        (e.g. for np.ndarrays).
 
-    def _check(self, value, recursive=False):
-        if isinstance(self, Container):
-            self.check_content_range(value)
-        else:
-            if self.lb_op(value, self.lb):
-                raise ValueError("Value exceeds lower bound")
-            elif self.ub_op(value, self.ub):
-                raise ValueError("Value exceeds upper bound")
+        Parameters
+        ----------
+        value : Any
+            Value to check against the range.
+
+        Raises
+        ------
+        ValueError
+            If the value is outside the specified bounds.
+        """
+        if self.lb_op(value, self.lb):
+            raise ValueError(f"Value {value} is below the lower bound of {self.lb}")
+        elif self.ub_op(value, self.ub):
+            raise ValueError(f"Value {value} is above the upper bound of {self.ub}")
+
+    def _check(self, instance, value, recursive=False):
+        """
+        Validate the value against the range.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
+
+        """
+        self.check_range(value)
 
         if recursive:
-            return super()._check(value, recursive)
+            super()._check(instance, value, recursive)
 
-        return True
+
+# Ranged scalar parameters
+class RangedInteger(Integer, Ranged):
+    """Parameter descriptor for integers parameters constrained within bounds."""
+
+    pass
 
 
 class RangedFloat(Float, Ranged):
+    """Parameter descriptor for float parameters constrained within bounds."""
+
     pass
 
 
-class RangedInteger(Integer, Ranged):
+# Ranged list / array parameters
+class RangedArray(Ranged):
+    """Parameter descriptor for arrays with elements constrained within some bounds.
+
+    This class extends the Ranged descriptor to support array-like structures
+    (lists, numpy arrays, etc.). Each element in the array is individually checked
+    against the specified bounds.
+
+    Examples
+    --------
+    Constraining elements of an array parameter between 0 and 10:
+
+    >>> class MyClass:
+    ...     values = RangedArray(lb=0, ub=10)
+    ...
+    >>> obj = MyClass()
+    >>> obj.values = [5, 7, 2]  # This is valid
+    >>> obj.values = [5, -1, 2]  # Raises an error indicating the second element is
+        below the lower bound.
+
+    Notes
+    -----
+    - The class uses numpy for efficient element-wise comparison.
+    - In case of out-of-bound values, the raised exception specifies the index/indices
+      of such values.
+
+    See Also
+    --------
+    Ranged
+    """
+
+    def check_range(self, value):
+        """Check each element of an array-like structure against specified bounds.
+
+        Parameters
+        ----------
+        value : array-like
+            The array whose elements need to be checked against the range.
+
+        Raises
+        ------
+        ValueError
+            If any element(s) of the array are outside the specified bounds. The raised exception
+            indicates the index/indices of out-of-bound values.
+        """
+        value_array = np.array(value)
+
+        if np.any(self.lb_op(value_array, self.lb)):
+            idx = np.where(self.lb_op(value_array, self.lb))[0]
+            raise ValueError(
+                f"Element(s) at index/indices {idx} below the lower bound of {self.lb}"
+            )
+
+        elif np.any(self.ub_op(value_array, self.ub)):
+            idx = np.where(self.ub_op(value_array, self.ub))[0]
+            raise ValueError(
+                f"Element(s) at index/indices {idx} above the upper bound of {self.ub}"
+            )
+
+
+class RangedList(List, RangedArray):
+    """Parameter descriptor for lists with elements constrained within bounds."""
+
     pass
 
 
+class RangedNdArray(NdArray, RangedArray):
+    """Parameter descriptor for numpy arrays with elements constrained within bounds."""
+
+    pass
+
+
+# Unsigned scalar parameters
 class Unsigned(Ranged):
+    """Parameter descriptor for non-negative parameters."""
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, lb=0, lb_op=operator.lt, **kwargs)
 
 
 class UnsignedInteger(Integer, Unsigned):
+    """Parameter descriptor for unsigned integer parameters."""
+
     pass
 
 
 class UnsignedFloat(Float, Unsigned):
+    """Parameter descriptor for unsigned floating-point parameters."""
+
     pass
 
 
-class Sized(Parameter):
-    def __init__(self, *args, minlen, maxlen, **kwargs):
-        self.minlen = minlen
-        self.maxlen = maxlen
+# Unsigned list / array parameters
+class UnsignedArray(Unsigned, RangedArray):
+    """Parameter descriptor for arrays with non-negative elements."""
+
+    pass
+
+
+class UnsignedList(List, UnsignedArray):
+    """Parameter descriptor for lists with non-negative elements."""
+
+    pass
+
+
+class UnsignedNdArray(NdArray, UnsignedArray):
+    """Parameter descriptor for numpy arrays with non-negative elements."""
+
+    pass
+
+
+# %% Sized Parameters
+
+class Sized(ParameterBase):
+    """
+    Descriptor for parameters with size that potentially depends on instance attributes.
+
+    Attributes
+    ----------
+    size : tuple
+        Expected size or dimensions of the parameter. Individual elements can be
+        either integers or strings indicating other instance parameters that influence
+        the size.
+
+    Methods
+    -------
+    is_independent : bool
+        Determines whether the size is independent of other parameters.
+    get_size(value) -> int
+        Calculates the size of the given value. Override for custom behavior.
+    get_expected_size(instance) -> int
+        Computes the expected size based on the instance's other attributes.
+    check_size(instance, value)
+        Validates that the provided value's size matches the expected size.
+    """
+
+    def __init__(self, *args, size, **kwargs):
+        """
+        Initialize the Sized descriptor.
+
+        Parameters
+        ----------
+        size : int or tuple
+            The expected size or dimensions of the parameter. Individual elements
+            can be either integers or strings (indicating other instance parameters).
+        """
+        if not isinstance(size, tuple):
+            size = (size,)
+
+        self.size = size
+
         super().__init__(*args, **kwargs)
 
-    def __set__(self, instance, value):
-        if value is None:
-            del(instance.__dict__[self.name])
+    @property
+    def is_independent(self):
+        """
+        Determine whether the size is independent of other parameters.
+
+        Returns
+        -------
+        bool
+            True if the size is independent,
+            False if it depends on other instance attributes.
+        """
+        flag = True
+        if any(isinstance(i, str) for i in self.size):
+            flag = False
+        return flag
+
+    def get_size(self, value):
+        """
+        Determines the size of the provided value.
+
+        Parameters
+        ----------
+        value : Any
+            The value for which the size needs to be calculated.
+
+        Returns
+        -------
+        Union[int, Tuple[int, ...]]
+            Size of the value.
+        """
+        return len(value)
+
+    def get_expected_size(self, instance):
+        """
+        Compute the expected size based on the instance's other attributes.
+
+        Parameters
+        ----------
+        instance : object
+            The instance whose attributes determine the expected size.
+
+        Returns
+        -------
+        int
+            Computed expected size based on instance attributes.
+
+        Raises
+        ------
+        ValueError
+            If an attribute, on which the size depends, is not set.
+        """
+        if not self.is_independent and instance is None:
+            raise ValueError(
+                "Parameter is not independent, need instance get expected size!"
+            )
+
+        size = []
+        for i in self.size:
+            if isinstance(i, int):
+                size.append(i)
+                continue
+
+            i_value = getattr(instance, i)
+            if i_value is None:
+                raise ValueError(f"Value for {i} not set.")
+
+            size.append(i_value)
+
+        return np.prod(size)
+
+    def check_size(self, instance, value):
+        """
+        Validate that the provided value's size matches the expected size.
+
+        Parameters
+        ----------
+        instance : object
+            The instance associated with the parameter.
+        value : Any
+            The value whose size needs to be validated.
+
+        Raises
+        ------
+        ValueError
+            If the value's size does not match the expected size.
+        """
+        if np.array(value).size == 1:
             return
 
-        if len(value) > self.maxlen:
-            raise ValueError("Too big!")
-        if len(value) < self.minlen:
-            raise ValueError("Too small!")
-        super().__set__(instance, value)
+        size = self.get_size(value)
+        exptected_size = self.get_expected_size(instance)
+
+        if size != exptected_size:
+            raise ValueError(f"Expected size {exptected_size}")
+
+    def _prepare(self, instance, value, recursive=False):
+        """
+        Prepare the value by typecasting and adjusting its size.
+
+        This method handles typecasting of the provided value to the expected type
+        (`self.ty`) and potentially adjusts its size. If the size of the parameter
+        depends on other instance attributes, it will retrieve that expected size and
+        adjust the value accordingly.
+
+        Parameters
+        ----------
+        instance : object
+            The instance associated with the parameter.
+        value : Any
+            The value to be prepared.
+        recursive : bool, optional
+            If True, recursively prepares the value using the superclass's method.
+            Defaults to False.
+
+        Returns
+        -------
+        Any
+            The prepared value, which has been potentially typecasted and resized.
+
+        Raises
+        ------
+        ValueError
+            If the value cannot be cast to the expected type.
+        """
+        if not isinstance(value, self.ty):
+            try:
+                expected_size = self.get_expected_size(instance)
+            except ValueError:
+                expected_size = None
+
+            if isinstance(value, (int, float)):
+                value = self.ty((value, ))
+            else:
+                raise ValueError("Cannot cast value from given value.")
+
+            if expected_size is not None:
+                value = np.prod(expected_size) * value
+
+        if recursive:
+            value = super()._prepare(instance, value, recursive)
+
+        return value
+
+    def _check(self, instance, value, recursive=False):
+        """
+        Validate the provided value's size.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
+        """
+        self.check_size(instance, value)
+
+        if recursive:
+            super()._check(instance, value, recursive)
 
 
-class SizedString(String, Sized):
+class SizedList(List, Sized):
+    """Descriptor for lists whose size may depend on other instance attributes."""
+
     pass
 
 
 class SizedTuple(Tuple, Sized):
+    """Descriptor for tuples whose size may depend on other instance attributes."""
+
     pass
 
 
 class SizedNdArray(NdArray, Sized):
-    pass
+    """Descriptor for NumPy arrays whose size may depend on other instance attributes."""
 
+    def get_size(self, value):
+        return value.shape
 
-class DependentlySized(Parameter):
-    """Check parameter shape depending on other parameters."""
+    def get_expected_size(self, instance):
+        """
+        Calculate the expected size of a numpy array based on the instance's other attributes.
 
-    def __init__(self, *args, dep, **kwargs):
-        if not isinstance(dep, tuple):
-            dep = (dep,)
+        Returns
+        -------
+        tuple
+            The expected shape of the array.
+        """
+        if not self.is_independent and instance is None:
+            raise ValueError("Parameter is not independent, need instance!")
 
-        self.dep = dep
-        super().__init__(*args, **kwargs)
+        expected_size = []
+        for i in self.size:
+            if isinstance(i, int):
+                expected_size += [i]
+                continue
 
-    def __set__(self, instance, value):
-        if value is None:
-            del(instance.__dict__[self.name])
-            return
+            dim = getattr(instance, i)
+            if dim is None:
+                raise ValueError(f"Value for {i} not set.")
 
-        if isinstance(self, Container):
-            self.check_content_size(instance, value)
-        else:
-            size = getattr(instance, self.dep)
-            if len(value) != size:
-                raise ValueError(f"Expected size {size}")
+            if isinstance(dim, np.ndarray):
+                dim = list(dim.shape)
+            elif isinstance(dim, int):
+                dim = [dim]
 
-        super().__set__(instance, value)
+            expected_size += dim
 
-    def __get__(self, instance, cls):
-        if not isinstance(self, Container):
-            return super().__get__(instance, cls)
+        expected_size = tuple(expected_size)
 
-        try:
-            return Descriptor.__get__(self, instance, cls)
-        except KeyError:
-            return self.get_default_values(instance)
+        return expected_size
 
+    def _prepare(self, instance, value, recursive=False):
+        """
+        Prepare the value for a NumPy array, ensuring it has the expected shape.
 
-class DependentlyModulated(Parameter):
-    """Check parameter shape depending on other parameters."""
+        If the value is a scalar (int or float), this method will transform it into a NumPy
+        array with the expected shape, filled with the scalar value. If the value is
+        already an array, this method ensures its shape matches the expected shape.
 
-    def __init__(self, *args, dep, **kwargs):
-        if not isinstance(dep, tuple):
-            dep = (dep,)
+        Parameters
+        ----------
+        instance : object
+            The instance associated with the parameter.
+        value : Any
+            The value to be prepared.
+        recursive : bool, optional
+            If True, recursively prepares the value using the superclass's method.
+            Defaults to False.
 
-        self.dep = dep
-        super().__init__(*args, **kwargs)
+        Returns
+        -------
+        np.ndarray
+            The prepared NumPy array with the correct shape.
 
-    def __set__(self, instance, value):
-        if value is None:
-            del(instance.__dict__[self.name])
-            return
-
-        if isinstance(self, Container):
-            self.check_content_size(instance, value, mod=True)
-        else:
-            size = getattr(instance, self.dep)
-            if len(value) != size:
-                raise ValueError(f"Expected size {size}")
-
-        super().__set__(instance, value)
-
-    def __get__(self, instance, cls):
-        if not isinstance(self, Container):
-            return super().__get__(instance, cls)
-
-        try:
-            return Descriptor.__get__(self, instance, cls)
-        except KeyError:
-            return self.get_default_values(instance)
-
-
-class DependentlySizedString(String, DependentlySized):
-    pass
-
-
-class DependentlySizedList(List, DependentlySized):
-    pass
-
-
-class DependentlySizedRangedList(List, Ranged, DependentlySized):
-    pass
-
-
-class DependentlySizedUnsignedList(List, Unsigned, DependentlySized):
-    pass
-
-
-class DependentlySizedRangedIntegerList(List, Ranged, Integer, DependentlySized):
-    pass
-
-
-class DependentlySizedUnsignedIntegerList(List, Unsigned, Integer, DependentlySized):
-    pass
-
-
-class DependentlyModulatedUnsignedList(List, Unsigned, DependentlyModulated):
-    pass
-
-
-class DependentlySizedNdArray(NdArray, DependentlySized):
-    pass
-
-
-class DependentlySizedUnsignedNdArray(NdArray, Unsigned, DependentlySized):
-    pass
-
-
-class Polynomial(DependentlySizedNdArray):
-    def __init__(self, *args, n_coeff=None, **kwargs):
-        if n_coeff is not None:
-            if 'dep' in kwargs:
-                raise ValueError("Duplicate entries for n_coeff")
-            kwargs['dep'] = (n_coeff,)
-
-        super().__init__(*args, **kwargs)
-
-    def __set__(self, instance, value):
-        if value is None:
-            try:
-                del(instance.__dict__[self.name])
-            except KeyError:
-                pass
-            return
-
-        shape = self.get_expected_shape(instance)
-        degree = shape[0]
-
+        Raises
+        ------
+        ValueError
+            If the value cannot be cast to a NumPy array with the expected shape.
+        """
+        # if not isinstance(value, self.ty):
         if isinstance(value, (int, float)):
-            value = np.array((value))
+            try:
+                expected_size = self.get_expected_size(instance)
+            except ValueError:
+                expected_size = None
 
-        if isinstance(value, (tuple, list)):
-            missing = degree - len(value)
-            value += missing*(0,)
+            if expected_size is not None:
+                value = value * np.ones(expected_size)
+        else:
+            try:
+                self.check_size(instance, np.array(value))
+            except ValueError:
+                raise ValueError("Cannot cast value from given value.")
 
-        value = np.array(value, ndmin=1)
+        if recursive:
+            value = super()._prepare(instance, value, recursive)
 
-        expected_shape = self.get_expected_shape(instance)
-        _value = np.zeros(expected_shape)
-
-        _value[0:value.shape[0]] = value
-
-        super().__set__(instance, _value)
+        return value
 
 
-class NdPolynomial(DependentlySizedNdArray):
-    """Dependently sized polynomial for n entries.
+class SizedRangedList(RangedList, Sized):
+    """Descriptor for ranged lists whose size depends on other instance attributes."""
 
-    Important: Use [entries x n_coeff] for dependencies.
+    pass
+
+
+class SizedUnsignedList(UnsignedList, SizedList):
+    """Descriptor for unsigned lists whose size depends on other instance attributes."""
+
+    pass
+
+
+class SizedUnsignedNdArray(UnsignedNdArray, SizedNdArray):
+    """Descriptor for unsigned numpy arrays whose size depends on other instance attributes."""
+
+    pass
+
+
+# Also check content type
+class SizedRangedIntegerList(RangedList, Integer, Sized):
+    """Descriptor for ranged lists of integers whose size depends on other instance attributes."""
+
+    pass
+
+
+class SizedUnsignedIntegerList(UnsignedList, Integer, Sized):
+    """Descriptor for unsigned lists of integers whose size depends on other instance attributes."""
+
+    pass
+
+
+# %% Dimensionalized Parameters
+
+class DimensionalizedArray(NdArray):
+    """
+    Parameter descriptor constrained to np.arrays with a specific dimensionality.
+
+    The descriptor ensures that the ndarray assigned matches the specified
+    number of dimensions (n_dim).
+
+    Attributes
+    ----------
+    n_dim : int
+        The number of dimensions the array must have.
+
+    Examples
+    --------
+    To create a descriptor for 2-dimensional arrays:
+
+    >>> class MyClass:
+    ...     arr = DimensionalizedArray(n_dim=2)
+    ...
+    >>> obj = MyClass()
+    >>> obj.arr = np.array([[1, 2], [3, 4]])  # This is valid
+    >>> obj.arr = np.array([1, 2, 3, 4])      # Raises a ValueError
+
+    Notes
+    -----
+    The n_dim attribute can be set during initialization.
 
     """
 
-    def __init__(self, *args, n_entries=None, n_coeff=None, **kwargs):
-        try:
-            dep = kwargs['dep']
-            if not isinstance(dep, tuple):
-                dep = (dep,)
-        except KeyError:
-            dep = (dep,)
-            pass
+    n_dim = None
 
-        if n_entries is None and n_coeff is None and len(dep) < 2:
-            raise ValueError("Missing entries for shape")
+    def __init__(self, n_dim=None, *args, **kwargs):
+        """
+        Initialize the DimensionalizedArray descriptor.
+
+        Parameters
+        ----------
+        n_dim : int, optional
+            The number of dimensions the array must have. If not specified,
+            it must be set before usage.
+
+        Raises
+        ------
+        ValueError
+            If n_dim is not an integer.
+        """
+        super().__init__(*args, **kwargs)
+
+        if n_dim is not None:
+            if not isinstance(n_dim, int):
+                raise ValueError('Dimensionality (n_dim) must be an integer.')
+            self.n_dim = n_dim
+
+        # Ensure the dimension is set and valid
+        if self.n_dim is None:
+            raise ValueError(
+                'Dimensionality (n_dim) must be set during initialization.'
+            )
+
+    def _check(self, instance, value, recursive=False):
+        """
+        Check the dimensionality of the given value.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        value : Any
+            Value to check.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False.
+
+        Raises
+        ------
+        ValueError
+            If the number of dimensions of the ndarray doesn't match n_dim.
+        """
+        if self.n_dim != np.array(value).ndim:
+            raise ValueError(
+                f"Expected {self.n_dim} dimensions, got {np.array(value).ndim}."
+            )
+
+        if recursive:
+            super()._check(instance, value, recursive)
+
+
+class Vector(DimensionalizedArray):
+    """
+    Parameter descriptor for one-dimensional numpy arrays (vectors).
+
+    Attributes
+    ----------
+    n_dim : int
+        Dimensionality of the numpy array, set to 1 for vectors.
+
+    Examples
+    --------
+    >>> class MyModel:
+    ...     coordinates = Vector()
+    ...
+    >>> model.coordinates = np.array([1, 2, 3])  # Valid
+    >>> model.coordinates = np.array([[1, 2], [3, 4]])  # Raises ValueError
+
+    See Also
+    --------
+    Dimensionalized
+    NdArray
+    """
+
+    n_dim = 1
+
+
+class Matrix(DimensionalizedArray):
+    """
+    Parameter descriptor for two-dimensional numpy arrays (matrices).
+
+    This descriptor ensures that the ndarray assigned is two-dimensional.
+
+    Attributes
+    ----------
+    n_dim : int
+        Dimensionality of the numpy array, set to 2 for matrices.
+
+    Examples
+    --------
+    >>> class MyModel:
+    ...     data = Matrix()
+    ...
+    >>> model = MyModel()
+    >>> model.data = np.array([[1, 2], [3, 4]])  # Valid
+    >>> model.data = np.array([1, 2, 3, 4])      # Raises ValueError
+
+    See Also
+    --------
+    DimensionalizedArray
+    NdArray
+    """
+
+    n_dim = 2
+
+
+# %% Polynomial Parameters
+
+class NdPolynomial(SizedNdArray):
+    """
+    Dependently sized polynomial for n entries.
+
+    This descriptor represents a polynomial whose size or dimensions may depend on other
+    instance attributes. The polynomial can also be thought of as a 2D array, where each
+    row represents a polynomial of a certain degree.
+
+    Important: Use [entries x n_coeff] for dependencies.
+
+    Parameters
+    ----------
+    n_entries : int, optional
+        Number of polynomials or rows. Default is None.
+    n_coeff : int, optional
+        Number of coefficients for each polynomial or columns. Default is None.
+
+    Attributes
+    ----------
+    size : tuple
+        The shape of the polynomial array, determined from n_entries and n_coeff.
+
+    Notes
+    -----
+    Currently, NdPolynomial is implemented as `SizedNdArray`.
+    Consequently, no default values can be set since their size would depend on the
+    dependent variables.
+    In theory, this could be split into `NdPolynomial` and `SizedNdPolynomial`,
+    but there is currently no use for this distinction.
+
+    Methods
+    -------
+    fill_values(dims, value) -> np.ndarray:
+        Fills values to generate the polynomial matrix of the desired size.
+    _prepare(instance, value, recursive=False) -> np.ndarray:
+        Prepare the given polynomial matrix s.t. it adheres to the expected size.
+    """
+
+    def __init__(self, *args, n_entries=None, n_coeff=None, **kwargs):
+        """
+        Initialize an NdPolynomial descriptor with specific entries and coefficients.
+
+        Parameters
+        ----------
+        n_entries : int, optional
+            Set the number of polynomials or rows. If not provided, it must be inferred
+            from 'size'.
+        n_coeff : int, optional
+            Define the number of coefficients for each polynomial or columns. If not
+            provided, it must be inferred from 'size'.
+        *args :
+            Variable length argument list.
+        **kwargs :
+            Arbitrary keyword arguments, can include 'size' which denotes the shape of
+            the polynomial array.
+
+        Raises
+        ------
+        ValueError
+            If both 'n_entries' and 'n_coeff' are missing and 'size' is not provided or
+            is incomplete.
+            If there's a mismatch or redundancy in provided dimensions.
+
+        Notes
+        -----
+        The shape of the polynomial array is determined from 'n_entries' and 'n_coeff'
+        or from the 'size' keyword argument.
+        """
+        if 'default' in kwargs and kwargs['default'] != 0:
+            raise ValueError("Default value for NdPolynomial must always be 0.")
+
+        try:
+            size = kwargs['size']
+            if not isinstance(size, tuple):
+                size = (size,)
+        except KeyError:
+            size = tuple()
+
+        if n_entries is None and n_coeff is None and len(size) < 2:
+            raise ValueError("Missing value for n_coeff for shape")
 
         if n_entries is not None:
-            if len(dep) > 1:
+            if len(size) > 1:
                 raise ValueError("Found duplicate n_entries for shape")
             _n_entries = n_entries
             if n_coeff is not None:
-                if len(dep) > 0:
+                if len(size) > 0:
                     raise ValueError("Found duplicate n_entries for shape")
         else:
-            _n_entries = dep[0]
+            _n_entries = size[0]
 
         if n_coeff is not None:
-            if len(dep) > 1:
+            if len(size) > 1:
                 raise ValueError("Found duplicate n_entries for shape")
             _n_coeff = n_coeff
             if n_entries is not None:
-                if len(dep) > 0:
+                if len(size) > 0:
                     raise ValueError("Found duplicate n_entries for shape")
         else:
             if n_entries is not None:
-                _n_coeff = dep[0]
+                _n_coeff = size[0]
             else:
-                _n_coeff = dep[1]
+                _n_coeff = size[1]
 
-        dep = (_n_entries, _n_coeff)
+        size = (_n_entries, _n_coeff)
 
-        kwargs['dep'] = dep
-        kwargs['default'] = 0
+        kwargs['size'] = size
 
         super().__init__(*args, **kwargs)
 
-    def __set__(self, instance, value):
-        n_entries, n_coeff = self.get_expected_shape(instance)
+    def fill_values(self, dims, value):
+        """
+        Fill values to generate the polynomial matrix of the desired size.
 
-        if value is None:
-            del(instance.__dict__[self.name])
-            return
+        Parameters
+        ----------
+        dims : tuple of int
+            Dimensions (n_entries, n_coeff) of the polynomial matrix.
+        value : Union[int, float, np.ndarray, list]
+            Value(s) to be filled in the polynomial matrix.
+
+        Returns
+        -------
+        np.ndarray
+            Polynomial matrix of the desired size filled with given values.
+
+        Raises
+        ------
+        ValueError
+            If there's a mismatch between the provided values and expected dimensions.
+        """
+        if len(dims) == 1:
+            n_entries = 1
+            n_coeff = dims[0]
+            single_entry = True
+            value = np.array(value, ndmin=2)
+        else:
+            n_entries = dims[0]
+            n_coeff = dims[1]
+            single_entry = False
+
+        if single_entry and n_entries > 1:
+            raise ValueError("Can only set single entry if n_entries == 1.")
+
+        if isinstance(value, np.ndarray) and value.size == 1:
+            value = float(value)
 
         if isinstance(value, (int, float)):
             value = n_entries * [value]
@@ -600,7 +1528,7 @@ class NdPolynomial(DependentlySizedNdArray):
         if len(value) != n_entries:
             raise ValueError("Number of entries does not match")
 
-        _value = self.get_default_values(instance)
+        _value = np.zeros((n_entries, n_coeff))
 
         for i, v in enumerate(value):
             if isinstance(v, (int, float, np.number)):
@@ -610,28 +1538,116 @@ class NdPolynomial(DependentlySizedNdArray):
                 v += missing*(0,)
             _value[i, :] = np.array(v)
 
-        super().__set__(instance, _value)
+        if single_entry:
+            _value = _value[0]
 
+        return _value
 
-class Switch(Parameter):
-    """Class for selecting one entry from a list."""
+    def _prepare(self, instance, value, recursive=False):
+        """
+        Prepare the given polynomial matrix s.t. it adheres to the expected size.
 
-    def __init__(self, *args, valid, **kwargs):
-        if not isinstance(valid, list):
-            raise TypeError("Expected a list for valid entries")
-        self.valid = valid
+        Parameters
+        ----------
+        instance : object
+            The instance whose attributes might influence the size.
+        value : Union[int, float, np.ndarray, list]
+            Value(s) to be filled in the polynomial matrix.
+        recursive : bool, optional
+            If True, perform the operation recursively. Defaults to False.
 
-        super().__init__(*args, **kwargs)
+        Returns
+        -------
+        np.ndarray
+            Polynomial matrix of the desired size prepared as per requirements.
 
-    def __set__(self, instance, value):
-        if Switch._check(self, value):
-            super().__set__(instance, value)
-
-    def _check(self, value, recursive=False):
-        if value not in self.valid:
-            raise ValueError(f"Value has to be in {self.valid}")
+        """
+        if instance is not None:
+            dims = self.get_expected_size(instance)
+            value = self.fill_values(dims, value)
 
         if recursive:
-            return super()._check(value, recursive)
+            value = super()._prepare(instance, value, recursive)
 
-        return True
+        return value
+
+
+class Polynomial(NdPolynomial):
+    """
+    Represent a single polynomial using coefficients.
+
+    This class serves as a simplified version of NdPolynomial, specifically tailored for
+    single polynomials. It is always defined by its coefficients, removing the need for
+    an 'n_entries' parameter.
+
+    Use this class when only a single polynomial representation is required.
+
+    Attributes
+    ----------
+    size : tuple
+        Size of the coefficients for the polynomial. Derived from NdPolynomial but omits
+        'n_entries'.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """
+        Initialize a Polynomial descriptor with a specific coefficient length.
+
+        Parameters
+        ----------
+        *args :
+            Variable length argument list.
+        **kwargs :
+            Arbitrary keyword arguments. Typically used for any parameters inherited
+            from NdPolynomial, except 'n_entries'.
+
+        Notes
+        -----
+        The Polynomial descriptor is a special case of NdPolynomial with 'n_entries'
+        always set to 1. Therefore, it's only defined by its coefficients.
+        """
+        super().__init__(*args, n_entries=1, **kwargs)
+        self.size = self.size[1:]
+
+
+# %% Modulated Parameters
+class DependentlyModulated(Sized):
+    """
+    Mixin for checking parameter shapes based on other instance attributes.
+
+    This mixin ensures that the size of a parameter is modulo an expected size.
+    If this condition is not met, a ValueError is raised.
+    """
+
+    def check_mod_value(self, instance, value):
+        """
+        Check if the size of the parameter modulo its expected size is zero.
+
+        By default, this method checks the modulo condition, but can be overridden
+        by subclasses to incorporate custom behaviors.
+
+        Parameters
+        ----------
+        instance : object
+            The instance associated with the parameter.
+        value : Any
+            The value whose size needs to be validated.
+
+        Raises
+        ------
+        ValueError
+            If the modulo condition of the size does not meet the expected criteria.
+        """
+        size = self.get_size(value)
+        exptected_size = self.get_expected_size(instance)
+
+        size %= exptected_size
+
+        if size != 0:
+            raise ValueError("Size mod exptected size is not 0")
+
+
+class DependentlyModulatedUnsignedList(UnsignedList, SizedList, DependentlyModulated):
+    """List of unsigned values whose size is dependent on other attributes."""
+
+    pass

--- a/CADETProcess/dynamicEvents/event.py
+++ b/CADETProcess/dynamicEvents/event.py
@@ -7,7 +7,7 @@ from collections import defaultdict
 
 from CADETProcess import CADETProcessError
 
-from CADETProcess.dataStructure import StructMeta, frozen_attributes
+from CADETProcess.dataStructure import Structure, frozen_attributes
 from CADETProcess.dataStructure import UnsignedFloat
 from CADETProcess.dataStructure import (
     CachedPropertiesMixin, cached_property_if_locked
@@ -25,7 +25,7 @@ __all__ = ['EventHandler', 'Event', 'Duration']
 
 
 @frozen_attributes
-class EventHandler(CachedPropertiesMixin, metaclass=StructMeta):
+class EventHandler(CachedPropertiesMixin, Structure):
     """Baseclass for handling Events that dynamically change parameters.
 
     Attributes
@@ -58,7 +58,6 @@ class EventHandler(CachedPropertiesMixin, metaclass=StructMeta):
         self._events = []
         self._durations = []
         self._lock = False
-        self._parameters = None
 
     @property
     def events(self):
@@ -513,7 +512,7 @@ class EventHandler(CachedPropertiesMixin, metaclass=StructMeta):
 
     @property
     def parameters(self):
-        parameters = Dict()
+        parameters = super().parameters
 
         events = {evt.name: evt.parameters for evt in self.independent_events}
         parameters.update(events)
@@ -544,22 +543,23 @@ class EventHandler(CachedPropertiesMixin, metaclass=StructMeta):
 
             evt.parameters = evt_parameters
 
-    @abstractmethod
-    def section_dependent_parameters(self):
-        return
-
     @property
-    def entry_dependent_parameters(self):
-        parameters = {
-            evt.parameter_path for evt in self.events
-            if evt.entry_index is not None
+    def sized_parameters(self):
+        parameters = super().sized_parameters
+
+        events = {
+            evt.parameter_path: evt.parameters
+            for evt in self.events
+            if evt.indices is not None
         }
+        parameters.update(events)
 
         return parameters
 
-    @abstractmethod
-    def polynomial_parameters(self):
-        return
+    def check_config(self):
+        flag = True
+
+        return flag
 
     def plot_events(self):
         """Plot parameter state as function of time.

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -37,7 +37,7 @@ class Section(metaclass=StructMeta):
 
     """
 
-    coeffs = NdPolynomial(dep=('n_entries', 'n_poly_coeffs'), default=0)
+    coeffs = NdPolynomial(size=('n_entries', 'n_poly_coeffs'), default=0)
 
     def __init__(self, start, end, coeffs, n_entries=None, degree=0):
         if n_entries is None:

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -5,7 +5,7 @@ import numpy as np
 import scipy
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import NdPolynomial
 from CADETProcess import plotting
 
@@ -13,7 +13,7 @@ from CADETProcess import plotting
 __all__ = ['Section', 'TimeLine', 'MultiTimeLine']
 
 
-class Section(metaclass=StructMeta):
+class Section(Structure):
     """Helper class to store parameter states between events.
 
     Attributes

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -37,27 +37,29 @@ class Section(Structure):
 
     """
 
-    coeffs = NdPolynomial(size=('n_entries', 'n_poly_coeffs'), default=0)
+    coeffs = NdPolynomial(size=('n_entries', 'n_poly_coeffs'))
 
-    def __init__(self, start, end, coeffs, n_entries=None, degree=0):
-        if n_entries is None:
-            if isinstance(coeffs, (int, bool, float)):
-                n_entries = 1
-            elif isinstance(coeffs, (list, tuple, np.ndarray)) and degree == 0:
-                n_entries = len(coeffs)
-            else:
-                raise ValueError("Ambiguous entries for n_entries and degree")
-        self.n_entries = n_entries
-
-        if n_entries == 1:
-            coeffs = [coeffs]
-
-        self.degree = degree
-        self.coeffs = coeffs
+    def __init__(self, start, end, coeffs, is_polynomial=False):
+        if start > end:
+            raise ValueError("End time must be greater than start time")
 
         self.start = start
         self.end = end
         diff = end-start
+
+        coeffs = np.array(coeffs, ndmin=1, dtype=np.float64)
+        self.parameter_shape = coeffs.shape
+
+        if is_polynomial:
+            coeffs = np.array(coeffs, ndmin=2, dtype=np.float64)
+            self.degree = coeffs.shape[-1] - 1
+            self.n_entries = coeffs.shape[0]
+
+            self.coeffs = coeffs
+        else:
+            self.degree = 0
+            self.n_entries = coeffs.size
+            self.coeffs = coeffs.reshape((coeffs.size, 1))
 
         self._poly = []
         for i in range(self.n_entries):
@@ -75,9 +77,27 @@ class Section(Structure):
                 self._poly_der.append(poly_der)
 
     @property
+    def is_polynomial(self):
+        """bool: True if Section represents polynomial parameter. False otherwise."""
+        if self.degree > 0:
+            return True
+        return False
+
+    @property
     def n_poly_coeffs(self):
         """int: Number of polynomial coefficients."""
         return self.degree + 1
+
+    @property
+    def is_single_entry(self):
+        """bool: True if Section contains single entry. False otherwise."""
+        if self.n_entries > 1:
+            return True
+
+        if self.is_polynomial and self.parameter_shape.ndim == 1:
+            return True
+
+        return False
 
     def value(self, t):
         """Return value of parameter section at time t.
@@ -126,7 +146,7 @@ class Section(Structure):
                 c[1] = self._poly_der[i](offset)
             coeffs.append(c)
 
-        return np.array(coeffs)
+        return np.array(coeffs).reshape(self.parameter_shape)
 
     def derivative(self, t, order=1):
         """Return derivative of parameter section at time t.
@@ -188,6 +208,13 @@ class Section(Structure):
         integ_methods = [p.integ(lbnd=start) for p in self._poly]
         return np.array([i(end) for i in integ_methods])
 
+    def __repr__(self):
+        args = f"start={self.start}, end={self.end}, coeffs={self.coeffs}"
+        if self.degree > 0:
+            args += f", degree={self.degree}"
+
+        return f"Section({args})"
+
 
 class TimeLine():
     """Class representing a timeline of time-varying data.
@@ -202,13 +229,12 @@ class TimeLine():
         List of Sections that make up the timeline.
     """
 
-    def __init__(self, n_entries=None):
-        if n_entries:
-            pass
+    def __init__(self):
         self._sections = []
 
     @property
     def sections(self):
+        """list: Sections of the TimeLine."""
         return self._sections
 
     @property
@@ -223,16 +249,13 @@ class TimeLine():
         if len(self.sections) > 0:
             return self.sections[0].n_entries
 
-    def add_section(self, section, entry_index=None):
+    def add_section(self, section):
         """Add a Section to the timeline.
 
         Parameters
         ----------
         section : Section
             The Section to be added to the timeline.
-        entry_index : int or None, optional
-            The index of the entry to be modified by the Section. If None,
-            all entries are modified. The default is None.
 
         Raises
         ------
@@ -471,7 +494,7 @@ class TimeLine():
                 continue
             end = ppoly.x[i+1]
             tl.add_section(
-                Section(start, end, np.flip(sec), n_entries=1, degree=3)
+                Section(start, end, np.flip(sec), is_polynomial=True)
             )
 
         return tl
@@ -482,7 +505,7 @@ class MultiTimeLine():
 
     Attributes
     ----------
-    base_state : list
+    base_state : np.array
         The base state that each TimeLine represents.
     n_entries : int
         The number of entries in each TimeLine.
@@ -492,7 +515,7 @@ class MultiTimeLine():
         The degree of the polynomials in each section.
     """
 
-    def __init__(self, base_state):
+    def __init__(self, base_state, is_polynomial=False):
         """Initialize a MultiTimeLine instance.
 
         Parameters
@@ -501,10 +524,21 @@ class MultiTimeLine():
             The base state that each TimeLine represents.
 
         """
-        self.base_state = base_state
-        self.n_entries = len(base_state)
-        self._degree = None
-        self.time_lines = [TimeLine() for _ in range(self.n_entries)]
+        base_state = np.array(base_state, ndmin=1, dtype=np.float64)
+        self.is_polynomial = is_polynomial
+
+        if self.is_polynomial:
+            if base_state.ndim == 1:
+                self.is_single_entry = True
+            else:
+                self.is_single_entry = False
+            self.base_state = np.array(base_state, ndmin=2, dtype=np.float64)
+            self.degree = self.base_state.shape[-1] - 1
+        else:
+            self.degree = 0
+            self.base_state = base_state
+
+        self.time_lines = [TimeLine() for _ in range(self.size)]
 
     @property
     def degree(self):
@@ -516,65 +550,276 @@ class MultiTimeLine():
         self._degree = degree
 
     @property
+    def n_entries(self):
+        """int: Number of entries handled by MultiTimeline."""
+        if self.degree > 0:
+            return len(self.base_state)
+        return self.base_state.size
+
+    @property
+    def size(self):
+        """int: Total number of internal TimeLines handled Number by MultiTimeline."""
+        return self.base_state.size
+
+    @property
     def section_times(self):
-        """list of float: A list of all the section times of all the TimeLines."""
+        """list: Combined section times of all TimeLines."""
         time_line_sections = [tl.section_times for tl in self.time_lines]
 
         section_times = set(itertools.chain.from_iterable(time_line_sections))
 
         return sorted(list(section_times))
 
-    def add_section(self, section, entry_index=None):
-        """Add section to each timeline in MultiTimeLine, or to a specific entry.
+    def add_section(self, section, entry_index):
+        """Add section to TimeLine with specific entry index.
 
         Parameters
         ----------
         section : Section
             Section to be added.
-        entry_index : int, optional
-            Index of the entry where the section will be added.
-            If not provided, the section will be added to each timeline.
+        entry_index : tuple
+            Index of the entry in the base_state for which the section will be added.
 
         Raises
         ------
-        CADETProcessError
-            If polynomial degree does not match the degree of the MultiTimeLine.
         ValueError
-            If the provided entry_index is greater than the number of entries.
+            If entry index is out of bounds for base_state.
 
         """
-        if self.degree is None:
-            self.degree = section.degree
+        index = flatten_index(self.base_state.shape, entry_index)[0]
+        if index > self.size:
+            raise CADETProcessError("Entry index is out of bounds.")
+        self.time_lines[index].add_section(section)
 
-        if section.degree != self.degree:
-            raise CADETProcessError('Polynomial degree does not match')
-
-        if entry_index is None:
-            for tl in self.time_lines:
-                tl.add_section(section)
-        else:
-            if entry_index > self.n_entries:
-                raise ValueError("Index exceeds entries.")
-
-            self.time_lines[entry_index].add_section(section)
-
+    @property
     def combined_time_line(self):
         """TimeLine: Object representing combination of all timelines in the MultiTimeLine."""
         tl = TimeLine()
+
+        n_poly_coeffs = self.degree + 1
+
+        coeffs = self.base_state
 
         section_times = self.section_times
         for iSec in range(len(section_times) - 1):
             start = self.section_times[iSec]
             end = self.section_times[iSec+1]
 
-            coeffs = []
-            for i, entry in enumerate(self.time_lines):
-                if len(entry.sections) == 0:
-                    coeffs.append(self.base_state[i])
-                else:
-                    coeffs.append(entry.coefficients(start)[0])
+            if not self.is_polynomial:
+                for i, entry in enumerate(self.time_lines):
+                    if len(entry.sections) > 0:
+                        index = unflatten_index(self.base_state.shape, i)[0]
+                        coeff = entry.coefficients(start)[0]
+                        coeffs[index] = coeff
+            else:
+                for i_entry in range(self.n_entries):
+                    tl_indices = slice(i_entry*n_poly_coeffs, (i_entry+1)*n_poly_coeffs)
+                    i_entry_tl = self.time_lines[tl_indices]
+                    for i_poly, i_poly_tl in enumerate(i_entry_tl):
+                        if self.is_single_entry:
+                            index = (0, i_poly)
+                        else:
+                            index = (i_entry, i_poly)
 
-            section = Section(start, end, coeffs, self.n_entries, self.degree)
+                        if len(i_poly_tl.sections) > 0 and start in i_poly_tl.section_times:
+                            coeffs[index] = i_poly_tl.coefficients(start)[0]
+
+            section = Section(start, end, coeffs, self.is_polynomial)
             tl.add_section(section)
 
+            coeffs = tl.coefficients(end)
+
         return tl
+
+
+def generate_indices(shape, indices=None):
+    """
+    Generate indices for indexing a parameter array from a list of indices.
+
+    Parameters
+    ----------
+    parameter : array_like
+        An array which is to be indexed. Scalar parameters are not supported.
+    indices : array_like
+        A 2D array or list of lists, where each inner list is a set of indices
+        into the 'parameter' array. None can be used in place of a full slice (:).
+
+    Raises
+    ------
+    ValueError
+        If 'parameter' is a scalar or if an index in 'indices' is out of bounds.
+
+    Returns
+    -------
+    list
+        A list of tuples, where each tuple represents indices into the 'parameter'
+        array. If the 'parameter' array was 1D, this will be a list of integers instead.
+
+    Examples
+    --------
+    >>> parameter = np.array([[1, 2, 3], [4, 5, 6], [7, 8, 9]])
+    >>> indices = [[0, 1], [1, 2]]
+    >>> generate_indices(parameter, indices)
+    [(0, 1), (1, 2)]
+    """
+    size = np.prod(shape)
+    if size == 1:
+        raise ValueError("Scalar parameters cannot have index slices.")
+
+    if indices is None:
+        indices = np.s_[:]
+
+    if not isinstance(indices, list):
+        indices = [indices, ]
+
+    indices_array = np.array(indices, ndmin=1)
+
+    indices = []
+    for ind in indices_array:
+        ind = tuple(np.array(ind, ndmin=1))
+        indices.append(ind)
+
+    _validate_indices(shape, indices)
+
+    return indices
+
+
+def _validate_indices(shape, indices):
+    """Validate that all indices can be set in an array with shape `shape`."""
+    param_ref = np.arange(np.prod(shape)).reshape(shape)
+
+    for ind in indices:
+        param_ref[ind]
+
+
+def unravel(shape, indices):
+    """
+    Unravel indices of a multi-dimensional array.
+
+    Parameters
+    ----------
+    shape : tuple of int
+        The shape of the original array.
+    indices : list of int or tuple
+        The indices in the flattened array to be unraveled.
+
+    Returns
+    -------
+    list of tuple
+        The unraveled indices in the multi-dimensional array.
+    """
+    if len(shape) == 0:
+        return []
+
+    indices_flat_ref = np.arange(np.prod(shape)).reshape(shape)
+
+    indices_unraveled = []
+    for ind in indices:
+        indices_flat = indices_flat_ref[ind].flatten()
+        indices_unravel = np.unravel_index(indices_flat, shape)
+        if not isinstance(indices_flat, (int, np.int64)):
+            indices_unravel = list(zip(*indices_unravel))
+        else:
+            indices_unravel = [indices_unravel]
+        indices_unraveled += indices_unravel
+
+    return indices_unraveled
+
+
+def flatten_index(shape, indices):
+    """Flatten indices to access array.
+
+    Parameters
+    ----------
+    shape: tuple
+        Shape of the array to be indexed
+    indices : tuple or list of tuples
+        Indices in tuple notation
+
+    Returns
+    -------
+    indices_flat : list
+        List of indices in flat notation.
+    """
+    if not isinstance(indices, list):
+        indices = [indices]
+
+    indices_flat_ref = np.arange(np.prod(shape)).reshape(shape)
+
+    return [indices_flat_ref[i] for i in indices]
+
+
+def unflatten_index(shape, indices_flat):
+    """Unflatten indices to access array.
+
+    Parameters
+    ----------
+    shape : tuple
+        Shape of the array to be indexed
+    indices_flat : int or list of ints
+        Flat indices
+
+    Returns
+    -------
+    indices : list
+        List of unflattened indices.
+    """
+    if not isinstance(indices_flat, list):
+        indices_flat = [indices_flat]
+
+    indices_unravel = np.unravel_index(indices_flat, shape)
+    indices = list(zip(*indices_unravel))
+
+    return indices
+
+
+def get_inhomogeneous_shape(value):
+    """If array is inhomogeneous, return list with shape of every element."""
+    try:
+        return np.array(value).shape
+    except ValueError:
+        pass
+
+    shape = []
+
+    for i in value:
+        i_shape = get_inhomogeneous_shape(i)
+        # if len(i_shape) == 0:
+        #     i_shape = (1, )
+
+        # i_shape = (1, ) + i_shape
+
+        shape.append(i_shape)
+
+    return shape
+
+
+def get_full_shape(inhomogeneous_shape):
+    """Create full shape from inhomogeneous shape to be used with numpy arrays."""
+    first_dimension = (len(inhomogeneous_shape))
+
+    sub_dims = ()
+    for sub_dim in inhomogeneous_shape:
+        if not isinstance(sub_dim, tuple):
+            sub_dim = get_full_shape(sub_dim)
+
+        sub_dims += (sub_dim, )
+
+    max_dims = {}
+    for el in sub_dims:
+        for i, dim in enumerate(el):
+            try:
+                max_dims[i] = max(max_dims[i], dim)
+            except KeyError:
+                max_dims[i] = dim
+
+    dims = (first_dimension, ) + tuple(max_dims.values())
+
+    return dims
+
+
+def extract_inhomogeneous_array(full_array, inhomogeneous_shape):
+    """Get inhomogeneous array from full_array."""
+    array = []
+    for i in inhomogeneous_shape:
+        array.append(full_array[i, :])

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -381,7 +381,7 @@ class TimeLine():
         return self.section_times[-1]
 
     @plotting.create_and_save_figure
-    def plot(self, ax):
+    def plot(self, ax, use_minutes=True):
         """Plot the state of the timeline over time.
 
         Parameters
@@ -399,12 +399,17 @@ class TimeLine():
         time = np.linspace(start, end, 1001)
         y = self.value(time)
 
-        ax.plot(time/60, y)
+        if use_minutes:
+            time /= 60
+            start /= 60
+            end /= 60
+
+        ax.plot(time, y)
 
         layout = plotting.Layout()
         layout.x_label = '$time~/~min$'
         layout.y_label = '$state$'
-        layout.x_lim = (start/60, end/60)
+        layout.x_lim = (start, end)
         layout.y_lim = (np.min(y), 1.1*np.max(y))
 
         plotting.set_layout(ax, layout)

--- a/CADETProcess/equilibria/buffer_capacity.py
+++ b/CADETProcess/equilibria/buffer_capacity.py
@@ -443,7 +443,7 @@ def plot_charge_distribution(
     if plot_cumulative:
         labels = reaction_system.component_system.names
     else:
-        labels = reaction_system.component_system.labels
+        labels = reaction_system.component_system.species
 
     labels.remove('H+')
 

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -341,7 +341,7 @@ class FractionationOptimizer():
             else:
                 raise CADETProcessError(str(e))
 
-        frac = opt.set_variables(results.x[0])[0]
+        opt.set_variables(results.x[0])
         frac.reset()
 
         # Restore previous lock state

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -379,7 +379,7 @@ class Fractionator(EventHandler):
             for chrom_index, chrom in enumerate(self.chromatograms):
                 chrom_events = self.chromatogram_events[chrom]
                 for evt_index, evt in enumerate(chrom_events):
-                    target = int(np.nonzero(evt.state)[0])
+                    target = int(np.nonzero(evt.full_state)[0])
 
                     frac_start = evt.time
 

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -1,13 +1,13 @@
 import numpy as np
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     UnsignedInteger, UnsignedFloat, Vector
 )
 
 
-class Fraction(metaclass=StructMeta):
+class Fraction(Structure):
     """A class representing a fraction of a mixture.
 
     A fraction is defined by its mass and volume, and can be used to calculate
@@ -94,7 +94,7 @@ class Fraction(metaclass=StructMeta):
             f"(mass={self.mass},volume={self.volume})"
 
 
-class FractionPool(metaclass=StructMeta):
+class FractionPool(Structure):
     """Collection of pooled fractions.
 
     This class manages multiple fractions of a mixture, facilitating the

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -6,7 +6,7 @@ import matplotlib.pyplot as plt
 from CADETProcess import CADETProcessError
 from CADETProcess import plotting
 
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import Integer, UnsignedInteger, UnsignedFloat
 
 from CADETProcess.processModel import UnitBaseClass, FlowSheet, Process
@@ -18,7 +18,7 @@ from CADETProcess.solution import SolutionBase
 __all__ = ['CarouselBuilder', 'SerialZone', 'ParallelZone']
 
 
-class CarouselBuilder(metaclass=StructMeta):
+class CarouselBuilder(Structure):
     switch_time = UnsignedFloat()
 
     def __init__(self, component_system, name):

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -4,7 +4,7 @@ from addict import Dict
 import numpy as np
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import Float, Vector
 
 
@@ -31,7 +31,7 @@ def hash_array(array):
     return hashlib.sha256(array.tobytes()).hexdigest()
 
 
-class Individual(metaclass=StructMeta):
+class Individual(Structure):
     """Set of variables evaluated during Optimization.
 
     Attributes

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -17,8 +17,7 @@ from CADETProcess import settings
 
 from CADETProcess.dataStructure import StructMeta
 from CADETProcess.dataStructure import (
-    String, Switch, RangedInteger, Callable, Tuple,
-    DependentlySizedNdArray
+    String, Switch, RangedInteger, Callable, Tuple, SizedNdArray
 )
 from CADETProcess.dataStructure import frozen_attributes
 from CADETProcess.dataStructure import (
@@ -3164,7 +3163,7 @@ class Objective(metaclass=StructMeta):
     type = Switch(valid=['minimize', 'maximize'])
     n_objectives = RangedInteger(lb=1)
     n_metrics = n_objectives
-    bad_metrics = DependentlySizedNdArray(dep='n_metrics', default=np.inf)
+    bad_metrics = SizedNdArray(size='n_metrics', default=np.inf)
 
     def __init__(
             self,
@@ -3255,7 +3254,7 @@ class NonlinearConstraint(metaclass=StructMeta):
     name = String()
     n_nonlinear_constraints = RangedInteger(lb=1)
     n_metrics = n_nonlinear_constraints
-    bad_metrics = DependentlySizedNdArray(dep='n_metrics', default=np.inf)
+    bad_metrics = SizedNdArray(size='n_metrics', default=np.inf)
 
     def __init__(
             self,
@@ -3454,7 +3453,7 @@ class MetaScore(metaclass=StructMeta):
     name = String()
     n_meta_scores = RangedInteger(lb=1)
     n_metrics = n_meta_scores
-    bad_metrics = DependentlySizedNdArray(dep='n_metrics', default=np.inf)
+    bad_metrics = SizedNdArray(size='n_metrics', default=np.inf)
 
     def __init__(
             self,

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -15,7 +15,7 @@ from CADETProcess import CADETProcessError
 from CADETProcess import log
 from CADETProcess import settings
 
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     String, Switch, RangedInteger, Callable, Tuple, SizedNdArray
 )
@@ -34,7 +34,7 @@ from CADETProcess.optimization import ResultsCache
 
 
 @frozen_attributes
-class OptimizationProblem(metaclass=StructMeta):
+class OptimizationProblem(Structure):
     """Class for configuring optimization problems.
 
     Stores information about
@@ -3113,7 +3113,7 @@ class OptimizationVariable:
         return string
 
 
-class Evaluator(metaclass=StructMeta):
+class Evaluator(Structure):
     """Wrapper class to call evaluator."""
 
     evaluator = Callable()
@@ -3154,7 +3154,7 @@ class Evaluator(metaclass=StructMeta):
         return self.name
 
 
-class Objective(metaclass=StructMeta):
+class Objective(Structure):
     """Wrapper class to evaluate objective functions."""
 
     objective = Callable()
@@ -3247,7 +3247,7 @@ class Objective(metaclass=StructMeta):
         return self.name
 
 
-class NonlinearConstraint(metaclass=StructMeta):
+class NonlinearConstraint(Structure):
     """Wrapper class to evaluate nonlinear constraint functions."""
 
     nonlinear_constraint = Callable()
@@ -3338,7 +3338,7 @@ class NonlinearConstraint(metaclass=StructMeta):
         return self.name
 
 
-class Callback(metaclass=StructMeta):
+class Callback(Structure):
     """Wrapper class to evaluate callbacks.
 
     Callable must implement function with the following signature:
@@ -3446,7 +3446,7 @@ class Callback(metaclass=StructMeta):
         return self.name
 
 
-class MetaScore(metaclass=StructMeta):
+class MetaScore(Structure):
     """Wrapper class to evaluate meta scores."""
 
     meta_score = Callable()
@@ -3520,7 +3520,7 @@ class MetaScore(metaclass=StructMeta):
         return self.name
 
 
-class MultiCriteriaDecisionFunction(metaclass=StructMeta):
+class MultiCriteriaDecisionFunction(Structure):
     """Wrapper class to evaluate multi-criteria decision functions."""
 
     decision_function = Callable()

--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -25,8 +25,7 @@ class ParallelizationBackendBase(Structure):
 
     n_cores = RangedInteger(lb=-cpu_count, ub=cpu_count, default=1)
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
+    _parameters = ['n_cores']
 
     @property
     def _n_cores(self):
@@ -127,6 +126,7 @@ class Joblib(ParallelizationBackendBase):
     """
 
     verbose = UnsignedInteger(default=0)
+    _parameters = ['verbose']
 
     def evaluate(self, function: callable, population: Iterable) -> list:
         """Evaluate the function in parallalel for all individuals of the population.

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -12,7 +12,7 @@ import numpy as np
 
 from cadet import H5
 from CADETProcess import plotting
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     NdArray, String, UnsignedInteger, UnsignedFloat
 )
@@ -21,7 +21,7 @@ from CADETProcess import CADETProcessError
 from CADETProcess.optimization import Individual, Population, ParetoFront
 
 
-class OptimizationResults(metaclass=StructMeta):
+class OptimizationResults(Structure):
     """Optimization results.
 
     Attributes

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -83,8 +83,8 @@ class SciPyInterface(OptimizerBase):
         def callback_function(x, state=None):
             """Internal callback to report progress after evaluation.
 
-            Note
-            ----
+            Notes
+            -----
             Currently, this evaluates all functions again. This should not be a problem
             since objectives and constraints are automatically cached.
 
@@ -118,7 +118,6 @@ class SciPyInterface(OptimizerBase):
             options['maxiter'] = self.maxiter - self.n_evals
             if str(self) == 'COBYLA':
                 options['maxiter'] -= 1
-
 
         with warnings.catch_warnings():
             warnings.filterwarnings('ignore', category=OptimizeWarning)
@@ -292,8 +291,8 @@ class SciPyInterface(OptimizerBase):
             constr : optimize.NonlinearConstraint
                 Constraint object.
 
-            Note
-            ----
+            Notes
+            -----
             Note, this is necessary to avoid side effects when creating the function
             in the main loop.
             """
@@ -378,10 +377,10 @@ class TrustConstr(SciPyInterface):
     factorization_method : str or None, optional
         Method to factorize the Jacobian of the constraints.
         Use None (default) for auto selection or one of:
-            - 'NormalEquation'
-            - 'AugmentedSystem'
-            - 'QRFactorization'
-            - 'SVDFactorization'.
+        - 'NormalEquation'
+        - 'AugmentedSystem'
+        - 'QRFactorization'
+        - 'SVDFactorization'.
         The methods 'NormalEquation' and 'AugmentedSystem' can be used only with sparse
         constraints. The methods 'QRFactorization' and 'SVDFactorization' can be used
         only with dense constraints.
@@ -390,10 +389,10 @@ class TrustConstr(SciPyInterface):
         Maximum number of algorithm iterations. Default is 1000.
     verbose : UnsignedInteger, optional
         Level of algorithm's verbosity:
-            - 0 (default) for silent
-            - 1 for a termination report
-            - 2 for progress during iterations
-            - 3 for more complete progress report.
+        - 0 (default) for silent
+        - 1 for a termination report
+        - 2 for progress during iterations
+        - 3 for more complete progress report.
     disp : Bool, optional
         If True, then verbose will be set to 1 if it was 0. Default is False.
 

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -501,12 +501,12 @@ class NelderMead(SciPyInterface):
         Set to True to print convergence messages.
     """
 
-    maxiter = UnsignedInteger(1000)
+    maxiter = UnsignedInteger(default=1000)
     initial_simplex = None
     xatol = UnsignedFloat(default=1e-3)
     fatol = UnsignedFloat(default=1e-3)
     adaptive = Bool(default=True)
-    disp = Bool(optional=False)
+    disp = Bool(default=False)
 
     x_tol = xatol           # Alias for uniform interface
     f_tol = fatol           # Alias for uniform interface

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -36,8 +36,8 @@ Mostly convenince method.
     PerformanceProduct
     MassBalanceDifference
 
-Note
-----
+Notes
+-----
 Performance Indicators might be deprecated in future since with new evaluation chains
 it's no longer required for setting up as optimization problem.
 

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -48,7 +48,7 @@ import numpy as np
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import Structure
 from CADETProcess.metric import MetricBase
-from CADETProcess.dataStructure import DependentlySizedNdArray
+from CADETProcess.dataStructure import SizedNdArray
 from CADETProcess.processModel import ComponentSystem
 
 
@@ -94,13 +94,13 @@ class Performance(Structure):
         'productivity', 'eluent_consumption', 'mass_balance_difference'
     ]
 
-    mass = DependentlySizedNdArray(dep=('n_comp'))
-    concentration = DependentlySizedNdArray(dep=('n_comp'))
-    purity = DependentlySizedNdArray(dep=('n_comp'))
-    recovery = DependentlySizedNdArray(dep=('n_comp'))
-    productivity = DependentlySizedNdArray(dep=('n_comp'))
-    eluent_consumption = DependentlySizedNdArray(dep=('n_comp'))
-    mass_balance_difference = DependentlySizedNdArray(dep=('n_comp'))
+    mass = SizedNdArray(size=('n_comp'))
+    concentration = SizedNdArray(size=('n_comp'))
+    purity = SizedNdArray(size=('n_comp'))
+    recovery = SizedNdArray(size=('n_comp'))
+    productivity = SizedNdArray(size=('n_comp'))
+    eluent_consumption = SizedNdArray(size=('n_comp'))
+    mass_balance_difference = SizedNdArray(size=('n_comp'))
 
     def __init__(
             self, mass, concentration, purity, recovery,

--- a/CADETProcess/plotting.py
+++ b/CADETProcess/plotting.py
@@ -85,7 +85,7 @@ from matplotlib import cycler
 
 from CADETProcess import CADETProcessError
 
-from CADETProcess.dataStructure import StructMeta, Structure
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     Integer, List, String, Tuple, Callable, UnsignedFloat
 )
@@ -310,7 +310,7 @@ def add_fill_regions(ax, fill_regions, x_lim=None):
             )
 
 
-class HLines(metaclass=StructMeta):
+class HLines(Structure):
     y = UnsignedFloat()
     x_min = UnsignedFloat()
     x_max = UnsignedFloat()

--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -76,17 +76,11 @@ class BindingBaseClass(Structure):
     )
     non_binding_component_indices = []
 
-    _parameter_names = ['is_kinetic']
-    _required_parameters = []
+    _parameters = ['is_kinetic']
 
     def __init__(self, component_system, name=None, *args, **kwargs):
         self.component_system = component_system
         self.name = name
-
-        self._parameters = {
-            param: getattr(self, param)
-            for param in self._parameter_names
-        }
 
         super().__init__(*args, **kwargs)
 
@@ -129,53 +123,6 @@ class BindingBaseClass(Structure):
     def n_bound_states(self):
         return sum(self.bound_states)
 
-    @property
-    def parameters(self):
-        """dict: Dictionary with parameter values."""
-        return self._parameters
-
-    @parameters.setter
-    def parameters(self, parameters):
-        for param, value in parameters.items():
-            if param not in self._parameters:
-                raise CADETProcessError('Not a valid parameter')
-            setattr(self, param, value)
-
-    @property
-    def required_parameters(self):
-        return self._required_parameters
-
-    @property
-    def missing_parameters(self):
-        """list: List of missing parameters."""
-        missing_parameters = []
-        for param in self.required_parameters:
-            if getattr(self, param) is None:
-                missing_parameters.append(param)
-
-        return missing_parameters
-
-    def check_required_parameters(self):
-        """Check if al required parameters are set.
-
-        Returns
-        -------
-        bool
-            True if all parameters are set. False otherwise.
-
-        Raises
-        ------
-        Warning
-            If any required parameters are missing.
-
-        """
-        if len(self.missing_parameters) == 0:
-            return True
-        else:
-            for param in self.missing_parameters:
-                warn(f'Binding Model {self.name}: Missing parameter "{param}".')
-            return False
-
     def __repr__(self):
         return f"{self.__class__.__name__}(\
             component_system={self.component_system}, name={self.name})')"
@@ -212,8 +159,9 @@ class Linear(BindingBaseClass):
     adsorption_rate = SizedUnsignedList(size='n_comp')
     desorption_rate = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'adsorption_rate', 'desorption_rate'
+    _parameters = [
+        'adsorption_rate',
+        'desorption_rate',
     ]
 
 
@@ -235,11 +183,10 @@ class Langmuir(BindingBaseClass):
     desorption_rate = SizedUnsignedList(size='n_comp')
     capacity = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'adsorption_rate', 'desorption_rate', 'capacity'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate', 'desorption_rate', 'capacity'
+    _parameters = [
+        'adsorption_rate',
+        'desorption_rate',
+        'capacity',
     ]
 
 
@@ -261,12 +208,7 @@ class LangmuirLDF(BindingBaseClass):
     driving_force_coefficient = SizedUnsignedList(size='n_comp')
     capacity = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'equilibrium_constant',
-        'driving_force_coefficient',
-        'capacity',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'equilibrium_constant',
         'driving_force_coefficient',
         'capacity',
@@ -293,12 +235,7 @@ class BiLangmuir(BindingBaseClass):
     desorption_rate = SizedUnsignedList(size='n_bound_states')
     capacity = SizedUnsignedList(size='n_bound_states')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'capacity',
@@ -330,12 +267,7 @@ class BiLangmuirLDF(BindingBaseClass):
     driving_force_coefficient = SizedUnsignedList(size='n_bound_states')
     capacity = SizedUnsignedList(size='n_bound_states')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'equilibrium_constant',
-        'driving_force_coefficient',
-        'capacity',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'equilibrium_constant',
         'driving_force_coefficient',
         'capacity',
@@ -365,12 +297,7 @@ class FreundlichLDF(BindingBaseClass):
     freundlich_coefficient = SizedUnsignedList(size='n_comp')
     exponent = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'driving_force_coefficient',
-        'freundlich_coefficient',
-        'exponent',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'driving_force_coefficient',
         'freundlich_coefficient',
         'exponent',
@@ -413,7 +340,7 @@ class StericMassAction(BindingBaseClass):
     reference_liquid_phase_conc = UnsignedFloat(default=1.0)
     reference_solid_phase_conc = UnsignedFloat(default=1.0)
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'characteristic_charge',
@@ -421,13 +348,6 @@ class StericMassAction(BindingBaseClass):
         'capacity',
         'reference_liquid_phase_conc',
         'reference_solid_phase_conc'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
     ]
 
     @property
@@ -480,13 +400,7 @@ class AntiLangmuir(BindingBaseClass):
     capacity = SizedUnsignedList(size='n_comp')
     antilangmuir = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'antilangmuir'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'capacity',
@@ -520,18 +434,9 @@ class Spreading(BindingBaseClass):
     exchange_from_1_2 = SizedUnsignedList(size='n_comp')
     exchange_from_2_1 = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
-        'activation_temp',
-        'capacity',
-        'exchange_from_1_2',
-        'exchange_from_2_1'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'desorption_rate',
-        'activation_temp',
         'capacity',
         'exchange_from_1_2',
         'exchange_from_2_1'
@@ -564,14 +469,7 @@ class MobilePhaseModulator(BindingBaseClass):
     hydrophobicity = SizedUnsignedList(size='n_comp')
     gamma = hydrophobicity
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'ion_exchange_characteristic',
-        'hydrophobicity',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'capacity',
@@ -612,15 +510,7 @@ class ExtendedMobilePhaseModulator(BindingBaseClass):
     gamma = hydrophobicity
     component_mode = SizedUnsignedList(size='n_comp')
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'ion_exchange_characteristic',
-        'hydrophobicity',
-        'component_mode',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'capacity',
@@ -666,7 +556,7 @@ class SelfAssociation(BindingBaseClass):
     reference_liquid_phase_conc = UnsignedFloat(default=1.0)
     reference_solid_phase_conc = UnsignedFloat(default=1.0)
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'adsorption_rate_dimerization',
         'desorption_rate',
@@ -675,14 +565,6 @@ class SelfAssociation(BindingBaseClass):
         'capacity',
         'reference_liquid_phase_conc',
         'reference_solid_phase_conc'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'adsorption_rate_dimerization',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
     ]
 
 
@@ -726,7 +608,7 @@ class BiStericMassAction(BindingBaseClass):
     reference_liquid_phase_conc = SizedUnsignedList(size='n_binding_sites', default=1)
     reference_solid_phase_conc = SizedUnsignedList(size='n_binding_sites', default=1)
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'characteristic_charge',
@@ -734,13 +616,6 @@ class BiStericMassAction(BindingBaseClass):
         'capacity',
         'reference_liquid_phase_conc',
         'reference_solid_phase_conc'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
     ]
 
     def __init__(self, *args, n_states=2, **kwargs):
@@ -794,7 +669,7 @@ class MultistateStericMassAction(BindingBaseClass):
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'characteristic_charge',
@@ -803,14 +678,6 @@ class MultistateStericMassAction(BindingBaseClass):
         'capacity',
         'reference_liquid_phase_conc',
         'reference_solid_phase_conc'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'conversion_rate',
-        'capacity',
     ]
 
     @property
@@ -899,7 +766,7 @@ class SimplifiedMultistateStericMassAction(BindingBaseClass):
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'desorption_rate',
         'characteristic_charge_first',
@@ -918,23 +785,6 @@ class SimplifiedMultistateStericMassAction(BindingBaseClass):
         'reference_liquid_phase_conc',
         'reference_solid_phase_conc'
     ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge_first',
-        'characteristic_charge_last',
-        'quadratic_modifiers_charge',
-        'steric_factor_first',
-        'steric_factor_last',
-        'quadratic_modifiers_steric',
-        'capacity',
-        'exchange_from_weak_stronger',
-        'linear_exchange_ws',
-        'quadratic_exchange_ws',
-        'exchange_from_stronger_weak',
-        'linear_exchange_sw',
-        'quadratic_exchange_sw',
-    ]
 
 
 class Saska(BindingBaseClass):
@@ -952,11 +802,9 @@ class Saska(BindingBaseClass):
     henry_const = SizedUnsignedList(size='n_comp')
     quadratic_factor = SizedUnsignedList(size=('n_comp', 'n_comp'))
 
-    _parameter_names = BindingBaseClass._parameter_names + [
-        'henry_const', 'quadratic_factor'
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'henry_const', 'quadratic_factor'
+    _parameters = [
+        'henry_const',
+        'quadratic_factor',
     ]
 
 
@@ -1042,7 +890,7 @@ class GeneralizedIonExchange(BindingBaseClass):
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
-    _parameter_names = BindingBaseClass._parameter_names + [
+    _parameters = [
         'adsorption_rate',
         'adsorption_rate_linear',
         'adsorption_rate_quadratic',
@@ -1064,13 +912,6 @@ class GeneralizedIonExchange(BindingBaseClass):
         'capacity',
         'reference_liquid_phase_conc',
         'reference_solid_phase_conc',
-    ]
-    _required_parameters = BindingBaseClass._required_parameters + [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
     ]
 
     @property

--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -6,10 +6,13 @@ from CADETProcess import CADETProcessError
 
 from CADETProcess.dataStructure import frozen_attributes
 from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import Bool, String, \
-    RangedInteger, UnsignedInteger, UnsignedFloat, DependentlySizedList, \
-    DependentlySizedRangedIntegerList, DependentlySizedUnsignedIntegerList, \
-    DependentlySizedUnsignedList, DependentlyModulatedUnsignedList
+from CADETProcess.dataStructure import (
+    Bool, String,
+    RangedInteger, UnsignedInteger, UnsignedFloat, SizedList,
+    SizedRangedIntegerList, SizedUnsignedIntegerList,
+    SizedUnsignedList,
+    DependentlyModulatedUnsignedList
+)
 
 from .componentSystem import ComponentSystem
 
@@ -68,8 +71,8 @@ class BindingBaseClass(Structure):
     is_kinetic = Bool(default=True)
 
     n_binding_sites = RangedInteger(lb=1, ub=1, default=1)
-    _bound_states = DependentlySizedRangedIntegerList(
-        dep=('n_binding_sites', 'n_comp'), lb=0, ub=1, default=1
+    _bound_states = SizedRangedIntegerList(
+        size=('n_binding_sites', 'n_comp'), lb=0, ub=1, default=1
     )
     non_binding_component_indices = []
 
@@ -206,8 +209,8 @@ class Linear(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate', 'desorption_rate'
@@ -228,9 +231,9 @@ class Langmuir(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    capacity = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
+    capacity = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate', 'desorption_rate', 'capacity'
@@ -254,13 +257,9 @@ class LangmuirLDF(BindingBaseClass):
 
     """
 
-    equilibrium_constant = DependentlySizedUnsignedList(
-        dep=('n_comp', 'n_states')
-    )
-    driving_force_coefficient = DependentlySizedUnsignedList(
-        dep=('n_comp', 'n_states')
-    )
-    capacity = DependentlySizedUnsignedList(dep=('n_comp', 'n_states'))
+    equilibrium_constant = SizedUnsignedList(size='n_comp')
+    driving_force_coefficient = SizedUnsignedList(size='n_comp')
+    capacity = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'equilibrium_constant',
@@ -290,9 +289,9 @@ class BiLangmuir(BindingBaseClass):
 
     n_binding_sites = UnsignedInteger(default=2)
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    capacity = DependentlySizedUnsignedList(dep='n_bound_states')
+    adsorption_rate = SizedUnsignedList(size='n_bound_states')
+    desorption_rate = SizedUnsignedList(size='n_bound_states')
+    capacity = SizedUnsignedList(size='n_bound_states')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate',
@@ -327,9 +326,9 @@ class BiLangmuirLDF(BindingBaseClass):
 
     n_binding_sites = UnsignedInteger(default=2)
 
-    equilibrium_constant = DependentlySizedUnsignedList(dep='n_bound_states')
-    driving_force_coefficient = DependentlySizedUnsignedList(dep='n_bound_states')
-    capacity = DependentlySizedUnsignedList(dep='n_bound_states')
+    equilibrium_constant = SizedUnsignedList(size='n_bound_states')
+    driving_force_coefficient = SizedUnsignedList(size='n_bound_states')
+    capacity = SizedUnsignedList(size='n_bound_states')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'equilibrium_constant',
@@ -362,9 +361,9 @@ class FreundlichLDF(BindingBaseClass):
 
     """
 
-    driving_force_coefficient = DependentlySizedUnsignedList(dep='n_comp')
-    freundlich_coefficient = DependentlySizedUnsignedList(dep='n_comp')
-    exponent = DependentlySizedUnsignedList(dep='n_comp')
+    driving_force_coefficient = SizedUnsignedList(size='n_comp')
+    freundlich_coefficient = SizedUnsignedList(size='n_comp')
+    exponent = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'driving_force_coefficient',
@@ -406,10 +405,10 @@ class StericMassAction(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    characteristic_charge = DependentlySizedUnsignedList(dep='n_comp')
-    steric_factor = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
+    characteristic_charge = SizedUnsignedList(size='n_comp')
+    steric_factor = SizedUnsignedList(size='n_comp')
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1.0)
     reference_solid_phase_conc = UnsignedFloat(default=1.0)
@@ -476,10 +475,10 @@ class AntiLangmuir(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    capacity = DependentlySizedUnsignedList(dep='n_comp')
-    antilangmuir = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
+    capacity = SizedUnsignedList(size='n_comp')
+    antilangmuir = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate',
@@ -515,11 +514,11 @@ class Spreading(BindingBaseClass):
 
     n_binding_sites = RangedInteger(lb=2, ub=2, default=2)
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_total_bound')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_total_bound')
-    capacity = DependentlySizedUnsignedList(dep='n_total_bound')
-    exchange_from_1_2 = DependentlySizedUnsignedList(dep='n_comp')
-    exchange_from_2_1 = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_total_bound')
+    desorption_rate = SizedUnsignedList(size='n_total_bound')
+    capacity = SizedUnsignedList(size='n_total_bound')
+    exchange_from_1_2 = SizedUnsignedList(size='n_comp')
+    exchange_from_2_1 = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate',
@@ -557,12 +556,12 @@ class MobilePhaseModulator(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    capacity = DependentlySizedUnsignedList(dep='n_comp')
-    ion_exchange_characteristic = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
+    capacity = SizedUnsignedList(size='n_comp')
+    ion_exchange_characteristic = SizedUnsignedList(size='n_comp')
     beta = ion_exchange_characteristic
-    hydrophobicity = DependentlySizedUnsignedList(dep='n_comp')
+    hydrophobicity = SizedUnsignedList(size='n_comp')
     gamma = hydrophobicity
 
     _parameter_names = BindingBaseClass._parameter_names + [
@@ -604,14 +603,14 @@ class ExtendedMobilePhaseModulator(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    capacity = DependentlySizedUnsignedList(dep='n_comp')
-    ion_exchange_characteristic = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
+    capacity = SizedUnsignedList(size='n_comp')
+    ion_exchange_characteristic = SizedUnsignedList(size='n_comp')
     beta = ion_exchange_characteristic
-    hydrophobicity = DependentlySizedUnsignedList(dep='n_comp')
+    hydrophobicity = SizedUnsignedList(size='n_comp')
     gamma = hydrophobicity
-    component_mode = DependentlySizedUnsignedList(dep='n_comp')
+    component_mode = SizedUnsignedList(size='n_comp')
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate',
@@ -658,11 +657,11 @@ class SelfAssociation(BindingBaseClass):
 
     """
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    adsorption_rate_dimerization = DependentlySizedUnsignedList(dep='n_comp')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_comp')
-    characteristic_charge = DependentlySizedUnsignedList(dep='n_comp')
-    steric_factor = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_comp')
+    adsorption_rate_dimerization = SizedUnsignedList(size='n_comp')
+    desorption_rate = SizedUnsignedList(size='n_comp')
+    characteristic_charge = SizedUnsignedList(size='n_comp')
+    steric_factor = SizedUnsignedList(size='n_comp')
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1.0)
     reference_solid_phase_conc = UnsignedFloat(default=1.0)
@@ -718,20 +717,14 @@ class BiStericMassAction(BindingBaseClass):
 
     n_binding_sites = UnsignedInteger(default=2)
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    adsorption_rate_dimerization = DependentlySizedUnsignedList(
-        dep='n_bound_states'
-    )
-    desorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    characteristic_charge = DependentlySizedUnsignedList(dep='n_bound_states')
-    steric_factor = DependentlySizedUnsignedList(dep='n_bound_states')
-    capacity = DependentlySizedUnsignedList(dep='n_binding_sites')
-    reference_liquid_phase_conc = DependentlySizedUnsignedList(
-        dep='n_binding_sites', default=1
-    )
-    reference_solid_phase_conc = DependentlySizedUnsignedList(
-        dep='n_binding_sites', default=1
-    )
+    adsorption_rate = SizedUnsignedList(size='n_bound_states')
+    adsorption_rate_dimerization = SizedUnsignedList(size='n_bound_states')
+    desorption_rate = SizedUnsignedList(size='n_bound_states')
+    characteristic_charge = SizedUnsignedList(size='n_bound_states')
+    steric_factor = SizedUnsignedList(size='n_bound_states')
+    capacity = SizedUnsignedList(size='n_binding_sites')
+    reference_liquid_phase_conc = SizedUnsignedList(size='n_binding_sites', default=1)
+    reference_solid_phase_conc = SizedUnsignedList(size='n_binding_sites', default=1)
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'adsorption_rate',
@@ -788,15 +781,15 @@ class MultistateStericMassAction(BindingBaseClass):
 
     """
 
-    bound_states = DependentlySizedUnsignedIntegerList(
-        dep=('n_binding_sites', 'n_comp'), default=1
+    bound_states = SizedUnsignedIntegerList(
+        size=('n_binding_sites', 'n_comp'), default=1
     )
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    characteristic_charge = DependentlySizedUnsignedList(dep='n_bound_states')
-    steric_factor = DependentlySizedUnsignedList(dep='n_bound_states')
-    conversion_rate = DependentlySizedUnsignedList(dep='_conversion_entries')
+    adsorption_rate = SizedUnsignedList(size='n_bound_states')
+    desorption_rate = SizedUnsignedList(size='n_bound_states')
+    characteristic_charge = SizedUnsignedList(size='n_bound_states')
+    steric_factor = SizedUnsignedList(size='n_bound_states')
+    conversion_rate = SizedUnsignedList(size='_conversion_entries')
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
@@ -884,25 +877,25 @@ class SimplifiedMultistateStericMassAction(BindingBaseClass):
 
     """
 
-    bound_states = DependentlySizedUnsignedIntegerList(
-        dep=('n_binding_sites', 'n_comp'), default=1
+    bound_states = SizedUnsignedIntegerList(
+        size=('n_binding_sites', 'n_comp'), default=1
     )
 
-    adsorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    desorption_rate = DependentlySizedUnsignedList(dep='n_bound_states')
-    characteristic_charge_first = DependentlySizedUnsignedList(dep='n_comp')
-    characteristic_charge_last = DependentlySizedUnsignedList(dep='n_comp')
-    quadratic_modifiers_charge = DependentlySizedUnsignedList(dep='n_comp')
-    steric_factor_first = DependentlySizedUnsignedList(dep='n_comp')
-    steric_factor_last = DependentlySizedUnsignedList(dep='n_comp')
-    quadratic_modifiers_steric = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedUnsignedList(size='n_bound_states')
+    desorption_rate = SizedUnsignedList(size='n_bound_states')
+    characteristic_charge_first = SizedUnsignedList(size='n_comp')
+    characteristic_charge_last = SizedUnsignedList(size='n_comp')
+    quadratic_modifiers_charge = SizedUnsignedList(size='n_comp')
+    steric_factor_first = SizedUnsignedList(size='n_comp')
+    steric_factor_last = SizedUnsignedList(size='n_comp')
+    quadratic_modifiers_steric = SizedUnsignedList(size='n_comp')
     capacity = UnsignedFloat()
-    exchange_from_weak_stronger = DependentlySizedUnsignedList(dep='n_comp')
-    linear_exchange_ws = DependentlySizedUnsignedList(dep='n_comp')
-    quadratic_exchange_ws = DependentlySizedUnsignedList(dep='n_comp')
-    exchange_from_stronger_weak = DependentlySizedUnsignedList(dep='n_comp')
-    linear_exchange_sw = DependentlySizedUnsignedList(dep='n_comp')
-    quadratic_exchange_sw = DependentlySizedUnsignedList(dep='n_comp')
+    exchange_from_weak_stronger = SizedUnsignedList(size='n_comp')
+    linear_exchange_ws = SizedUnsignedList(size='n_comp')
+    quadratic_exchange_ws = SizedUnsignedList(size='n_comp')
+    exchange_from_stronger_weak = SizedUnsignedList(size='n_comp')
+    linear_exchange_sw = SizedUnsignedList(size='n_comp')
+    quadratic_exchange_sw = SizedUnsignedList(size='n_comp')
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
@@ -956,8 +949,8 @@ class Saska(BindingBaseClass):
 
     """
 
-    henry_const = DependentlySizedUnsignedList(dep='n_comp')
-    quadratic_factor = DependentlySizedUnsignedList(dep=('n_comp', 'n_comp'))
+    henry_const = SizedUnsignedList(size='n_comp')
+    quadratic_factor = SizedUnsignedList(size=('n_comp', 'n_comp'))
 
     _parameter_names = BindingBaseClass._parameter_names + [
         'henry_const', 'quadratic_factor'
@@ -1027,52 +1020,24 @@ class GeneralizedIonExchange(BindingBaseClass):
 
     non_binding_component_indices = [1]
 
-    adsorption_rate = DependentlySizedList(dep='n_comp')
-    adsorption_rate_linear = DependentlySizedList(dep='n_comp')
-    adsorption_rate_quadratic = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    adsorption_rate_cubic = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    adsorption_rate_salt = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    adsorption_rate_protein = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    desorption_rate = DependentlySizedList(dep='n_comp')
-    desorption_rate_linear = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    desorption_rate_quadratic = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    desorption_rate_cubic = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    desorption_rate_salt = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    desorption_rate_protein = DependentlySizedList(
-        dep='n_comp', default=0
-    )
-    characteristic_charge_breaks = DependentlyModulatedUnsignedList(
-        dep='n_comp'
-    )
-    characteristic_charge = DependentlySizedList(
-        dep=('n_pieces', 'n_comp'),
-    )
-    characteristic_charge_linear = DependentlySizedList(
-        dep=('n_pieces', 'n_comp'), default=0
-    )
-    characteristic_charge_quadratic = DependentlySizedList(
-        dep=('n_pieces', 'n_comp'), default=0
-    )
-    characteristic_charge_cubic = DependentlySizedList(
-        dep=('n_pieces', 'n_comp'), default=0
-    )
-    steric_factor = DependentlySizedUnsignedList(dep='n_comp')
+    adsorption_rate = SizedList(size='n_comp')
+    adsorption_rate_linear = SizedList(size='n_comp')
+    adsorption_rate_quadratic = SizedList(size='n_comp', default=0)
+    adsorption_rate_cubic = SizedList(size='n_comp', default=0)
+    adsorption_rate_salt = SizedList(size='n_comp', default=0)
+    adsorption_rate_protein = SizedList(size='n_comp', default=0)
+    desorption_rate = SizedList(size='n_comp')
+    desorption_rate_linear = SizedList(size='n_comp', default=0)
+    desorption_rate_quadratic = SizedList(size='n_comp', default=0)
+    desorption_rate_cubic = SizedList(size='n_comp', default=0)
+    desorption_rate_salt = SizedList(size='n_comp', default=0)
+    desorption_rate_protein = SizedList(size='n_comp', default=0)
+    characteristic_charge_breaks = DependentlyModulatedUnsignedList(size='n_comp')
+    characteristic_charge = SizedList(size=('n_pieces', 'n_comp'),)
+    characteristic_charge_linear = SizedList(size=('n_pieces', 'n_comp'), default=0)
+    characteristic_charge_quadratic = SizedList(size=('n_pieces', 'n_comp'), default=0)
+    characteristic_charge_cubic = SizedList(size=('n_pieces', 'n_comp'), default=0)
+    steric_factor = SizedUnsignedList(size='n_comp')
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)

--- a/CADETProcess/processModel/componentSystem.py
+++ b/CADETProcess/processModel/componentSystem.py
@@ -4,7 +4,7 @@ from functools import wraps
 from addict import Dict
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure, StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import String, Integer, UnsignedFloat
 
 
@@ -31,7 +31,7 @@ class Species(Structure):
     molecular_weight = UnsignedFloat()
 
 
-class Component(metaclass=StructMeta):
+class Component(Structure):
     """Information about single component.
 
     A component can contain subspecies (e.g. differently charged variants).
@@ -145,7 +145,7 @@ class Component(metaclass=StructMeta):
         yield from self.species
 
 
-class ComponentSystem(metaclass=StructMeta):
+class ComponentSystem(Structure):
     """Information about components in system.
 
     A component can contain subspecies (e.g. differently charged variants).

--- a/CADETProcess/processModel/componentSystem.py
+++ b/CADETProcess/processModel/componentSystem.py
@@ -159,19 +159,19 @@ class ComponentSystem(Structure):
     n_species : int
         Number of Subspecies.
     n_comp : int
-        Number of all components including species.
+        Number of all component species.
     n_components : int
         Number of components.
     indices : dict
         Component indices.
     names : list
         Names of all components.
-    labels : list
-        Labels of all components (including species).
+    species : list
+        Names of all component species.
     charge : list
-        Charges of all components (including species).
+        Charges of all components species.
     molecular_weight : list
-        Molecular weights of all components (including species).
+        Molecular weights of all component species.
 
     See Also
     --------
@@ -311,6 +311,7 @@ class ComponentSystem(Structure):
 
     @property
     def indices(self):
+        """dict: List of species indices for each component name."""
         indices = defaultdict(list)
 
         index = 0
@@ -320,6 +321,19 @@ class ComponentSystem(Structure):
                 index += 1
 
         return Dict(indices)
+
+    @property
+    def species_indices(self):
+        """dict: Indices for each species."""
+        indices = Dict()
+
+        index = 0
+        for comp in self.components:
+            for spec in comp.species:
+                indices[spec.name] = index
+                index += 1
+
+        return indices
 
     @property
     def names(self):
@@ -334,23 +348,18 @@ class ComponentSystem(Structure):
     @property
     def species(self):
         """list: List of species names."""
-        return self.labels
-
-    @property
-    def labels(self):
-        """list: List of species names."""
-        labels = []
+        species = []
         index = 0
         for comp in self.components:
             for label in comp.label:
                 if label is None:
-                    labels.append(str(index))
+                    species.append(str(index))
                 else:
-                    labels.append(label)
+                    species.append(label)
 
                 index += 1
 
-        return labels
+        return species
 
     @property
     def charges(self):

--- a/CADETProcess/processModel/discretization.py
+++ b/CADETProcess/processModel/discretization.py
@@ -16,7 +16,7 @@ from CADETProcess.dataStructure import ParametersGroup
 from CADETProcess.dataStructure import (
     Bool, Switch,
     RangedInteger, UnsignedInteger, UnsignedFloat,
-    DependentlySizedRangedList
+    SizedRangedList
 )
 
 
@@ -334,7 +334,7 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
         Discretization scheme inside the particles for all or each particle type.
         Valid values are 'EQUIDISTANT_PAR', 'EQUIVOLUME_PAR', and 'USER_DEFINED_PAR'.
         Default is 'EQUIDISTANT_PAR'.
-    par_disc_vector : DependentlySizedRangedList, optional
+    par_disc_vector : SizedRangedList, optional
         Node coordinates for the cell boundaries
         (ignored if `par_disc_type` != `USER_DEFINED_PAR).
         The coordinates are relative and have to include the endpoints `0` and `1`.
@@ -389,8 +389,8 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
         default='EQUIDISTANT_PAR',
         valid=['EQUIDISTANT_PAR', 'EQUIVOLUME_PAR', 'USER_DEFINED_PAR']
     )
-    par_disc_vector = DependentlySizedRangedList(
-        lb=0, ub=1, dep='par_disc_vector_length'
+    par_disc_vector = SizedRangedList(
+        lb=0, ub=1, size='par_disc_vector_length'
     )
 
     par_boundary_order = RangedInteger(lb=1, ub=2, default=2)
@@ -494,8 +494,8 @@ class GRMDiscretizationDG(DGMixin):
         default='EQUIDISTANT_PAR',
         valid=['EQUIDISTANT_PAR', 'EQUIVOLUME_PAR', 'USER_DEFINED_PAR']
     )
-    par_disc_vector = DependentlySizedRangedList(
-        lb=0, ub=1, dep='par_disc_vector_length'
+    par_disc_vector = SizedRangedList(
+        lb=0, ub=1, size='par_disc_vector_length'
     )
 
     par_boundary_order = RangedInteger(lb=1, ub=2, default=2)

--- a/CADETProcess/processModel/flowSheet.py
+++ b/CADETProcess/processModel/flowSheet.py
@@ -8,7 +8,7 @@ from addict import Dict
 
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import frozen_attributes
-from CADETProcess.dataStructure import StructMeta, UnsignedInteger, String
+from CADETProcess.dataStructure import Structure, UnsignedInteger, String
 from .componentSystem import ComponentSystem
 from .unitOperation import UnitBaseClass
 from .unitOperation import Inlet, Outlet, Cstr
@@ -16,7 +16,7 @@ from .binding import NoBinding
 
 
 @frozen_attributes
-class FlowSheet(metaclass=StructMeta):
+class FlowSheet(Structure):
     """Class to design process flow sheet.
 
     In this class, UnitOperation models are added and connected in a flow
@@ -50,8 +50,9 @@ class FlowSheet(metaclass=StructMeta):
         self._output_states = Dict()
         self._flow_rates = Dict()
         self._parameters = Dict()
-        self._section_dependent_parameters = Dict()
+        self._sized_parameters = Dict()
         self._polynomial_parameters = Dict()
+        self._section_dependent_parameters = Dict()
 
     @property
     def component_system(self):
@@ -106,9 +107,15 @@ class FlowSheet(metaclass=StructMeta):
             self._section_dependent_parameters[unit.name] = \
                 unit.section_dependent_parameters
             self._polynomial_parameters[unit.name] = unit.polynomial_parameters
+            self._sized_parameters[unit.name] = unit.sized_parameters
 
         self._parameters['output_states'] = {
             unit.name: self.output_states[unit] for unit in self.units
+        }
+
+        self._sized_parameters['output_states'] = {
+            unit.name: self.output_states[unit]
+            for unit in self.units
         }
 
         self._section_dependent_parameters['output_states'] = {
@@ -143,8 +150,7 @@ class FlowSheet(metaclass=StructMeta):
 
     @property
     def number_of_units(self):
-        """int: Number of unit operations in the FlowSheet.
-        """
+        """int: Number of unit operations in the FlowSheet."""
         return len(self._units)
 
     @unit_name_decorator
@@ -495,7 +501,7 @@ class FlowSheet(metaclass=StructMeta):
         Raises
         ------
         CADETProcessError
-            If unit not in flowSheet
+            If unit not in FlowSheet
             If state is integer and the state >= the state_length.
             If the length of the states is unequal the state_length.
             If the sum of the states is not equal to 1.
@@ -915,12 +921,16 @@ class FlowSheet(metaclass=StructMeta):
         self.update_parameters()
 
     @property
-    def section_dependent_parameters(self):
-        return self._section_dependent_parameters
+    def sized_parameters(self):
+        return self._sized_parameters
 
     @property
     def polynomial_parameters(self):
         return self._polynomial_parameters
+
+    @property
+    def section_dependent_parameters(self):
+        return self._section_dependent_parameters
 
     @property
     def initial_state(self):

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -98,7 +98,7 @@ class Process(EventHandler):
             else:
                 feed_signal_time_line = TimeLine()
                 feed_section = Section(
-                    0, self.cycle_time, feed.c, n_entries=self.n_comp, degree=3
+                    0, self.cycle_time, feed.c, is_polynomial=True
                 )
                 feed_signal_time_line.add_section(feed_section)
 
@@ -166,32 +166,32 @@ class Process(EventHandler):
                 # If inlet, also use outlet for total_in
                 if isinstance(self.flow_sheet[unit], Inlet):
                     section = Section(
-                        start, end, flow_rate.total_out, n_entries=1, degree=3
+                        start, end, flow_rate.total_out, is_polynomial=True
                     )
                 else:
                     section = Section(
-                        start, end, flow_rate.total_in, n_entries=1, degree=3
+                        start, end, flow_rate.total_in, is_polynomial=True
                     )
                 unit_flow_rates['total_in'].add_section(section)
                 for orig, flow_rate_orig in flow_rate.origins.items():
                     section = Section(
-                        start, end, flow_rate_orig, n_entries=1, degree=3
+                        start, end, flow_rate_orig, is_polynomial=True
                     )
                     unit_flow_rates['origins'][orig].add_section(section)
 
                 # If outlet, also use inlet for total_out
                 if isinstance(self.flow_sheet[unit], Outlet):
                     section = Section(
-                        start, end, flow_rate.total_in, n_entries=1, degree=3
+                        start, end, flow_rate.total_in, is_polynomial=True
                     )
                 else:
                     section = Section(
-                        start, end, flow_rate.total_out, n_entries=1, degree=3
+                        start, end, flow_rate.total_out, is_polynomial=True
                     )
                 unit_flow_rates['total_out'].add_section(section)
                 for dest, flow_rate_dest in flow_rate.destinations.items():
                     section = Section(
-                        start, end, flow_rate_dest, n_entries=1, degree=3
+                        start, end, flow_rate_dest, is_polynomial=True
                     )
                     unit_flow_rates['destinations'][dest].add_section(section)
 
@@ -215,25 +215,25 @@ class Process(EventHandler):
             for unit, unit_flow_rates in self.flow_rate_timelines.items():
                 if isinstance(self.flow_sheet[unit], Inlet):
                     section_states[sec_time][unit]['total_in'] \
-                        = unit_flow_rates['total_out'].coefficients(sec_time)[0]
+                        = unit_flow_rates['total_out'].coefficients(sec_time)
                 else:
                     section_states[sec_time][unit]['total_in'] \
-                        = unit_flow_rates['total_in'].coefficients(sec_time)[0]
+                        = unit_flow_rates['total_in'].coefficients(sec_time)
 
                     for orig, tl in unit_flow_rates.origins.items():
                         section_states[sec_time][unit]['origins'][orig] \
-                            = tl.coefficients(sec_time)[0]
+                            = tl.coefficients(sec_time)
 
                 if isinstance(self.flow_sheet[unit], Outlet):
                     section_states[sec_time][unit]['total_out'] \
-                        = unit_flow_rates['total_in'].coefficients(sec_time)[0]
+                        = unit_flow_rates['total_in'].coefficients(sec_time)
                 else:
                     section_states[sec_time][unit]['total_out'] \
-                        = unit_flow_rates['total_out'].coefficients(sec_time)[0]
+                        = unit_flow_rates['total_out'].coefficients(sec_time)
 
                     for dest, tl in unit_flow_rates.destinations.items():
                         section_states[sec_time][unit]['destinations'][dest] \
-                            = tl.coefficients(sec_time)[0]
+                            = tl.coefficients(sec_time)
 
         return Dict(section_states)
 
@@ -477,7 +477,6 @@ class Process(EventHandler):
     def section_dependent_parameters(self):
         parameters = Dict()
         parameters.flow_sheet = self.flow_sheet.section_dependent_parameters
-
         return parameters
 
     @property
@@ -647,7 +646,7 @@ class Process(EventHandler):
             True if process is setup correctly. False otherwise.
 
         """
-        flag = True
+        flag = super().check_config()
 
         missing_parameters = self.flow_sheet.missing_parameters
         if len(missing_parameters) > 0:

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -402,7 +402,7 @@ class Process(EventHandler):
             if len(param_parts) == 3:
                 associated_model = param_parts[1]
 
-            if comp is not None and comp not in self.component_system.labels:
+            if comp is not None and comp not in self.component_system.species:
                 raise CADETProcessError(f'Unknown component {comp}.')
 
             unit = self.flow_sheet[unit]
@@ -525,7 +525,7 @@ class Process(EventHandler):
         self.parameters = config['parameters']
         self.initial_state = config['initial_state']
 
-    def add_concentration_profile(self, unit, time, c, component_index=None, s=1e-6):
+    def add_concentration_profile(self, unit, time, c, components=None, s=1e-6):
         """Add concentration profile to Process.
 
         Parameters

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -482,9 +482,14 @@ class Process(EventHandler):
 
     @property
     def polynomial_parameters(self):
-        parameters = Dict()
+        parameters = super().polynomial_parameters
         parameters.flow_sheet = self.flow_sheet.polynomial_parameters
+        return parameters
 
+    @property
+    def sized_parameters(self):
+        parameters = super().sized_parameters
+        parameters.flow_sheet = self.flow_sheet.sized_parameters
         return parameters
 
     @property

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -151,16 +151,16 @@ class Reaction(Structure):
         for i, nu in enumerate(self.stoich):
             if nu < 0:
                 if nu == - 1:
-                    educts.append(f"{self.component_system.labels[i]}")
+                    educts.append(f"{self.component_system.species[i]}")
                 else:
                     educts.append(
-                        f"{abs(nu)} {self.component_system.labels[i]}"
+                        f"{abs(nu)} {self.component_system.species[i]}"
                     )
             elif nu > 0:
                 if nu == 1:
-                    products.append(f"{self.component_system.labels[i]}")
+                    products.append(f"{self.component_system.species[i]}")
                 else:
-                    products.append(f"{nu} {self.component_system.labels[i]}")
+                    products.append(f"{nu} {self.component_system.species[i]}")
 
         if self.is_kinetic:
             reaction_operator = f' <=>[{self.k_fwd:.2E}][{self.k_bwd:.2E}] '
@@ -379,32 +379,32 @@ class CrossPhaseReaction(Structure):
         for i, nu in enumerate(self.stoich_liquid):
             if nu < 0:
                 if nu == - 1:
-                    educts.append(f"{self.component_system.labels[i]}(l)")
+                    educts.append(f"{self.component_system.species[i]}(l)")
                 else:
                     educts.append(
-                        f"{abs(nu)} {self.component_system.labels[i]}(l)"
+                        f"{abs(nu)} {self.component_system.species[i]}(l)"
                     )
             elif nu > 0:
                 if nu == 1:
-                    products.append(f"{self.component_system.labels[i]}(l)")
+                    products.append(f"{self.component_system.species[i]}(l)")
                 else:
                     products.append(
-                        f"{nu} {self.component_system.labels[i]}(l)"
+                        f"{nu} {self.component_system.species[i]}(l)"
                     )
         for i, nu in enumerate(self.stoich_solid):
             if nu < 0:
                 if nu == - 1:
-                    educts.append(f"{self.component_system.labels[i]}(s)")
+                    educts.append(f"{self.component_system.species[i]}(s)")
                 else:
                     educts.append(
-                        f"{abs(nu)} {self.component_system.labels[i]}(s)"
+                        f"{abs(nu)} {self.component_system.species[i]}(s)"
                     )
             elif nu > 0:
                 if nu == 1:
-                    products.append(f"{self.component_system.labels[i]}(s)")
+                    products.append(f"{self.component_system.species[i]}(s)")
                 else:
                     products.append(
-                        f"{nu} {self.component_system.labels[i]}(s)"
+                        f"{nu} {self.component_system.species[i]}(s)"
                     )
 
         if self.is_kinetic:

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -3,7 +3,7 @@ from functools import wraps
 import numpy as np
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import String, UnsignedInteger
 
 from .componentSystem import ComponentSystem
@@ -355,7 +355,7 @@ class CrossPhaseReaction():
         return " + ".join(educts) + reaction_operator + " + ".join(products)
 
 
-class ReactionBaseClass(metaclass=StructMeta):
+class ReactionBaseClass(Structure):
     """Abstract base class for parameters of reaction models.
 
     Attributes
@@ -371,7 +371,7 @@ class ReactionBaseClass(metaclass=StructMeta):
     name = String()
     n_comp = UnsignedInteger()
 
-    _parameter_names = []
+    _parameters = []
 
     def __init__(self, component_system, name=None, *args, **kwargs):
         self.component_system = component_system
@@ -379,7 +379,7 @@ class ReactionBaseClass(metaclass=StructMeta):
 
         self._parameters = {
             param: getattr(self, param)
-            for param in self._parameter_names
+            for param in self._parameters
         }
 
         super().__init__(*args, **kwargs)
@@ -403,18 +403,6 @@ class ReactionBaseClass(metaclass=StructMeta):
     def n_comp(self):
         """int: Number of components."""
         return self.component_system.n_comp
-
-    @property
-    def parameters(self):
-        """dict: Dictionary with parameter values."""
-        return {param: getattr(self, param) for param in self._parameter_names}
-
-    @parameters.setter
-    def parameters(self, parameters):
-        for param, value in parameters.items():
-            if param not in self._parameter_names:
-                raise CADETProcessError('Not a valid parameter')
-            setattr(self, param, value)
 
     def __repr__(self):
         return \
@@ -442,9 +430,7 @@ class NoReaction(ReactionBaseClass):
 class MassActionLaw(ReactionBaseClass):
     """Parameters for Reaction in Bulk Phase."""
 
-    _parameter_names = ReactionBaseClass._parameter_names + [
-        'stoich', 'exponents_fwd', 'exponents_bwd', 'k_fwd', 'k_bwd'
-    ]
+    _parameters = ['stoich', 'exponents_fwd', 'exponents_bwd', 'k_fwd', 'k_bwd']
 
     def __init__(self, *args, **kwargs):
         self._reactions = []
@@ -516,7 +502,7 @@ class MassActionLaw(ReactionBaseClass):
 class MassActionLawParticle(ReactionBaseClass):
     """Parameters for Reaction in Particle Phase."""
 
-    _parameter_names = ReactionBaseClass._parameter_names + [
+    _parameters = [
         'stoich_liquid', 'exponents_fwd_liquid', 'exponents_bwd_liquid',
         'k_fwd_liquid', 'k_bwd_liquid',
         'exponents_fwd_liquid_modsolid', 'exponents_bwd_liquid_modsolid',

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -74,11 +74,9 @@ class UnitBaseClass(Structure):
     """
     name = String()
 
-    _parameter_names = []
+    _parameters = []
     _section_dependent_parameters = []
-    _polynomial_parameters = []
     _initial_state = []
-    _required_parameters = []
 
     supports_binding = False
     supports_bulk_reaction = False
@@ -97,11 +95,6 @@ class UnitBaseClass(Structure):
         self.discretization = NoDiscretization()
 
         self.solution_recorder = IORecorder()
-
-        self._parameters = {
-            param: getattr(self, param)
-            for param in self._parameter_names
-        }
 
         super().__init__(*args, **kwargs)
 
@@ -142,8 +135,7 @@ class UnitBaseClass(Structure):
 
     @property
     def parameters(self):
-        """dict: Dictionary with parameter values.
-        """
+        """dict: Dictionary with parameter values."""
         parameters = self._parameters
 
         if not isinstance(self.binding_model, NoBinding):
@@ -182,11 +174,7 @@ class UnitBaseClass(Structure):
         except KeyError:
             pass
 
-        for param, value in parameters.items():
-            if param not in self._parameters:
-                raise CADETProcessError('Not a valid parameter')
-            if value is not None:
-                setattr(self, param, value)
+        super(UnitBaseClass, self.__class__).parameters.fset(self, parameters)
 
     @property
     def section_dependent_parameters(self):
@@ -194,20 +182,7 @@ class UnitBaseClass(Structure):
             key: value for key, value in self.parameters.items()
             if key in self._section_dependent_parameters
         }
-
         return parameters
-
-    @property
-    def polynomial_parameters(self):
-        parameters = {
-            key: value for key, value in self.parameters.items()
-            if key in self._polynomial_parameters
-        }
-        return parameters
-
-    @property
-    def required_parameters(self):
-        return self._required_parameters
 
     @property
     def initial_state(self):
@@ -227,10 +202,7 @@ class UnitBaseClass(Structure):
 
     @property
     def missing_parameters(self):
-        missing_parameters = []
-        for param in self._required_parameters:
-            if getattr(self, param) is None:
-                missing_parameters.append(param)
+        missing_parameters = super().missing_parameters
 
         missing_parameters += [
             f'binding_model.{param}' for param in self.binding_model.missing_parameters
@@ -363,10 +335,9 @@ class SourceMixin(Structure):
 
     """
     _n_poly_coeffs = 4
-    _parameter_names = ['flow_rate']
     flow_rate = Polynomial(size=('_n_poly_coeffs'))
+    _parameters = ['flow_rate']
     _section_dependent_parameters = ['flow_rate']
-    _polynomial_parameters = ['flow_rate']
 
 
 class SinkMixin():
@@ -398,19 +369,11 @@ class Inlet(UnitBaseClass, SourceMixin):
     c = NdPolynomial(size=('n_comp', '_n_poly_coeffs'), default=0)
     flow_rate = Polynomial(size=('_n_poly_coeffs'), default=0)
     _n_poly_coeffs = 4
-    _parameter_names = \
-        UnitBaseClass._parameter_names + \
-        SourceMixin._parameter_names + \
-        ['c']
+    _parameters = ['c']
     _section_dependent_parameters = \
         UnitBaseClass._section_dependent_parameters + \
         SourceMixin._section_dependent_parameters + \
         ['c']
-    _polynomial_parameters = \
-        UnitBaseClass._polynomial_parameters + \
-        SourceMixin._polynomial_parameters + \
-        ['c']
-    _required_parameters = ['flow_rate']
 
 
 class Outlet(UnitBaseClass, SinkMixin):
@@ -463,14 +426,10 @@ class TubularReactorBase(UnitBaseClass):
     axial_dispersion = UnsignedFloat()
     flow_direction = Switch(valid=[-1, 1], default=1)
     _initial_state = UnitBaseClass._initial_state + ['c']
-    _parameter_names = UnitBaseClass._parameter_names + [
-        'length', 'diameter',
-        'axial_dispersion', 'flow_direction'
-    ]
+    _parameters = ['length', 'diameter', 'axial_dispersion', 'flow_direction']
     _section_dependent_parameters = \
         UnitBaseClass._section_dependent_parameters + \
         ['axial_dispersion', 'flow_direction']
-    _required_parameters = ['length', 'axial_dispersion', 'diameter']
 
     @property
     @abstractmethod
@@ -704,8 +663,8 @@ class TubularReactor(TubularReactorBase):
     total_porosity = Constant(1)
 
     c = SizedList(size='n_comp', default=0)
-    _initial_state = UnitBaseClass._initial_state + ['c']
-    _parameter_names = TubularReactorBase._parameter_names + _initial_state
+    _initial_state = ['c']
+    _parameters = ['c']
 
     def __init__(self, *args, discretization_scheme='FV', **kwargs):
         super().__init__(*args, **kwargs)
@@ -745,15 +704,13 @@ class LumpedRateModelWithoutPores(TubularReactorBase):
     discretization_schemes = (LRMDiscretizationFV, LRMDiscretizationDG)
 
     total_porosity = UnsignedFloat(ub=1)
-    _parameter_names = TubularReactorBase._parameter_names + [
-        'total_porosity'
-    ]
-    _required_parameters = TubularReactorBase._required_parameters + ['total_porosity']
+    _parameters = ['total_porosity']
 
     c = SizedList(size='n_comp', default=0)
     _q = SizedUnsignedList(size='n_bound_states', default=0)
     _initial_state = TubularReactorBase._initial_state + ['q']
-    _parameter_names = _parameter_names + _initial_state
+
+    _parameters = _parameters + _initial_state
 
     def __init__(self, *args, discretization_scheme='FV', **kwargs):
         super().__init__(*args, **kwargs)
@@ -811,24 +768,26 @@ class LumpedRateModelWithPores(TubularReactorBase):
     bed_porosity = UnsignedFloat(ub=1)
     particle_porosity = UnsignedFloat(ub=1)
     particle_radius = UnsignedFloat()
-    _parameter_names = TubularReactorBase._parameter_names + [
     film_diffusion = SizedUnsignedList(size='n_comp')
     pore_accessibility = SizedUnsignedList(size='n_comp')
-            'bed_porosity', 'particle_porosity', 'particle_radius',
-            'film_diffusion'
-            ]
-    _section_dependent_parameters = \
-        TubularReactorBase._section_dependent_parameters + ['film_diffusion']
-    _required_parameters = TubularReactorBase._required_parameters + [
-        'bed_porosity', 'particle_porosity', 'particle_radius', 'film_diffusion'
+    _parameters = [
+        'bed_porosity',
+        'particle_porosity',
+        'particle_radius',
+        'film_diffusion',
     ]
+
+    _section_dependent_parameters = \
+        UnitBaseClass._section_dependent_parameters + \
+        TubularReactorBase._section_dependent_parameters + \
+        ['film_diffusion']
 
     c = SizedList(size='n_comp', default=0)
     _cp = SizedUnsignedList(size='n_comp')
     _q = SizedUnsignedList(size='n_bound_states', default=0)
 
-    _initial_state = TubularReactorBase._initial_state + ['cp', 'q']
-    _parameter_names = _parameter_names + _initial_state
+    _initial_state = ['cp', 'q']
+    _parameters = _parameters + _initial_state
 
     def __init__(self, *args, discretization_scheme='FV', **kwargs):
         super().__init__(*args, **kwargs)
@@ -842,8 +801,7 @@ class LumpedRateModelWithPores(TubularReactorBase):
 
     @property
     def total_porosity(self):
-        """float: Total porosity of the column
-        """
+        """float: Total porosity of the column."""
         return self.bed_porosity + \
             (1 - self.bed_porosity) * self.particle_porosity
 
@@ -943,30 +901,25 @@ class GeneralRateModel(TubularReactorBase):
     bed_porosity = UnsignedFloat(ub=1)
     particle_porosity = UnsignedFloat(ub=1)
     particle_radius = UnsignedFloat()
-    _parameter_names = \
-        TubularReactorBase._parameter_names + \
     film_diffusion = SizedUnsignedList(size='n_comp')
     pore_diffusion = SizedUnsignedList(size='n_comp')
     _surface_diffusion = SizedUnsignedList(size='n_bound_states')
     pore_accessibility = SizedUnsignedList(size='n_comp')
-        [
-            'bed_porosity', 'particle_porosity', 'particle_radius',
-            'film_diffusion', 'pore_diffusion', 'surface_diffusion'
-        ]
-    _section_dependent_parameters = \
-        TubularReactorBase._section_dependent_parameters + \
-        ['film_diffusion', 'pore_diffusion', 'surface_diffusion']
-    _required_parameters = TubularReactorBase._required_parameters + [
-        'bed_porosity', 'particle_porosity', 'particle_radius', 'film_diffusion',
-        'pore_diffusion'
+    _parameters = [
+        'bed_porosity', 'particle_porosity', 'particle_radius',
+        'film_diffusion', 'pore_diffusion', 'surface_diffusion'
     ]
+    _section_dependent_parameters = \
+        UnitBaseClass._section_dependent_parameters + \
+        TubularReactorBase._section_dependent_parameters + \
+        ['film_diffusion']
 
     c = SizedList(size='n_comp', default=0)
     _cp = SizedUnsignedList(size='n_comp')
     _q = SizedUnsignedList(size='n_bound_states', default=0)
+    _initial_state = ['cp', 'q']
 
-    _initial_state = TubularReactorBase._initial_state + ['cp', 'q']
-    _parameter_names = _parameter_names + _initial_state
+    _parameters = _parameters + _initial_state
 
     def __init__(self, *args, discretization_scheme='FV', **kwargs):
         super().__init__(*args, **kwargs)
@@ -1073,7 +1026,7 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         Initial volume of the reactor.
     total_porosity : UnsignedFloat between 0 and 1.
         Total porosity of the column.
-    flow_rate_filter: float:
+    flow_rate_filter: float
         Flow rate of pure liquid without components to reduce volume.
     solution_recorder : CSTRRecorder
         Solution recorder for the unit operation.
@@ -1085,31 +1038,33 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
 
     porosity = UnsignedFloat(ub=1, default=1)
     flow_rate_filter = UnsignedFloat(default=0)
-    _parameter_names = \
-        UnitBaseClass._parameter_names + \
-        SourceMixin._parameter_names + \
-        ['porosity', 'flow_rate_filter']
+    _parameters = ['porosity', 'flow_rate_filter']
+
     _section_dependent_parameters = \
         UnitBaseClass._section_dependent_parameters + \
         SourceMixin._section_dependent_parameters + \
         ['flow_rate_filter']
-    _polynomial_parameters = \
-        UnitBaseClass._polynomial_parameters + \
-        SourceMixin._polynomial_parameters + \
-        ['flow_rate_filter']
-    _required_parameters = UnitBaseClass._required_parameters + ['V']
 
     c = SizedList(size='n_comp', default=0)
     _q = SizedUnsignedList(size='n_bound_states', default=0)
     V = UnsignedFloat()
-    _initial_state = \
-        UnitBaseClass._initial_state + \
-        ['c', 'q', 'V']
-    _parameter_names = _parameter_names + _initial_state
+    _initial_state = ['c', 'q', 'V']
+    _parameters = _parameters + _initial_state
 
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.solution_recorder = CSTRRecorder()
+
+    @property
+    def required_parameters(self):
+        """
+        Remove 'flow_rate' from required parameters.
+
+        If flow rate is None, Q_in == Q_out'.
+        """
+        required_parameters = super().required_parameters.copy()
+        required_parameters.remove('flow_rate')
+        return required_parameters
 
     @property
     def volume(self):

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -1,4 +1,4 @@
-from abc import abstractproperty
+from abc import abstractmethod
 import math
 from warnings import warn
 
@@ -478,7 +478,8 @@ class TubularReactorBase(UnitBaseClass):
         ['axial_dispersion', 'flow_direction']
     _required_parameters = ['length', 'axial_dispersion', 'diameter']
 
-    @abstractproperty
+    @property
+    @abstractmethod
     def total_porosity(self):
         pass
 

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -9,8 +9,8 @@ from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     Constant, UnsignedFloat,
     String, Switch,
-    DependentlySizedUnsignedList,
-    Polynomial, NdPolynomial, DependentlySizedList
+    SizedUnsignedList,
+    Polynomial, NdPolynomial, SizedList
 )
 
 from .componentSystem import ComponentSystem
@@ -363,8 +363,8 @@ class SourceMixin(Structure):
 
     """
     _n_poly_coeffs = 4
-    flow_rate = Polynomial(dep=('_n_poly_coeffs'))
     _parameter_names = ['flow_rate']
+    flow_rate = Polynomial(size=('_n_poly_coeffs'))
     _section_dependent_parameters = ['flow_rate']
     _polynomial_parameters = ['flow_rate']
 
@@ -395,8 +395,8 @@ class Inlet(UnitBaseClass, SourceMixin):
 
     """
 
-    c = NdPolynomial(dep=('n_comp', '_n_poly_coeffs'), default=0)
-    flow_rate = Polynomial(dep=('_n_poly_coeffs'), default=0)
+    c = NdPolynomial(size=('n_comp', '_n_poly_coeffs'), default=0)
+    flow_rate = Polynomial(size=('_n_poly_coeffs'), default=0)
     _n_poly_coeffs = 4
     _parameter_names = \
         UnitBaseClass._parameter_names + \
@@ -703,7 +703,7 @@ class TubularReactor(TubularReactorBase):
 
     total_porosity = Constant(1)
 
-    c = DependentlySizedList(dep='n_comp', default=0)
+    c = SizedList(size='n_comp', default=0)
     _initial_state = UnitBaseClass._initial_state + ['c']
     _parameter_names = TubularReactorBase._parameter_names + _initial_state
 
@@ -750,8 +750,8 @@ class LumpedRateModelWithoutPores(TubularReactorBase):
     ]
     _required_parameters = TubularReactorBase._required_parameters + ['total_porosity']
 
-    c = DependentlySizedList(dep='n_comp', default=0)
-    _q = DependentlySizedUnsignedList(dep='n_bound_states', default=0)
+    c = SizedList(size='n_comp', default=0)
+    _q = SizedUnsignedList(size='n_bound_states', default=0)
     _initial_state = TubularReactorBase._initial_state + ['q']
     _parameter_names = _parameter_names + _initial_state
 
@@ -811,9 +811,9 @@ class LumpedRateModelWithPores(TubularReactorBase):
     bed_porosity = UnsignedFloat(ub=1)
     particle_porosity = UnsignedFloat(ub=1)
     particle_radius = UnsignedFloat()
-    film_diffusion = DependentlySizedUnsignedList(dep='n_comp')
-    pore_accessibility = DependentlySizedUnsignedList(dep='n_comp')
     _parameter_names = TubularReactorBase._parameter_names + [
+    film_diffusion = SizedUnsignedList(size='n_comp')
+    pore_accessibility = SizedUnsignedList(size='n_comp')
             'bed_porosity', 'particle_porosity', 'particle_radius',
             'film_diffusion'
             ]
@@ -823,9 +823,9 @@ class LumpedRateModelWithPores(TubularReactorBase):
         'bed_porosity', 'particle_porosity', 'particle_radius', 'film_diffusion'
     ]
 
-    c = DependentlySizedList(dep='n_comp', default=0)
-    _cp = DependentlySizedUnsignedList(dep='n_comp')
-    _q = DependentlySizedUnsignedList(dep='n_bound_states', default=0)
+    c = SizedList(size='n_comp', default=0)
+    _cp = SizedUnsignedList(size='n_comp')
+    _q = SizedUnsignedList(size='n_bound_states', default=0)
 
     _initial_state = TubularReactorBase._initial_state + ['cp', 'q']
     _parameter_names = _parameter_names + _initial_state
@@ -943,12 +943,12 @@ class GeneralRateModel(TubularReactorBase):
     bed_porosity = UnsignedFloat(ub=1)
     particle_porosity = UnsignedFloat(ub=1)
     particle_radius = UnsignedFloat()
-    film_diffusion = DependentlySizedUnsignedList(dep='n_comp')
-    pore_diffusion = DependentlySizedUnsignedList(dep='n_comp')
-    _surface_diffusion = DependentlySizedUnsignedList(dep='n_bound_states')
-    pore_accessibility = DependentlySizedUnsignedList(dep='n_comp')
     _parameter_names = \
         TubularReactorBase._parameter_names + \
+    film_diffusion = SizedUnsignedList(size='n_comp')
+    pore_diffusion = SizedUnsignedList(size='n_comp')
+    _surface_diffusion = SizedUnsignedList(size='n_bound_states')
+    pore_accessibility = SizedUnsignedList(size='n_comp')
         [
             'bed_porosity', 'particle_porosity', 'particle_radius',
             'film_diffusion', 'pore_diffusion', 'surface_diffusion'
@@ -961,9 +961,9 @@ class GeneralRateModel(TubularReactorBase):
         'pore_diffusion'
     ]
 
-    c = DependentlySizedList(dep='n_comp', default=0)
-    _cp = DependentlySizedUnsignedList(dep='n_comp')
-    _q = DependentlySizedUnsignedList(dep='n_bound_states', default=0)
+    c = SizedList(size='n_comp', default=0)
+    _cp = SizedUnsignedList(size='n_comp')
+    _q = SizedUnsignedList(size='n_bound_states', default=0)
 
     _initial_state = TubularReactorBase._initial_state + ['cp', 'q']
     _parameter_names = _parameter_names + _initial_state
@@ -1099,8 +1099,8 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         ['flow_rate_filter']
     _required_parameters = UnitBaseClass._required_parameters + ['V']
 
-    c = DependentlySizedList(dep='n_comp', default=0)
-    _q = DependentlySizedUnsignedList(dep='n_bound_states', default=0)
+    c = SizedList(size='n_comp', default=0)
+    _q = SizedUnsignedList(size='n_bound_states', default=0)
     V = UnsignedFloat()
     _initial_state = \
         UnitBaseClass._initial_state + \

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -769,18 +769,18 @@ class LumpedRateModelWithPores(TubularReactorBase):
     particle_porosity = UnsignedFloat(ub=1)
     particle_radius = UnsignedFloat()
     film_diffusion = SizedUnsignedList(size='n_comp')
-    pore_accessibility = SizedUnsignedList(size='n_comp')
+    pore_accessibility = SizedUnsignedList(ub=1, size='n_comp', default=1)
     _parameters = [
         'bed_porosity',
         'particle_porosity',
         'particle_radius',
         'film_diffusion',
+        'pore_accessibility',
     ]
 
     _section_dependent_parameters = \
-        UnitBaseClass._section_dependent_parameters + \
         TubularReactorBase._section_dependent_parameters + \
-        ['film_diffusion']
+        ['film_diffusion', 'pore_accessibility']
 
     c = SizedList(size='n_comp', default=0)
     _cp = SizedUnsignedList(size='n_comp')
@@ -877,12 +877,14 @@ class GeneralRateModel(TubularReactorBase):
         Porosity of particles.
     particle_radius : UnsignedFloat
         Radius of the particles.
+    film_diffusion : List of unsigned floats. Length depends on n_comp.
+        Diffusion rate for components in pore volume.
+    pore_accessibility : List of unsigned floats. Length depends on n_comp.
+        Accessibility of pores for components.
     pore_diffusion : List of unsigned floats. Length depends on n_comp.
         Diffusion rate for components in pore volume.
     surface_diffusion : List of unsigned floats. Length depends on n_comp.
         Diffusion rate for components in adsrobed state.
-    pore_accessibility : List of unsigned floats. Length depends on n_comp.
-        Accessibility of pores for components.
     c : List of unsigned floats. Length depends on n_comp
         Initial concentration of the reactor.
     cp : List of unsigned floats. Length depends on n_comp
@@ -902,17 +904,17 @@ class GeneralRateModel(TubularReactorBase):
     particle_porosity = UnsignedFloat(ub=1)
     particle_radius = UnsignedFloat()
     film_diffusion = SizedUnsignedList(size='n_comp')
+    pore_accessibility = SizedUnsignedList(ub=1, size='n_comp', default=1)
     pore_diffusion = SizedUnsignedList(size='n_comp')
     _surface_diffusion = SizedUnsignedList(size='n_bound_states')
-    pore_accessibility = SizedUnsignedList(size='n_comp')
     _parameters = [
         'bed_porosity', 'particle_porosity', 'particle_radius',
-        'film_diffusion', 'pore_diffusion', 'surface_diffusion'
+        'film_diffusion', 'pore_accessibility',
+        'pore_diffusion', 'surface_diffusion'
     ]
     _section_dependent_parameters = \
-        UnitBaseClass._section_dependent_parameters + \
         TubularReactorBase._section_dependent_parameters + \
-        ['film_diffusion']
+        ['film_diffusion', 'pore_accessibility', 'pore_diffusion', 'surface_diffusion']
 
     c = SizedList(size='n_comp', default=0)
     _cp = SizedUnsignedList(size='n_comp')

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -413,9 +413,6 @@ class Inlet(UnitBaseClass, SourceMixin):
     _required_parameters = ['flow_rate']
 
 
-Source = Inlet
-
-
 class Outlet(UnitBaseClass, SinkMixin):
     """Pseudo unit operation model for streams leaving the system.
 
@@ -426,9 +423,6 @@ class Outlet(UnitBaseClass, SinkMixin):
     """
 
     pass
-
-
-Sink = Outlet
 
 
 class MixerSplitter(UnitBaseClass):

--- a/CADETProcess/settings.py
+++ b/CADETProcess/settings.py
@@ -19,14 +19,14 @@ import shutil
 import tempfile
 from warnings import warn
 
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import Bool, Switch
 
 
 __all__ = ['Settings']
 
 
-class Settings(metaclass=StructMeta):
+class Settings(Structure):
     """A class for managing general settings.
 
     Attributes

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -23,7 +23,7 @@ import addict
 
 from CADETProcess import CADETProcessError
 from CADETProcess import settings
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     Dict, String, List, UnsignedInteger, UnsignedFloat
 )
@@ -32,7 +32,7 @@ from CADETProcess.dataStructure import (
 __all__ = ['SimulationResults']
 
 
-class SimulationResults(metaclass=StructMeta):
+class SimulationResults(Structure):
     """Class for storing simulation results including the solver configuration
 
     Attributes

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -3,13 +3,13 @@ import numpy as np
 
 from CADETProcess import CADETProcessError
 from CADETProcess.log import get_logger, log_time, log_results, log_exceptions
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import Bool, UnsignedFloat, UnsignedInteger
 from CADETProcess.processModel import Process
 from CADETProcess.stationarity import StationarityEvaluator, RelativeArea, NRMSE
 
 
-class SimulatorBase(metaclass=StructMeta):
+class SimulatorBase(Structure):
     """Base class for Solver APIs.
 
     Holds the configuration of the individual solvers and provides an interface
@@ -45,6 +45,7 @@ class SimulatorBase(metaclass=StructMeta):
     CADETProcess.stationarity.StationarityEvaluator
 
     """
+
     time_resolution = UnsignedFloat(default=1)
     resolution_cutoff = UnsignedFloat(default=1e-3)
 

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -1719,16 +1719,16 @@ def slice_solution(
         if len(coordinates) > 0:
             raise CADETProcessError(f"Unknown dimensions: {coordinates.keys()}")
 
-        solution.solution = solution.solution[slices]
+        solution.solution = solution_original.solution[slices]
 
     # First calculate total_concentration of components, if required.
     if use_total_concentration_components:
-        sol = solution.total_concentration_components
+        sol_total_concentration_comp = solution.total_concentration_components
         for comp in solution.component_system:
             if comp.n_species > 1:
                 comp._species = []
                 comp.add_species(comp.name)
-        solution.solution = sol
+        solution.solution = sol_total_concentration_comp
 
     # Then, slice components. Note that component index can only be used if total
     # concentration of components has already been calculated and set as solution array.
@@ -1754,14 +1754,15 @@ def slice_solution(
         if len(components) != 0:
             raise CADETProcessError(f"Unknown components: {components}")
 
+        solution_components = solution.solution[..., component_indices]
         solution.component_system = component_system
-        solution.solution = solution.solution[..., component_indices]
+        solution.solution = solution_components
 
     # Only calculate total concentration after removing unwanted components.
     if use_total_concentration:
-        sol = solution.total_concentration
+        solution_total_concentration = solution.total_concentration
         solution.component_system = ComponentSystem(['total_concentration'])
-        solution.solution = sol
+        solution.solution = solution_total_concentration
 
     solution.update()
     solution.update_transform()

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -34,7 +34,7 @@ import matplotlib.pyplot as plt
 from scipy.interpolate import PchipInterpolator
 from scipy import integrate
 
-from CADETProcess.dataStructure import StructMeta
+from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     String, UnsignedInteger, UnsignedFloat, Vector, SizedNdArray
 )
@@ -59,7 +59,7 @@ __all__ = [
 ]
 
 
-class SolutionBase(metaclass=StructMeta):
+class SolutionBase(Structure):
     """Base class for solutions of component systems.
 
     This class represents a solution of a component system at different time points.

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -36,7 +36,7 @@ from scipy import integrate
 
 from CADETProcess.dataStructure import StructMeta
 from CADETProcess.dataStructure import (
-    String, UnsignedInteger, UnsignedFloat, Vector, DependentlySizedNdArray
+    String, UnsignedInteger, UnsignedFloat, Vector, SizedNdArray
 )
 
 from CADETProcess.processModel import ComponentSystem
@@ -88,7 +88,7 @@ class SolutionBase(metaclass=StructMeta):
 
     name = String()
     time = Vector()
-    solution = DependentlySizedNdArray(dep='solution_shape')
+    solution = SizedNdArray(size='solution_shape')
     c_min = UnsignedFloat(default=1e-6)
 
     dimensions = ['time']

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -1337,7 +1337,7 @@ class SolutionSolid(SolutionBase):
         layout.title = f'Solid phase concentration, comp={comp}, state={state}'
         layout.x_label = '$z~/~m$'
         layout.y_label = '$r~/~m$'
-        layout.labels = self.component_system.labels[c_i]
+        layout.labels = self.component_system.species[c_i]
         plotting.set_layout(ax, layout)
 
         return ax, mesh

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -20,7 +20,7 @@ from addict import Dict
 import numpy as np
 
 from CADETProcess import log
-from CADETProcess.dataStructure import StructMeta, UnsignedFloat
+from CADETProcess.dataStructure import Structure, UnsignedFloat
 from CADETProcess import SimulationResults
 from CADETProcess.comparison import Comparator
 from CADETProcess.processModel import Inlet
@@ -29,7 +29,7 @@ from CADETProcess.processModel import Inlet
 __all__ = ['RelativeArea', 'NRMSE', 'StationarityEvaluator']
 
 
-class CriterionBase(metaclass=StructMeta):
+class CriterionBase(Structure):
     threshold = UnsignedFloat(default=1e-3)
 
     def __str__(self):

--- a/docs/source/user_guide/optimization/index.md
+++ b/docs/source/user_guide/optimization/index.md
@@ -42,5 +42,6 @@ optimizer
 parallel_evaluation
 evaluator
 multi_objective_optimization
+variable_indices
 variable_dependencies
 ```

--- a/docs/source/user_guide/optimization/variable_indices.md
+++ b/docs/source/user_guide/optimization/variable_indices.md
@@ -1,0 +1,240 @@
+---
+jupytext:
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+    jupytext_version: 1.15.0
+kernelspec:
+  display_name: dev
+  language: python
+  name: python3
+---
+
+```{code-cell} ipython3
+:tags: [remove-cell]
+
+import sys
+sys.path.append('../../../../')
+```
+
+(variable_indices_guide)=
+# Specifying indices of multidimensional parameters for Optimization Variables
+
+Similar to events, sometimes we only want to add individual entries of a parameter as an optimization variable.
+In fact, optimization variables can only be scalar.
+Consequently, an index *must* be provided if the parameter is not scalar.
+
+For this tutorial, consider the following process model and optimization problem:
+
+```{code-cell} ipython3
+import copy
+import numpy as np
+
+from CADETProcess.processModel import ComponentSystem
+component_system = ComponentSystem(2)
+
+from CADETProcess.processModel import MassActionLaw
+reaction_system = MassActionLaw(component_system)
+reaction_system.add_reaction(
+    indices=[0, 1],
+    coefficients=[-1, 1],
+    k_fwd=0.1,
+    k_bwd=0,
+)
+reaction_system.add_reaction(
+    indices=[1, 0],
+    coefficients=[-1, 1],
+    k_fwd=0.2,
+    k_bwd=0,
+)
+
+from CADETProcess.processModel import Inlet
+inlet = Inlet(component_system, 'inlet')
+
+from CADETProcess.processModel import Inlet, LumpedRateModelWithPores, Outlet
+inlet = Inlet(component_system, name='inlet')
+column = LumpedRateModelWithPores(component_system, 'column')
+column.bulk_reaction_model = reaction_system
+outlet = Outlet(component_system, 'outlet')
+
+from CADETProcess.processModel import FlowSheet, Process
+
+flow_sheet = FlowSheet(component_system)
+flow_sheet.add_unit(inlet)
+flow_sheet.add_unit(column)
+flow_sheet.add_unit(outlet)
+
+flow_sheet.add_connection(inlet, column)
+flow_sheet.add_connection(column, outlet)
+
+def setup_process():
+    process = Process(flow_sheet, 'Demo Indices')
+    process.cycle_time = 10
+
+    return process
+
+from CADETProcess.optimization import OptimizationProblem
+
+def setup_optimization_problem():
+    optimization_problem = OptimizationProblem('Demo Indices', use_diskcache=False)
+    optimization_problem.add_evaluation_object(process)
+
+    return optimization_problem
+```
+
+## Specifying indices for (multidimensional) arrays
+
+The procedure of adding indices is similar to that of the {class}`~CADETProcess.dynamicEvents.Event` indices (see {ref}`here <event_indices_guide>`).
+By default, if no indices are specified, all entries of that array are set to the same value.
+E.g. to let the `film_diffusion` coefficients all have the same value, specify the following:
+
+```{code-cell} ipython3
+process = setup_process()
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'film_diffusion_all', evaluation_objects=process, parameter_path='flow_sheet.column.film_diffusion'
+)
+var.value = 1
+print(process.flow_sheet.column.film_diffusion)
+```
+
+To add a variable that only modifies a single entry of the parameter array, add an `indices` flag.
+E.g. for the first component of the (1D) `film_diffusion` array:
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'film_diffusion_0', evaluation_objects=process, parameter_path='flow_sheet.column.film_diffusion', indices=0
+)
+var.value = 2
+print(process.flow_sheet.column.film_diffusion)
+```
+
+Note, for polynomial parameters, if no index is specified, only the constant coefficient is set and the rest of the coefficients are set to zero.
+So, to add the constant term for the `inlet.flow_rate`, use:
+
+```{code-cell} ipython3
+var = optimization_problem.add_variable(
+    'flow_rate_fill', evaluation_objects=process, parameter_path='flow_sheet.inlet.flow_rate'
+)
+var.value = 1
+print(process.flow_sheet.inlet.flow_rate)
+```
+
+However, adding indices still works as expected.
+E.g. for the linear coefficient of the `flow_rate`:
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'flow_rate_single', evaluation_objects=process, parameter_path='flow_sheet.inlet.flow_rate', indices=1
+)
+var.value = 2
+print(process.flow_sheet.inlet.flow_rate)
+```
+
+Just as with 1D arrays, the value is set to all entries of that array if no indices are specified.
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'exponents', evaluation_objects=process, parameter_path='flow_sheet.column.bulk_reaction_model.exponents_fwd'
+)
+var.value = 1
+print(process.flow_sheet.column.bulk_reaction_model.exponents_fwd)
+```
+
+Multidimensional parameters can also be indexed by specifying a tuple with the index for each of the parameter dimensions.
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'exponents_single', evaluation_objects=process, parameter_path='flow_sheet.column.bulk_reaction_model.exponents_fwd', indices=(0, 0)
+)
+var.value = 2
+print(process.flow_sheet.column.bulk_reaction_model.exponents_fwd)
+```
+
+Just as with Events, slicing notation is also supported:
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'exponents_slice', evaluation_objects=process, parameter_path='flow_sheet.column.bulk_reaction_model.exponents_fwd', indices=np.s_[0, :]
+)
+var.value = 3
+print(process.flow_sheet.column.bulk_reaction_model.exponents_fwd)
+```
+
+Also the procedure for polynomial parameters is analogous to the 1D case.
+For example, to optimize the linear coefficient of the first component of the `inlet` concentration:
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'concentration_constant_all', evaluation_objects=process, parameter_path='flow_sheet.inlet.c'
+)
+var.value = 1
+print(process.flow_sheet.inlet.c)
+```
+
+To modify only the constant coefficient of a single entry:
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'concentration_fill_values_single', evaluation_objects=process, parameter_path='flow_sheet.inlet.c', indices=0
+)
+var.value = 2
+print(process.flow_sheet.inlet.c)
+```
+
+Explicitly modify linear coefficient of single entry.
+
+```{code-cell} ipython3
+optimization_problem = setup_optimization_problem()
+
+var = optimization_problem.add_variable(
+    'concentration_single_entry', evaluation_objects=process, parameter_path='flow_sheet.inlet.c', indices=(0, 1)
+)
+var.value = 3
+print(process.flow_sheet.inlet.c)
+```
+
+## Specifying Indices of Multidimensional Event States
+
+In certain scenarios, optimizing the state of an event becomes essential.
+Depending on which parameter dimensions the event modifies, and the indices chosen for the event state, it might be imperative to include indices in the optimization variable as well.
+
+Consider the slope of an elution gradient that starts at a specific time.
+Here, the first component starts at $c = 0~mM$ with a slope of $1~mM / s$ whereas the second component's concentration is always $0~mM$.
+
+```{code-cell} ipython3
+process = setup_process()
+optimization_problem = setup_optimization_problem()
+
+evt = process.add_event(
+    'c_poly', 'flow_sheet.inlet.c', [[0, 1], 0], time=1
+)
+print(inlet.c)
+```
+
+To add an optimization variable that only modifies the linear coefficient, add the event state as `parameter_path` and the corresponding index.
+
+```{code-cell} ipython3
+var = optimization_problem.add_variable(
+    'concentration_single_entry', evaluation_objects=process, parameter_path='c_poly.state', indices=(0, 1)
+)
+var.value = 2
+
+print(inlet.c)
+```

--- a/docs/source/user_guide/process_model/process.md
+++ b/docs/source/user_guide/process_model/process.md
@@ -16,6 +16,7 @@ sys.path.append('../../../../')
 
 (process_guide)=
 # Process
+
 The {class}`~CADETProcess.processModel.Process` class is used to define dynamic changes to of the units and connections.
 To instantiate a {class}`~CADETProcess.processModel.Process`, a {class}`~CADETProcess.processModel.FlowSheet` needs to be passed as argument, as well as a string to name that process.
 For this guide, a {ref}`flow_sheet_batch_elution` {class}`~CADETProcess.processModel.FlowSheet` is used.
@@ -66,14 +67,14 @@ process.add_event('inject_on', 'flow_sheet.feed.flow_rate', 1, 0)
 process.add_event('inject_off', 'flow_sheet.feed.flow_rate', 0, 1)
 ```
 
-If the event shall only modify a single entry of an array, an additional `entry_index` can be added.
+If the event shall only modify a single entry of an array, an additional `indices` argument can be added.
 For example, the following will only modify the concentration of the first component.
 
 ```{code-cell} ipython3
 :tags: [remove-output]
 
-process.add_event('conc_high', 'flow_sheet.feed.c', 1, 0, entry_index=0)
-process.add_event('conc_low', 'flow_sheet.feed.c', 0, 1, entry_index=0)
+process.add_event('conc_high', 'flow_sheet.feed.c', 1, 0, indices=0)
+process.add_event('conc_low', 'flow_sheet.feed.c', 0, 1, indices=0)
 ```
 
 All events can are stored in the {attr}`~CADETProcess.processModel.Process.events` attribute.
@@ -85,6 +86,7 @@ _ = process.plot_events()
 
 (event_dependencies_guide)=
 ## Event Dependencies
+
 In order to reduce the complexity of process configurations, {class}`~CADETProcess.dynamicEvents.Event` dependencies can be specified that define the time at which an {class}`~CADETProcess.dynamicEvents.Event` occurs as a function of other {class}`~CADETProcess.dynamicEvents.Event` times.
 Especially for more advanced processes, this reduces the degrees of freedom and facilitates the overall handiness.
 For this purpose, {class}`Durations <CADETProcess.dynamicEvents.Duration>` can also be defined to describe the time between the execution of two {class}`Events <CADETProcess.dynamicEvents.Event>`.
@@ -161,8 +163,188 @@ print(f'eluent_on: {process.eluent_on.time}')
 
 For a more complex scenario refer to {ref}`SSR process <ssr_process>`.
 
+(event_indices_guide)=
+## Specifying Indices of Multidimensional Parameters for Events
 
-## Inlet Profile from Existing Data
+Many model parameters in **CADET-Process** are not scalar and their size may depend on the number of components, binding sites, reactions, etc.
+**CADET-Process** provides some functionality to manage these sized parameters when adding events.
+
+For this tutorial, consider the following process model:
+
+```{code-cell} ipython3
+:tags: [hide-cell]
+
+import copy
+import numpy as np
+
+from CADETProcess.processModel import ComponentSystem
+component_system = ComponentSystem(2)
+
+from CADETProcess.processModel import Inlet
+inlet = Inlet(component_system, 'inlet')
+
+from CADETProcess.processModel import Inlet, LumpedRateModelWithPores, Outlet
+inlet = Inlet(component_system, name='inlet')
+column = LumpedRateModelWithPores(component_system, 'column')
+outlet = Outlet(component_system, 'outlet')
+
+from CADETProcess.processModel import FlowSheet, Process
+
+flow_sheet = FlowSheet(component_system)
+flow_sheet.add_unit(inlet)
+flow_sheet.add_unit(column)
+flow_sheet.add_unit(outlet)
+
+flow_sheet.add_connection(inlet, column)
+flow_sheet.add_connection(column, outlet)
+
+def setup_process():
+    process = Process(flow_sheet, 'Demo Indices')
+    process.cycle_time = 10
+
+    return process
+```
+
+### Specifying Indices for 1D Arrays
+
+Consider a 1D parameter, such as the {attr}`~CADETProcess.processModel.LumpedRateModelWithPorse.film_diffusion` coefficient of the {class}`~CADETProcess.processModel.LumpedRateModelWithPores`.
+If no indices are provided, all entries of the parameter are set to the same value,
+E.g., to change the value of all film diffusion coefficients to the value `1e-6` at `time=0`, add the following:
+
+```{code-cell} ipython3
+process = setup_process()
+
+process.add_event(
+    'film_diffusion_all', 'flow_sheet.column.film_diffusion', [1e-6, 1e-6], time=0
+)
+print(column.film_diffusion)
+```
+
+To add an event for a single entry in a 1D list / array, add an `indices` argument that specifies the index of the entry to be modified.
+E.g., to only change the value of the first component's film diffusion coefficient to `1e-7` at `time=1`, add `indices=0`.
+
+```{code-cell} ipython3
+process.add_event(
+    'film_diffusion_index_0', 'flow_sheet.column.film_diffusion', 1e-7, indices=0, time=1
+)
+print(column.film_diffusion)
+```
+
+It is also possible to specify multiple indices at once.
+The length of `indices` must match the length of the provided states.
+Also, the order of the indices is mapped to the order of the state entries.
+
+```{code-cell} ipython3
+process.add_event(
+    'film_diffusion_index_10', 'flow_sheet.column.film_diffusion', [2e-7, 3e-7], indices=[1, 0], time=2
+)
+print(column.film_diffusion)
+```
+
+### Specifying Indices for 1D Polynomial Parameters
+
+As mentioned {ref}`here <polynomial_guide>`, polynomial parameters are a bit special with regard to their setter methods.
+As with regular 1D parameters, it is possible to specify all state values at once.
+To demonstrate this, consider the `flow_rate` attribute of the `inlet` unit operation.
+
+```{code-cell} ipython3
+process = setup_process()
+
+process.add_event(
+    'flow_rate_all', 'flow_sheet.inlet.flow_rate', [0, 1, 2, 3], time=0
+)
+print(inlet.flow_rate)
+```
+
+Also events that only modify a single entry are equivalent:
+
+```{code-cell} ipython3
+process.add_event(
+    'flow_rate_index_0', 'flow_sheet.inlet.flow_rate', 1, indices=0, time=1
+)
+print(inlet.flow_rate)
+```
+
+However, if no indices are passed, the event acts as if the state is set directly to the parameter.
+Consequently, setting the state to `1` would automatically fill missing polynomial coefficients and set them all to `0`.
+
+```{code-cell} ipython3
+process.add_event(
+    'flow_rate_fill_all', 'flow_sheet.inlet.flow_rate', 1, time=2
+)
+print(inlet.flow_rate)
+```
+
+Adding a subset of the coefficients as list also works as expected:
+
+```{code-cell} ipython3
+process.add_event(
+    'flow_rate_fill_subset', 'flow_sheet.inlet.flow_rate', [2, 1], time=3
+)
+print(inlet.flow_rate)
+```
+
+### Specifying Indices for Multidimensional (Polynomial) Parameters
+
+The process for adding events for multidimensional parameters is similar.
+For this purpose, consider the concentration `c` of the `inlet` unit operation (which also happens to be polynomial).
+
+Here, the parameter is fully specified in the event:
+```{code-cell} ipython3
+process = setup_process()
+
+evt = process.add_event(
+    'c_all', 'flow_sheet.inlet.c',
+    [[0, 1, 2, 3], [4, 5, 6, 7]],
+    time=0
+)
+print(inlet.c)
+```
+
+To add an event that only modify a single entry, note that `indices` must now be a tuple containing the index of every dimension of the array.
+
+```{code-cell} ipython3
+evt = process.add_event(
+    'c_single', 'flow_sheet.inlet.c', 1, indices=(0, 0), time=1
+)
+print(inlet.c)
+```
+
+To add multiple indices, make sure to pass a list of tuples.
+
+```{code-cell} ipython3
+evt = process.add_event(
+    'c_multi', 'flow_sheet.inlet.c', [2, 3], indices=[(0, 0), (1, 1)], time=2
+)
+print(inlet.c)
+```
+
+Slicing is also possible using `np.s_`.
+For more information, refer to [this post](https://forum.cadet-web.de/t/exposing-array-indices-programmatically/751).
+
+E.g. to add an event that modifies all entries of the first row:
+
+```{code-cell} ipython3
+evt = process.add_event(
+    'c_row', 'flow_sheet.inlet.c', 1, indices=np.s_[0, :], time=3
+)
+print(inlet.c)
+```
+
+As with 1D polynomials, leveraging the setter convenience function is also possible for polynomial parameters.
+
+E.g. to set the first entry to a constant `2` and the second to value where the constant coefficient is `1` and the linear coefficient is `2` specify the following as `state`: `[2, [1, 2]]`.
+Note, this only works when no indices are provided.
+
+```{code-cell} ipython3
+evt = process.add_event(
+    'c_poly', 'flow_sheet.inlet.c', [2, [1, 2]], time=4
+)
+print(inlet.c)
+```
+
+## Generating Inlet Profiles from Existing Data
+
 In some cases, it is desirable to use an existing concentration profile as inlet profile (e.g. the output of some upstream process).
 **CADET-Process** provides a method to automatically fit a piecewise cubic polynomial to a given profile and add the corresponding events to a specific inlet.
 
@@ -192,13 +374,13 @@ To add the profile to the unit called `inlet`, use the {meth}`~CADETProcess.proc
 - `unit_operation` : Inlet unit operation
 - `time` : Time points
 - `c` : Concentration values
-- `component_index`: Component index to which concentration profile shall be set. If `-1`, the same profile is set for all components.
+- `components`: List of component species to which the concentration profile shall be added. If `-1`, the same profile is set for all components.
 
 ```{code-cell} ipython3
-process.add_concentration_profile('inlet', time, c, component_index=-1)
+process.add_concentration_profile('inlet', time, c, components=-1)
 ```
 
-When inspecting the {meth}`~CADETProcess.processModel.Process.plot_events` method, the concentration profile can now be seen.
+When calling the {meth}`~CADETProcess.processModel.Process.plot_events` method, the concentration profile can now be seen.
 
 ```{code-cell} ipython3
 _ = process.plot_events()
@@ -224,6 +406,7 @@ _ = process.plot_events()
 
 (sensitivity_guide)=
 ## Parameter Sensitivities
+
 ```{warning}
 This functionality is still work in progress.
 Changes in the interface are to be expected.
@@ -233,7 +416,7 @@ Parameter sensitivities $s = \partial y / \partial p$ of a solution $y$ with res
 The CADET simulator implements the forward sensitivity approach which creates a linear companion DAE for each sensitive parameter.
 To add a parameter sensitivity to the process, use the {meth}`~CADETProcess.processModel.Process.add_parameter_sensitivity` method.
 The first argument is the parameter path in dot notation.
-Since currently parameter sensitivities cannot be computed for {attr}`CADETProcess.processModel.FlowSheet.output_states` or event times, it is not required to specify `flow_sheet` in the path.
+Since currently parameter sensitivities cannot be computed for {attr}`~CADETProcess.processModel.FlowSheet.output_states` or event times, it is not required to specify `flow_sheet` in the path.
 Optionally, a `name` can be provided.
 If none is provided, the parameter path is used.
 

--- a/docs/source/user_guide/process_model/unit_operation.md
+++ b/docs/source/user_guide/process_model/unit_operation.md
@@ -52,9 +52,13 @@ To only show required parameters, inspect `required_parameters`.
 print(unit.required_parameters)
 ```
 
-## Polynomial Coeffients
-Some parameters represent polynomial coefficients.
-For example, the concentration of an {class}`~CADETProcess.processModel.Inlet` represents the coefficients of a cubic polynomial (in time).
+(polynomial_guide)=
+## Polynomial Coefficients
+
+Some parameters in **CADET-Process** are represented by polynomial coefficients.
+For example, the {attr}`~CADETProcess.processModel.Inlet.flow_rate` of an {class}`~CADETProcess.processModel.Inlet` can be described by a cubic polynomial (in time).
+
+By default, all coefficients are $0$.
 
 ```{code-cell} ipython3
 :tags: [hide-cell]
@@ -63,42 +67,72 @@ from CADETProcess.processModel import Inlet
 inlet = Inlet(component_system, 'inlet')
 ```
 
-To specify a constant value for each component, use a list with length `n_comp`.
-
 ```{code-cell} ipython3
-inlet.c = [1, 2]
+print(inlet.flow_rate)
 ```
 
-To specify the polynomial coefficients, a list of lists needs to be set.
-For each component, the coefficients are added in ascending order where the first entry is the constant term, the second is the linear term etc.
-E.g. consider a gradient where the first component concentration has a constant term of $0~mM$ and increases linearly with slope $1 mM \cdot s^{-1}$, and the second component starts at $2~mM$ and decreases with a quadratic term of $-1~mM \cdot s^{-2}$.
-Note, missing coefficients are always added internally.
-
-```{code-cell} ipython3
-inlet.c = [[0, 1], [2, 0, -1]]
-print(inlet.c)
-```
-
-Similarly, the polynomial coefficients for the unit flow rate can be set for {class}`Inlets <CADETProcess.processModel.Inlet>` and {class}`Cstrs <CADETProcess.processModel.Cstr>`.
-For example, a constant flow rate can be set with:
+When assigning a scalar value to the parameter, the new state is assumed to be constant.
+All other coefficients are set to $0$.
+Note that polynomial coefficients are specified in order of increasing degree.
+I.e. the first coefficient corresponds to the constant term, the second to the linear term, etc.
 
 ```{code-cell} ipython3
 inlet.flow_rate = 1
 print(inlet.flow_rate)
 ```
 
-And a linearly increasing flow rate with:
+It is also possible to specify only any subset of polynomial coefficients.
+E.g. consider a linear gradient where the flow rate starts at $1 m^3 \cdot s^{-1}$ and increases with a slope of $2 m^3 \cdot s^{-2}$:
 
 ```{code-cell} ipython3
-inlet.flow_rate = [1,2]
+inlet.flow_rate = [1, 2]
 print(inlet.flow_rate)
+```
+
+Or, specify all polynomial coefficients:
+
+
+```{code-cell} ipython3
+inlet.flow_rate = [0, 1, 2, 3]
+print(inlet.flow_rate)
+```
+
+This also works for parameters with multiple entries, e.g. the {attr}`concentration <CADETProcess.processModel.Inlet.c>` of an {class}`~CADETProcess.processModel.Inlet`.
+
+Set all components to same (constant) concentration:
+
+```{code-cell} ipython3
+inlet.c = 1
+print(inlet.c)
+```
+
+Specify constant term for each component:
+
+
+```{code-cell} ipython3
+inlet.c = [1, 2]
+print(inlet.c)
+```
+
+Specify polynomial coefficients for each component:
+
+```{code-cell} ipython3
+inlet.c = [[1, 2], 1]
+print(inlet.c)
+```
+
+Specify all polynomial coefficients:
+
+```{code-cell} ipython3
+inlet.c = [[0, 1, 2, 3], [4, 5, 6, 7]]
+print(inlet.c)
 ```
 
 Since these parameters are mostly used in dynamic process models, they are usually modified using {class}`Events <CADETProcess.dynamicEvents.Event>`.
 
-
 For an example, refer to {ref}`SSR process <lwe_example>`.
 
+(discretization_guide)=
 ### Discretization
 Some of the unit operations need to be spatially discretized.
 The discretization parameters are stored in a {class}`DiscretizationParametersBase` class.

--- a/examples/characterize_chromatographic_system/particle_porosity.md
+++ b/examples/characterize_chromatographic_system/particle_porosity.md
@@ -125,10 +125,10 @@ process.add_event(
 
 ```{code-cell}
 from CADETProcess.simulator import Cadet
-process_simulator = Cadet()
+simulator = Cadet()
 
 if __name__ == '__main__':
-    simulation_results = process_simulator.simulate(process)
+    simulation_results = simulator.simulate(process)
     _ = simulation_results.solution.outlet.inlet.plot()
 ```
 

--- a/examples/characterize_chromatographic_system/particle_porosity.py
+++ b/examples/characterize_chromatographic_system/particle_porosity.py
@@ -124,10 +124,10 @@ process.add_event(
 
 # %%
 from CADETProcess.simulator import Cadet
-process_simulator = Cadet()
+simulator = Cadet()
 
 if __name__ == '__main__':
-    simulation_results = process_simulator.simulate(process)
+    simulation_results = simulator.simulate(process)
     _ = simulation_results.solution.outlet.inlet.plot()
 
 # %% [markdown]

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -59,28 +59,28 @@ class TestComponents(unittest.TestCase):
         with self.assertRaises(CADETProcessError):
             self.component_system_1.add_component('A')
 
-    def test_labels(self):
-        labels_expected = ['0', '1']
-        labels = self.component_system_0.labels
-        np.testing.assert_equal(labels, labels_expected)
+    def test_species(self):
+        species_expected = ['0', '1']
+        species = self.component_system_0.species
+        np.testing.assert_equal(species, species_expected)
 
-        labels_expected = ['A', 'B']
-        labels = self.component_system_1.labels
-        np.testing.assert_equal(labels, labels_expected)
+        species_expected = ['A', 'B']
+        species = self.component_system_1.species
+        np.testing.assert_equal(species, species_expected)
 
-        labels_expected = ['A', 'B+', 'B-']
-        labels = self.component_system_2.labels
-        np.testing.assert_equal(labels, labels_expected)
+        species_expected = ['A', 'B+', 'B-']
+        species = self.component_system_2.species
+        np.testing.assert_equal(species, species_expected)
 
-        labels_expected = [
+        species_expected = [
             'NH4+', 'NH3', 'Lys2+', 'Lys+', 'Lys', 'Lys', 'H+'
         ]
-        labels = self.component_system_3.labels
-        np.testing.assert_equal(labels, labels_expected)
+        species = self.component_system_3.species
+        np.testing.assert_equal(species, species_expected)
 
-        labels_expected = ['0', '1', 'manual_label']
-        labels = self.component_system_4.labels
-        np.testing.assert_equal(labels, labels_expected)
+        species_expected = ['0', '1', 'manual_label']
+        species = self.component_system_4.species
+        np.testing.assert_equal(species, species_expected)
 
     def test_indices(self):
         indices_expected = {

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -4,17 +4,14 @@
     add/remove durations
     add/remove dependencies
 
-
 - event times (especially considerung time modulo cycle time)
 - event /parameter/ performer timelines
 - section states (especially piecewise poly times)
 
-- conflicing events at same time?
-
 Notes
 -----
-    Since the EventHandler defines an interface, that requires the
-    implementation of some methods, a TestHandler class is defined.
+Since the EventHandler defines an interface, that requires the
+implementation of some methods, a TestHandler class is defined.
 
 Maybe this is too complicated, just use Process instead?
 """
@@ -22,20 +19,53 @@ Maybe this is too complicated, just use Process instead?
 import unittest
 
 from addict import Dict
+import numpy as np
 
 import CADETProcess
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import StructMeta
-from CADETProcess.dataStructure import Float, Switch, SizedTuple
+from CADETProcess.dataStructure import Structure
+from CADETProcess.dataStructure import (
+    Float, Switch, SizedTuple, SizedList, SizedNdArray, Polynomial, NdPolynomial,
+)
+
+plot = True
 
 
-class TestPerformer(metaclass=StructMeta):
-    param_1 = Float(default=0)
-    param_2 = SizedTuple(minlen=2, maxlen=2, default=(1, 1))
-    param_3 = Switch(valid=[-1, 1], default=1)
+class TestPerformer(Structure):
+    n_entries = 4
+    n_coeff = 4
 
-    _parameters = ['param_1', 'param_2', 'param_3']
-    _section_dependent_parameters = ['param_1', 'param_2']
+    scalar_float = Float(default=0)
+    switch = Switch(valid=[-1, 1], default=1)
+    sized_tuple = SizedTuple(size=2, default=(1, 1))
+    array_1d = SizedList(size=4, default=0)
+    ndarray = SizedNdArray(size=(2, 4), default=0)
+    ndarray_no_default = SizedNdArray(size=(2, 4))
+    array_1d_poly = Polynomial(n_coeff=4, default=0)
+    ndarray_poly = NdPolynomial(n_entries=2, n_coeff=4, default=0)
+    ndarray_poly_dep = NdPolynomial(size=('n_entries', 'n_coeff'), default=0)
+
+    _parameters = [
+        'scalar_float',
+        'sized_tuple',
+        'switch',
+        'array_1d',
+        'ndarray',
+        'ndarray_no_default',
+        'array_1d_poly',
+        'ndarray_poly',
+        'ndarray_poly_dep',
+    ]
+    _section_dependent_parameters = [
+        'scalar_float',
+        'sized_tuple',
+        'array_1d',
+        'ndarray',
+        'ndarray_no_default',
+        'array_1d_poly',
+        'ndarray_poly',
+        'ndarray_poly_dep',
+    ]
 
     @property
     def section_dependent_parameters(self):
@@ -45,25 +75,10 @@ class TestPerformer(metaclass=StructMeta):
         }
         return parameters
 
-    @property
-    def parameters(self):
-        parameters = {
-            param: getattr(self, param)
-            for param in self._parameters
-        }
-        return parameters
-
-    @parameters.setter
-    def parameters(self, parameters):
-        for param, value in parameters.items():
-            if param not in self._parameters:
-                raise CADETProcessError('Not a valid parameter')
-            if value is not None:
-                setattr(self, param, value)
-
 
 class TestHandler(CADETProcess.dynamicEvents.EventHandler):
     def __init__(self):
+        self.name = None
         self.performer = TestPerformer()
         super().__init__()
 
@@ -90,80 +105,746 @@ class TestHandler(CADETProcess.dynamicEvents.EventHandler):
         parameters['performer'] = self.performer.section_dependent_parameters
         return parameters
 
+    @property
+    def polynomial_parameters(self):
+        parameters = Dict()
+        parameters['performer'] = self.performer.polynomial_parameters
+        return parameters
+
 
 class Test_Events(unittest.TestCase):
 
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
 
-    def create_event_handler(self):
+    def setup_event_handler(self, add_events=False):
         event_handler = TestHandler()
+        event_handler.cycle_time = 20
 
-        event_handler.add_event('evt0', 'performer.param_1', 0, 0)
-        event_handler.add_event('evt1', 'performer.param_1', 1, 0)
-        event_handler.add_event('evt2', 'performer.param_2', (2, 1), 0)
-        event_handler.add_event('evt3', 'performer.param_2', (3, 2), 0)
-        event_handler.add_event('evt4', 'performer.param_2', (3, 3), 0)
+        if add_events:
+            evt = event_handler.add_event('evt0', 'performer.scalar_float', 0)
+            evt = event_handler.add_event('evt1', 'performer.scalar_float', 1)
+            evt = event_handler.add_event('evt2', 'performer.sized_tuple', (2, 1))
+            evt = event_handler.add_event('evt3', 'performer.sized_tuple', (3, 2))
+            evt = event_handler.add_event('evt4', 'performer.sized_tuple', (3, 3))
 
         return event_handler
 
-    def test_adding_events(self):
-        event_handler = self.create_event_handler()
+    def setUp(self):
+        self.event_handler = self.setup_event_handler()
 
+    def test_exceptions(self):
+        event_handler = self.setup_event_handler()
+
+        # Invalid path
         with self.assertRaises(CADETProcess.CADETProcessError):
             event_handler.add_event('wrong_path', 'performer.wrong', 1)
 
-        with self.assertRaises(CADETProcess.CADETProcessError):
+        # Invalid state
+        with self.assertRaises(TypeError):
             event_handler.add_event(
-                'wrong_value', 'performer.param_1', 'wrong'
+                'wrong_value', 'performer.scalar_float', 'wrong'
             )
 
+        # Duplicate name
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event('duplicate', 'performer.param_1', 1)
-            event_handler.add_event('duplicate', 'performer.param_1', 1)
+            event_handler.add_event('duplicate', 'performer.scalar_float', 1)
+            event_handler.add_event('duplicate', 'performer.scalar_float', 1)
 
+        # Not section dependent
         with self.assertRaises(CADETProcess.CADETProcessError):
             event_handler.add_event(
-                'not_sec_dependent', 'performer.param_3', 1
+                'not_sec_dependent', 'performer.switch', 1
             )
+
+    def test_event_scalar(self):
+        event_handler = self.event_handler
+
+        evt = event_handler.add_event('trivial', 'performer.scalar_float', 1, time=0)
+        self.assertEqual(evt.state, 1)
+        self.assertEqual(evt.full_state, 1)
+        self.assertEqual(evt.n_entries, 1)
+        self.assertEqual(evt.indices, None)
+        self.assertEqual(evt.full_indices, [])
+        self.assertEqual(evt.n_indices, 0)
+        self.assertEqual(event_handler.performer.scalar_float, 1)
+
+        # Raise Error for indices
+        with self.assertRaises(IndexError):
+            evt = event_handler.add_event(
+                'param_has_no_indices', 'performer.scalar_float', 1, time=0, indices=1
+            )
+
+    def test_event_1D(self):
+        # TODO: Check too many / few indices
+        event_handler = self.event_handler
+
+        # Add event for single entry in 1D list / array
+        event_handler.performer.array_1d
+        evt = event_handler.add_event(
+            '1D_single', 'performer.array_1d', 1, indices=0, time=0
+        )
+        self.assertEqual(evt.state, 1)
+        self.assertEqual(evt.full_state, [1])
+        self.assertEqual(evt.n_entries, 1)
+        self.assertEqual(evt.indices, [(0,)])
+        self.assertEqual(evt.full_indices, [(0,)])
+        self.assertEqual(evt.n_indices, 1)
+        np.testing.assert_equal(event_handler.performer.array_1d, [1, 0, 0, 0])
+
+        # Add event for multiple entries in 1D list / array
+        # TODO: When creating section, missing parameters must be read at that time!
+        evt = event_handler.add_event(
+            '1D_multi', 'performer.array_1d', [0, 1], indices=[0, 1], time=1
+        )
+        np.testing.assert_equal(evt.state, [0, 1])
+        self.assertEqual(evt.full_state, [0, 1])
+        self.assertEqual(evt.n_entries, 2)
+        np.testing.assert_equal(evt.indices, [(0,), (1,)])
+        self.assertEqual(evt.full_indices, [(0,), (1,)])
+        self.assertEqual(evt.n_indices, 2)
+        np.testing.assert_equal(event_handler.performer.array_1d, [0, 1, 0, 0])
+
+        # Add event for multiple entries in 1D list / array with custom order
+        evt = event_handler.add_event(
+            '1D_multi_order', 'performer.array_1d', [2, 3], indices=[1, 2], time=2
+        )
+        np.testing.assert_equal(evt.state, [2, 3])
+        np.testing.assert_equal(evt.full_state, [2, 3])
+        self.assertEqual(evt.n_entries, 2)
+        np.testing.assert_equal(evt.indices, [(1,), (2,)])
+        np.testing.assert_equal(evt.full_indices, [(1,), (2,)])
+        self.assertEqual(evt.n_indices, 2)
+        np.testing.assert_equal(event_handler.performer.array_1d, [0, 2, 3, 0])
+
+        # Add event for all entries in 1D list / array
+        evt = event_handler.add_event(
+            '1D_all', 'performer.array_1d', [0, 0, 1], indices=[0, 1, 2], time=3
+        )
+        np.testing.assert_equal(evt.state, [0, 0, 1])
+        np.testing.assert_equal(evt.full_state, [0, 0, 1])
+        self.assertEqual(evt.n_entries, 3)
+        np.testing.assert_equal(evt.indices, [(0,), (1,), (2,)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,)])
+        self.assertEqual(evt.n_indices, 3)
+        np.testing.assert_equal(event_handler.performer.array_1d, [0, 0, 1, 0])
+
+        # Set all values without indices
+        evt = event_handler.add_event(
+            '1D_all_slice_all_no_indices', 'performer.array_1d',
+            [0, 1, 2, 3], time=4
+        )
+        np.testing.assert_equal(evt.state, [0, 1, 2, 3])
+        np.testing.assert_equal(evt.full_state, [0, 1, 2, 3])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(event_handler.performer.array_1d, [0, 1, 2, 3])
+
+        # Set all values using slicing notation.
+        evt = event_handler.add_event(
+            '1D_all_slice', 'performer.array_1d',
+            [2, 3, 4, 5], indices=np.s_[:], time=5
+        )
+        np.testing.assert_equal(evt.state, [2, 3, 4, 5])
+        np.testing.assert_equal(evt.full_state, [2, 3, 4, 5])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(event_handler.performer.array_1d, [2, 3, 4, 5])
+
+        # Set all values to one value using slicing notation
+        evt = event_handler.add_event(
+            '1D_all_slice_one_value', 'performer.array_1d', 1, indices=np.s_[:], time=6
+        )
+        np.testing.assert_equal(evt.state, 1)
+        np.testing.assert_equal(evt.full_state, [1, 1, 1, 1])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(event_handler.performer.array_1d, [1, 1, 1, 1])
+
+        # Set all values from starting_index to one value using slice
+        evt = event_handler.add_event(
+            '1D_partial_slice', 'performer.array_1d', 2, indices=np.s_[1:], time=7
+        )
+        np.testing.assert_equal(evt.state, 2)
+        np.testing.assert_equal(evt.full_state, [2, 2, 2])
+        self.assertEqual(evt.n_entries, 3)
+        np.testing.assert_equal(evt.indices, [(slice(1, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 3)
+        np.testing.assert_equal(event_handler.performer.array_1d, [1, 2, 2, 2])
+
+        if plot:
+            event_handler.plot_events()
+
+        # Number of indices
+        with self.assertRaises(ValueError):
+            event_handler.add_event(
+                'not_enough_entries', 'performer.array_1d', [1, 2], indices=[2]
+            )
+        with self.assertRaises(ValueError):
+            event_handler.add_event(
+                'too_many_indices', 'performer.array_1d', [1, 2], indices=[1, 2, 2]
+            )
+
+        # Index exceeds shape
+        with self.assertRaises(IndexError):
+            event_handler.add_event(
+                'index_exceeds_shape', 'performer.array_1d', [1, 2], indices=[1, 4]
+            )
+
+        # Duplicate entries for indices
+        with self.assertRaises(ValueError):
+            event_handler.add_event(
+                'duplicate_entries', 'performer.array_1d', [1, 2], indices=[1, 1]
+            )
+
+    def test_event_ndarray(self):
+        event_handler = self.event_handler
+
+        t = 0
+
+        # Add event for single entry in ndarray
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_single', 'performer.ndarray', 1, indices=(0, 0), time=t
+        )
+        np.testing.assert_equal(evt.state, 1)
+        self.assertEqual(evt.n_entries, 1)
+        np.testing.assert_equal(evt.indices, [(0, 0)])
+        np.testing.assert_equal(evt.full_indices, [(0, 0)])
+        self.assertEqual(evt.n_indices, 1)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[1, 0, 0, 0], [0, 0, 0, 0]]
+        )
+
+        # Add event for multiple entries in array
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_multiple', 'performer.ndarray',
+            [0, 1], indices=[(0, 0), (0, 1)], time=t
+        )
+        np.testing.assert_equal(evt.state, [0, 1])
+        np.testing.assert_equal(evt.full_state, [0, 1])
+        self.assertEqual(evt.n_entries, 2)
+        np.testing.assert_equal(evt.indices, [(0, 0), (0, 1)])
+        np.testing.assert_equal(evt.full_indices, [(0, 0), (0, 1)])
+        self.assertEqual(evt.n_indices, 2)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[0, 1, 0, 0], [0, 0, 0, 0]]
+        )
+
+        # Add event for multiple entries in array with custom order
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_multiple_order', 'performer.ndarray',
+            [1, 0], indices=[(1, 0), (0, 1)], time=t
+        )
+        np.testing.assert_equal(evt.state, [1, 0])
+        np.testing.assert_equal(evt.full_state, [1, 0])
+        self.assertEqual(evt.n_entries, 2)
+        np.testing.assert_equal(evt.indices, [(1, 0), (0, 1)])
+        np.testing.assert_equal(evt.full_indices, [(1, 0), (0, 1)])
+        self.assertEqual(evt.n_indices, 2)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[0, 0, 0, 0], [1, 0, 0, 0]]
+        )
+
+        # Add event for all entries in array
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_all', 'performer.ndarray',
+            [0, 1, 2, 3, 4, 5, 6, 7],
+            indices=[(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
+            time=t
+        )
+        np.testing.assert_equal(evt.state, [0, 1, 2, 3, 4, 5, 6, 7])
+        self.assertEqual(evt.n_entries, 8)
+        np.testing.assert_equal(
+            evt.indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        )
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        )
+        self.assertEqual(evt.n_indices, 8)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[0, 1, 2, 3], [4, 5, 6, 7]]
+        )
+
+        # Set all values without indices
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_all_no_indices', 'performer.ndarray',
+            [[8, 7, 6, 5], [4, 3, 2, 1]],
+            time=t
+        )
+        np.testing.assert_equal(evt.state, [[8, 7, 6, 5], [4, 3, 2, 1]])
+        np.testing.assert_equal(evt.full_state, [8, 7, 6, 5, 4, 3, 2, 1])
+        self.assertEqual(evt.n_entries, 8)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        )
+        self.assertEqual(evt.n_indices, 8)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[8, 7, 6, 5], [4, 3, 2, 1]]
+        )
+
+        # Set all values using slicing notation.
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_all_slice', 'performer.ndarray',
+            [[0, 0, 0, 0], [1, 1, 1, 1]], indices=np.s_[:], time=t
+        )
+        np.testing.assert_equal(evt.state, [[0, 0, 0, 0], [1, 1, 1, 1]])
+        np.testing.assert_equal(evt.full_state, [0, 0, 0, 0, 1, 1, 1, 1])
+        self.assertEqual(evt.n_entries, 8)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        )
+        self.assertEqual(evt.n_indices, 8)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[0, 0, 0, 0], [1, 1, 1, 1]]
+        )
+
+        # Set all values to one value using slicing notation
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_all_slice_one_value', 'performer.ndarray',
+            1, indices=np.s_[:], time=t
+        )
+        np.testing.assert_equal(evt.state, 1)
+        np.testing.assert_equal(evt.full_state, [1, 1, 1, 1, 1, 1, 1, 1])
+        self.assertEqual(evt.n_entries, 8)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        )
+        self.assertEqual(evt.n_indices, 8)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[1, 1, 1, 1], [1, 1, 1, 1]]
+        )
+
+        # TODO: Check slicing for rows/columns
+        # Set all values of one row using slicing notation
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_row_slice', 'performer.ndarray',
+            [0, 0, 0, 0], indices=np.s_[0, :], time=t
+        )
+        np.testing.assert_equal(evt.state, [0, 0, 0, 0])
+        np.testing.assert_equal(evt.full_state, [0, 0, 0, 0])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(0, slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3)]
+        )
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[0, 0, 0, 0], [1, 1, 1, 1]]
+        )
+
+        # Set all values of one row to one value using slicing notation
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_row_slice_one_value', 'performer.ndarray',
+            2, indices=np.s_[0, :], time=t
+        )
+        np.testing.assert_equal(evt.state, 2)
+        np.testing.assert_equal(evt.full_state, [2, 2, 2, 2])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(0, slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 0), (0, 1), (0, 2), (0, 3)]
+        )
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[2, 2, 2, 2], [1, 1, 1, 1]]
+        )
+
+        # Set all values of one column from starting_index to one value using slice
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_column_partial_slice', 'performer.ndarray',
+            3, indices=np.s_[1:, 1], time=t
+        )
+        np.testing.assert_equal(evt.state, 3)
+        np.testing.assert_equal(evt.full_state, [3])
+        self.assertEqual(evt.n_entries, 1)
+        np.testing.assert_equal(evt.indices, [(slice(1, None, None), 1)])
+        np.testing.assert_equal(evt.full_indices, [(1, 1)])
+        self.assertEqual(evt.n_indices, 1)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[2, 2, 2, 2], [1, 3, 1, 1]]
+        )
+
+        # Check multiple slices
+        t += 1
+        evt = event_handler.add_event(
+            'ndarray_multiple_slices', 'performer.ndarray',
+            [4, 5], indices=[np.s_[0, 1:], np.s_[1, :]], time=t
+        )
+        np.testing.assert_equal(evt.state, [4, 5])
+        np.testing.assert_equal(evt.full_state, [4, 4, 4, 5, 5, 5, 5])
+        self.assertEqual(evt.n_entries, 7)
+        np.testing.assert_equal(
+            evt.indices, [(0, slice(1, None, None)), (1, slice(None, None, None))]
+        )
+        np.testing.assert_equal(
+            evt.full_indices,
+            [(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+        )
+        self.assertEqual(evt.n_indices, 7)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray, [[2, 4, 4, 4], [5, 5, 5, 5]]
+        )
+
+        if plot:
+            event_handler.plot_events()
+
+    def test_event_polynomial_1D(self):
+        event_handler = self.event_handler
+
+        # Add event relying on filling missing coefficients
+        evt = event_handler.add_event(
+            '1D_single_fill', 'performer.array_1d_poly', 1, time=0
+        )
+        np.testing.assert_equal(evt.state, 1)
+        np.testing.assert_equal(evt.full_state, [1, 0, 0, 0])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.array_1d_poly, [1, 0, 0, 0]
+        )
+
+        # Fill all values to specific value
+        evt = event_handler.add_event(
+            '1D_multi_no_fill', 'performer.array_1d_poly', 2, indices=np.s_[:], time=1
+        )
+        np.testing.assert_equal(evt.state, 2)
+        np.testing.assert_equal(evt.full_state, [2, 2, 2, 2])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.array_1d_poly, [2, 2, 2, 2]
+        )
+
+        # Add event relying on filling missing coefficients
+        evt = event_handler.add_event(
+            '1D_multi_fill', 'performer.array_1d_poly', [3, 3], time=2
+        )
+        np.testing.assert_equal(evt.state, [3, 3])
+        np.testing.assert_equal(evt.full_state, [3, 3, 0, 0])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.array_1d_poly, [3, 3, 0, 0]
+        )
+
+        # Add event for single entry in array
+        evt = event_handler.add_event(
+            '1D_single', 'performer.array_1d_poly', 1, indices=0, time=3
+        )
+        np.testing.assert_equal(evt.state, 1)
+        np.testing.assert_equal(evt.full_state, [1])
+        self.assertEqual(evt.n_entries, 1)
+        np.testing.assert_equal(evt.indices, [(0, )])
+        np.testing.assert_equal(evt.full_indices, [(0,)])
+        self.assertEqual(evt.n_indices, 1)
+        np.testing.assert_equal(
+            event_handler.performer.array_1d_poly, [1, 3, 0, 0]
+        )
+
+        # Add event for multiple entry in array
+        evt = event_handler.add_event(
+            '1D_multi', 'performer.array_1d_poly', [2, 2], indices=[0, 1], time=4
+        )
+        np.testing.assert_equal(evt.state, [2, 2])
+        np.testing.assert_equal(evt.full_state, [2, 2])
+        self.assertEqual(evt.n_entries, 2)
+        np.testing.assert_equal(evt.indices, [(0,), (1,)])
+        np.testing.assert_equal(evt.full_indices, [(0,), (1,)])
+        self.assertEqual(evt.n_indices, 2)
+        np.testing.assert_equal(
+            event_handler.performer.array_1d_poly, [2, 2, 0, 0]
+        )
+
+        # Add event for single entry in array to check if list notation works
+        evt = event_handler.add_event(
+            '1D_multi_flat', 'performer.array_1d_poly', [0], indices=[1], time=5
+        )
+        np.testing.assert_equal(evt.state, [0])
+        np.testing.assert_equal(evt.full_state, [0])
+        self.assertEqual(evt.n_entries, 1)
+        np.testing.assert_equal(evt.indices, [(1,)])
+        np.testing.assert_equal(evt.full_indices, [(1,)])
+        self.assertEqual(evt.n_indices, 1)
+        np.testing.assert_equal(
+            event_handler.performer.array_1d_poly, [2, 0, 0, 0]
+        )
+
+        if plot:
+            event_handler.plot_events()
+
+    def test_event_polynomial_ndarray(self):
+        event_handler = self.event_handler
+
+        t = 0
+
+        # Add event relying for individual coefficient
+        t += 1
+        evt = event_handler.add_event(
+            'single_coeff', 'performer.ndarray_poly', 1, indices=(0, 1), time=t
+        )
+        np.testing.assert_equal(evt.state, 1)
+        np.testing.assert_equal(evt.full_state, [1])
+        self.assertEqual(evt.n_entries, 1)
+        np.testing.assert_equal(evt.indices, [(0, 1)])
+        np.testing.assert_equal(evt.full_indices, [(0, 1)])
+        self.assertEqual(evt.n_indices, 1)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray_poly,
+            [
+                [0, 1, 0, 0],
+                [0, 0, 0, 0],
+            ]
+        )
+
+        # Add event for multiple coefficients / indices
+        t += 1
+        evt = event_handler.add_event(
+            'multi_coeffs', 'performer.ndarray_poly',
+            [1, 2], indices=[(0, 0), (1, 1)], time=t
+        )
+        np.testing.assert_equal(evt.state, [1, 2])
+        np.testing.assert_equal(evt.full_state, [1, 2])
+        self.assertEqual(evt.n_entries, 2)
+        np.testing.assert_equal(evt.indices, [(0, 0), (1, 1)])
+        np.testing.assert_equal(evt.full_indices, [(0, 0), (1, 1)])
+        self.assertEqual(evt.n_indices, 2)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray_poly,
+            [
+                [1, 1, 0, 0],
+                [0, 2, 0, 0],
+            ]
+        )
+
+        # Add event relying on filling missing coefficients
+        t += 1
+        evt = event_handler.add_event(
+            'fill_all', 'performer.ndarray_poly', 1, time=t
+        )
+        np.testing.assert_equal(evt.state, 1)
+        np.testing.assert_equal(
+            evt.full_state,
+            [
+                1, 0, 0, 0,
+                1, 0, 0, 0,
+            ]
+        )
+        self.assertEqual(evt.n_entries, 8)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [
+                (0, 0), (0, 1), (0, 2), (0, 3),
+                (1, 0), (1, 1), (1, 2), (1, 3),
+            ]
+        )
+        self.assertEqual(evt.n_indices, 8)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray_poly,
+            [
+                [1, 0, 0, 0],
+                [1, 0, 0, 0],
+            ]
+        )
+        # Add event relying on filling missing coefficients for single entry
+        t += 1
+        evt = event_handler.add_event(
+            'multi_fill_single', 'performer.ndarray_poly', 3, indices=0, time=t
+        )
+        np.testing.assert_equal(evt.state, 3)
+        np.testing.assert_equal(
+            evt.full_state,
+            [
+                3, 0, 0, 0,
+            ]
+        )
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(0,)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [
+                (0, 0), (0, 1), (0, 2), (0, 3),
+            ]
+        )
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray_poly,
+            [
+                [3, 0, 0, 0],
+                [1, 0, 0, 0],
+            ]
+        )
+
+        # Add event relying on filling missing coefficients with inhomogeneous shape
+        t += 1
+        evt = event_handler.add_event(
+            'multi_fill_inhomogeneous', 'performer.ndarray_poly', [2, [0, 1]], time=t
+        )
+        np.testing.assert_equal(evt.state, [2, [0, 1]])
+        np.testing.assert_equal(
+            evt.full_state,
+            [
+                2, 0, 0, 0,
+                0, 1, 0, 0,
+            ]
+        )
+        self.assertEqual(evt.n_entries, 8)
+        np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [
+                (0, 0), (0, 1), (0, 2), (0, 3),
+                (1, 0), (1, 1), (1, 2), (1, 3),
+            ]
+        )
+        self.assertEqual(evt.n_indices, 8)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray_poly,
+            [
+                [2, 0, 0, 0],
+                [0, 1, 0, 0],
+            ]
+        )
+
+        # Add event using slicing (should work just like a regular ndarray)
+        t += 1
+        evt = event_handler.add_event(
+            'multi_slice', 'performer.ndarray_poly', [1], indices=[np.s_[0, :]], time=t
+        )
+
+        np.testing.assert_equal(evt.state, [1])
+        np.testing.assert_equal(evt.full_state, [1, 1, 1, 1])
+        self.assertEqual(evt.n_entries, 4)
+        np.testing.assert_equal(evt.indices, [(0, slice(None, None, None))])
+        np.testing.assert_equal(
+            evt.full_indices,
+            [
+                (0, 0), (0, 1), (0, 2), (0, 3),
+            ]
+        )
+        self.assertEqual(evt.n_indices, 4)
+        np.testing.assert_equal(
+            event_handler.performer.ndarray_poly,
+            [
+                [1, 1, 1, 1],
+                [0, 1, 0, 0],
+            ]
+        )
+
+        if plot:
+            event_handler.plot_events()
+
+    def test_lwe(self):
+        """This reproduces the situation from the LWE / SMA model in the examples."""
+        event_handler = self.setup_event_handler()
+        event_handler.name = 'LWE'
+
+        cycle_time = 110*60
+        event_handler.cycle_time = cycle_time
+
+        t_flush = 20*60
+
+        t_gradient_start = 90
+        gradient_duration = cycle_time - t_gradient_start - t_flush
+
+        c_load = np.array([5, 1, 1, 1])
+        c_wash = np.array([5, 0, 0, 0])
+        c_elute = np.array([1000, 0, 0, 0])
+        gradient_slope = (c_elute - c_wash)/gradient_duration
+        c_gradient_poly = np.array(list(zip(c_wash, gradient_slope)))
+        c_gradient_poly[0][1] = 0.4
+        c_gradient_poly = c_gradient_poly.tolist()
+
+        event_handler.add_event('load', 'performer.ndarray_poly_dep', c_load, time=0)
+        event_handler.add_event(
+            'wash', 'performer.ndarray_poly_dep',
+            c_wash, time=t_flush
+        )
+        event_handler.add_event(
+            'grad_start', 'performer.ndarray_poly_dep',
+            c_gradient_poly, time=t_gradient_start
+        )
+        event_handler.add_event(
+            'Flush', 'performer.ndarray_poly_dep',
+            c_elute, time=t_gradient_start + gradient_duration
+        )
+
+        if plot:
+            event_handler.plot_events()
 
     def test_event_times(self):
-        event_handler = self.create_event_handler()
+        event_handler = self.setup_event_handler(add_events=True)
 
-        self.assertEqual(event_handler.event_times, [0.0])
+        self.assertEqual(event_handler.event_times, [0])
 
         event_handler.evt0.time = 1
-        self.assertEqual(event_handler.event_times, [0.0, 1.0])
+        self.assertEqual(event_handler.event_times, [0, 1])
 
         event_handler.cycle_time = 10
         event_handler.evt0.time = 11
-        self.assertEqual(event_handler.event_times, [0.0, 1.0])
+        self.assertEqual(event_handler.event_times, [0, 1])
 
     def test_dependencies(self):
-        event_handler = self.create_event_handler()
+        event_handler = self.setup_event_handler(add_events=True)
 
         event_handler.add_event_dependency('evt1', 'evt0')
-        self.assertEqual(event_handler.event_times, [0.0])
+        self.assertEqual(event_handler.event_times, [0])
 
         event_handler.evt0.time = 1
-        self.assertEqual(event_handler.event_times, [0.0, 1.0])
+        self.assertEqual(event_handler.event_times, [0, 1])
 
         event_handler.add_event_dependency('evt2', 'evt1', 2)
-        self.assertEqual(event_handler.event_times, [0.0, 1.0, 2.0])
+        self.assertEqual(event_handler.event_times, [0, 1, 2])
 
         event_handler.add_event_dependency('evt3', ['evt1', 'evt0'], [2, 1])
-        self.assertEqual(event_handler.event_times, [0.0, 1.0, 2.0, 3.0])
+        self.assertEqual(event_handler.event_times, [0, 1, 2, 3])
 
         # Dependent event
         with self.assertRaises(CADETProcess.CADETProcessError):
             event_handler.evt1.time = 1
+
         # Event does not exist
         with self.assertRaises(CADETProcess.CADETProcessError):
             event_handler.add_event_dependency('evt3', 'evt0')
-        # Duplicate
+
+        # Duplicate dependency
         with self.assertRaises(CADETProcess.CADETProcessError):
             event_handler.add_event_dependency('evt1', 'evt0')
-        # factors not matching
+
+        # Linear factors not matching
         with self.assertRaises(CADETProcess.CADETProcessError):
             event_handler.add_event_dependency('evt1', 'evt0', [1, 1])
 
@@ -173,6 +854,30 @@ class Test_Events(unittest.TestCase):
     def test_timelines(self):
         pass
 
+    def test_duplicate_event_times(self):
+        event_handler = self.setup_event_handler()
+
+        event_handler.add_event('evt0', 'performer.scalar_float', 0, 0)
+        event_handler.add_event('evt1', 'performer.scalar_float', 1, 1)
+
+        event_handler.check_config()
+
+        event_handler.evt1.time = 0
+
+        self.assertFalse(event_handler.check_duplicate_events())
+
+    def test_uninitialized_indices(self):
+        event_handler = self.setup_event_handler()
+
+        event_handler.add_event(
+            'evt0', 'performer.ndarray_no_default', 0, indices=(0, 0)
+        )
+
+        self.assertFalse(event_handler.check_uninitialized_indices())
+
 
 if __name__ == '__main__':
+    plot = True
+    import matplotlib.pyplot as plt
+    plt.close('all')
     unittest.main()

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -7,6 +7,9 @@ from addict import Dict
 import numpy as np
 
 from CADETProcess import settings
+from CADETProcess.dataStructure import (
+    Structure, Float, SizedList, Polynomial, NdPolynomial
+)
 from CADETProcess.optimization import OptimizationProblem
 from tests.optimization_problem_fixtures import (
     LinearConstraintsSooTestProblem2,
@@ -14,34 +17,19 @@ from tests.optimization_problem_fixtures import (
 )
 
 
-class EvaluationObject():
+class EvaluationObject(Structure):
+    scalar_param = Float(default=1)
+    list_param = SizedList(size=2, default=[1, 2])
+    polynomial_param = Polynomial(n_coeff=2, default=0)
+    polynomial_param = Polynomial(n_coeff=2)
+
+    _parameters = ['scalar_param', 'list_param', 'polynomial_param']
+
     def __init__(self, name='Dummy'):
         self.name = name
-        self.dummy_parameter = 1
-        self.component_parameter = [1, 2]
-        self.polynomial_parameter = [1, 1]
 
     def __str__(self):
         return self.name
-
-    @property
-    def parameters(self):
-        return {
-            'dummy_parameter': self.dummy_parameter,
-            'component_parameter': self.component_parameter,
-            'polynomial_parameter': self.polynomial_parameter,
-        }
-
-    @property
-    def polynomial_parameters(self):
-        return {
-            'polynomial_parameter': self.polynomial_parameter,
-        }
-
-    @parameters.setter
-    def parameters(self, parameters):
-        for key, value in parameters.items():
-            setattr(self, key, value)
 
 
 class Evaluator(ABC):

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -2,163 +2,616 @@ import unittest
 
 import numpy as np
 
-from CADETProcess.dataStructure import StructMeta, \
-    String, List, RangedFloat, UnsignedInteger, \
-    DependentlySizedUnsignedNdArray, DependentlySizedUnsignedList, \
-    Polynomial, NdPolynomial
+from CADETProcess.dataStructure import (
+    Structure,
+    Constant, Switch,
+    Typed, Integer, String, List,
+    Callable,
+    RangedFloat, UnsignedInteger,
+    SizedList, SizedNdArray,
+    SizedUnsignedList, SizedUnsignedNdArray,
+    Polynomial, NdPolynomial,
+    Vector, Matrix,
+    DependentlyModulatedUnsignedList,
+)
 
 
-class TestParameters(unittest.TestCase):
+class TestDescription(unittest.TestCase):
 
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
 
     def setUp(self):
-        class DummyModel(metaclass=StructMeta):
-            string_var = String()
-            list_var = List()
-            unsigned_var = UnsignedInteger()
-            bound_var = RangedFloat(lb=-1, ub=1)
+        class Model(Structure):
+            param_with_description = Integer(description='foo')
 
-            dep_1 = UnsignedInteger(default=2, description='foo')
-            single_dep_var = DependentlySizedUnsignedList(
-                dep='dep_1', default=1
-            )
-            dep_2 = UnsignedInteger()
-            double_dep_var = DependentlySizedUnsignedNdArray(
-                dep=('dep_1', 'dep_2'), default=1
-            )
-
-            n_coeff = 4
-            poly_single_hard = Polynomial(n_coeff=2)
-            poly_single_dep = Polynomial(dep=('n_coeff'))
-
-            entries = 3
-            poly_nd_hard = NdPolynomial(n_coeff=2, dep=('entries'))
-            poly_nd_dep = NdPolynomial(dep=('entries', 'n_coeff'))
-
-        self.dummy = DummyModel()
-
-    def test_values(self):
-        self.dummy.string_var = 'sting_var'
-        self.assertEqual(self.dummy.string_var, 'sting_var')
-
-    def test_default(self):
-        self.assertEqual(self.dummy.dep_1, 2)
-
-        with self.assertRaises(TypeError):
-            class WrongDefaultDummy_1(metaclass=StructMeta):
-                param_1 = UnsignedInteger(default='string')
-
-        with self.assertRaises(ValueError):
-            class WrongDefaultDummy_2(metaclass=StructMeta):
-                param_1 = UnsignedInteger(default=-1)
-
-    def test_type_checking(self):
-        with self.assertRaises(TypeError):
-            self.dummy.string_var = 1
-        with self.assertRaises(TypeError):
-            self.dummy.string_var = [1]
-        with self.assertRaises(TypeError):
-            self.dummy.string_var = 1.6
-
-    def test_range_checking(self):
-        with self.assertRaises(ValueError):
-            self.dummy.unsigned_var = -1
-        with self.assertRaises(ValueError):
-            self.dummy.bound_var = -2
-        with self.assertRaises(ValueError):
-            self.dummy.bound_var = 2
-
-    def test_dependencies(self):
-        with self.assertRaises(ValueError):
-            self.dummy.unsigned_var = -1
-
-        self.assertListEqual(self.dummy.single_dep_var, [1, 1])
-
-        self.dummy.dep_2 = 3
-        np.testing.assert_array_equal(
-            self.dummy.double_dep_var, np.ones((2, 3))
-        )
-
-        # wrong shape
-        with self.assertRaises(ValueError):
-            self.dummy.double_dep_var = np.ones((3, 3))
-
-        # wrong range
-        with self.assertRaises(ValueError):
-            self.dummy.double_dep_var = -1 * np.ones((2, 3))
+        self.model = Model()
 
     def test_description(self):
-        self.assertEqual(type(self.dummy).dep_1.description, 'foo')
+        self.assertEqual(type(self.model).param_with_description.description, 'foo')
 
     def test_modified_descriptor(self):
-        try:
-            type(self.dummy).bound_var.ub = 2
-            self.dummy.bound_var = 2
-        except ValueError as e:
-            self.fail(str(e))
+        type(self.model).param_with_description.description = 'bar'
+        self.assertEqual(type(self.model).param_with_description.description, 'bar')
 
-    def test_poly(self):
-        self.dummy.poly_single_hard = 1
-        np.testing.assert_equal(self.dummy.poly_single_hard, [1, 0])
-        self.dummy.poly_single_dep = 1
-        np.testing.assert_equal(self.dummy.poly_single_dep, [1, 0, 0, 0])
 
-        self.dummy.poly_single_hard = [1, 2]
-        np.testing.assert_equal(self.dummy.poly_single_hard, [1, 2])
-        self.dummy.poly_single_dep = [1, 2]
-        np.testing.assert_equal(self.dummy.poly_single_dep, [1, 2, 0, 0])
+class TestParameterDictionaries(unittest.TestCase):
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
 
-        with self.assertRaises(ValueError):
-            class TestDuplicateCoeff(metaclass=StructMeta):
-                n_coeff = 2
-                faulty = Polynomial(n_coeff=2, dep=('n_coeff'))
+    def setUp(self):
+        class Model(Structure):
+            param = Integer()
+            param_default = Integer(default=1)
+            no_param = None
 
-        self.dummy.poly_nd_hard = 1
+            _parameters = ['param', 'param_default']
+
+        self.model = Model()
+
+    def test_parameters_dict_getter(self):
         np.testing.assert_equal(
-            self.dummy.poly_nd_hard, [[1, 0], [1, 0], [1, 0]]
+            self.model._parameters, {'param': None, 'param_default': 1}
         )
-        self.dummy.poly_nd_dep = 1
+
+        self.model.param = 1
         np.testing.assert_equal(
-            self.dummy.poly_nd_dep, [[1, 0, 0, 0], [1, 0, 0, 0], [1, 0, 0, 0]],
+            self.model._parameters, {'param': 1, 'param_default': 1}
         )
 
-        self.dummy.poly_nd_hard = [1, 2, 3]
-        np.testing.assert_almost_equal(
-            self.dummy.poly_nd_hard, [[1, 0], [2, 0], [3, 0]]
-        )
-        self.dummy.poly_nd_dep = [1, 2, 3]
-        np.testing.assert_almost_equal(
-            self.dummy.poly_nd_dep, [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]
+        self.model.param = None
+        np.testing.assert_equal(
+            self.model._parameters, {'param': None, 'param_default': 1}
         )
 
-        self.dummy.poly_nd_dep = [[1, 1], [2, -2], [3, 3]]
-        np.testing.assert_almost_equal(
-            self.dummy.poly_nd_dep, [[1, 1, 0, 0], [2, -2, 0, 0], [3, 3, 0, 0]]
+        self.model.param_default = 2
+        np.testing.assert_equal(
+            self.model._parameters, {'param': None, 'param_default': 2}
         )
 
-        self.dummy.poly_nd_dep = [[1], [2, -2], [3, 3, 0, 0]]
-        np.testing.assert_almost_equal(
-            self.dummy.poly_nd_dep, [[1, 0, 0, 0], [2, -2, 0, 0], [3, 3, 0, 0]]
+        self.model.param_default = None
+        np.testing.assert_equal(
+            self.model._parameters, {'param': None, 'param_default': 1}
+        )
+
+    def test_parameters_dict_setter(self):
+        self.model.parameters = {'param': 1, 'param_default': 2}
+        np.testing.assert_equal(
+            self.model._parameters, {'param': 1, 'param_default': 2}
+        )
+
+        self.model.parameters = {'param': 2}
+        np.testing.assert_equal(
+            self.model._parameters, {'param': 2, 'param_default': 2}
         )
 
         with self.assertRaises(ValueError):
-            self.dummy.poly_nd_hard = [1]
-        with self.assertRaises(ValueError):
-            self.dummy.poly_nd_hard = [1, 1, 1, 1]
+            self.model.parameters = {'not_a_valid_param': 1}
+
+
+class TestConstant(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            const_int = Constant(value=0)
+            const_list = Constant(value=[0, 1])
+
+        self.model = Model()
+
+    def test_constant(self):
+        self.assertEqual(self.model.const_int, 0)
 
         with self.assertRaises(ValueError):
-            # Missing number of entries
-            class TestDuplicateCoeff(metaclass=StructMeta):
+            self.model.const_int = 1
+
+        self.assertEqual(self.model.const_list, [0, 1])
+
+        with self.assertRaises(ValueError):
+            self.model.const_list = [1, 2]
+
+    def test_error_when_no_value(self):
+        with self.assertRaises(TypeError):
+            class NoValue(Structure):
+                const = Constant()
+
+
+class TestSwitch(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            switch = Switch(valid=['foo', 'bar'], default='foo')
+
+        self.model = Model()
+
+    def test_value(self):
+        self.model.switch = 'bar'
+        self.assertEqual(self.model.switch, 'bar')
+
+        with self.assertRaises(ValueError):
+            self.model.switch = 'spam'
+
+    def test_default(self):
+        self.assertEqual(self.model.switch, 'foo')
+
+        with self.assertRaises(ValueError):
+            class InvalidDefault(Structure):
+                switch = Switch(valid=['foo', 'bar'], default='spam')
+
+
+class TestTyped(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            string_param = String(default='foo')
+            list_param = List(default=[1, 2])
+            dynamic_type_param = Typed(ty=list, default=[0, 1])
+
+        self.model = Model()
+        self.model_other = Model()
+
+    def test_values(self):
+        self.model.string_param = 'string_param'
+        self.assertEqual(self.model.string_param, 'string_param')
+
+        with self.assertRaises(TypeError):
+            self.model.string_param = 0
+
+        self.model.list_param = [0,]
+        self.assertEqual(self.model.list_param, [0,])
+
+        with self.assertRaises(TypeError):
+            self.model.list_param = 0
+
+        self.model.dynamic_type_param = [0]
+        with self.assertRaises(TypeError):
+            self.model.dynamic_type_param = 0
+
+    def test_default(self):
+        self.assertEqual(self.model.string_param, 'foo')
+        self.assertEqual(self.model.list_param, [1, 2])
+        self.assertEqual(self.model.dynamic_type_param, [0, 1])
+
+        self.assertFalse(self.model.list_param is self.model_other.list_param)
+        self.assertFalse(self.model.dynamic_type_param is self.model_other.list_param)
+
+        with self.assertRaises(TypeError):
+            class WrongDefaultType(Structure):
+                param_1 = List(default='string')
+
+        with self.assertRaises(TypeError):
+            class WrongDefaultType(Structure):
+                param_1 = List(default=1)
+
+            model = WrongDefaultType()
+            model.param_1
+
+
+class TestCallable(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        def default_method(x):
+            return x
+
+        class Model(Structure):
+            method = Callable()
+            method_default = Callable(default=default_method)
+
+        self.model = Model()
+
+    def test_values(self):
+        def method(x):
+            return 2*x
+
+        self.model.method = method
+        assert (callable(self.model.method))
+
+        self.assertEqual(self.model.method(2), 4)
+
+        with self.assertRaises(TypeError):
+            self.model.method = 2
+
+    def test_default(self):
+        assert (callable(self.model.method_default))
+        self.assertEqual(self.model.method_default(2), 2)
+
+
+class TestRanged(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            bound_float_param = RangedFloat(lb=-1, ub=1, default=0)
+            unsigned_integer_param = UnsignedInteger(default=1)
+
+        self.model = Model()
+
+    def test_values(self):
+        self.model.bound_float_param = 0.5
+        self.assertEqual(self.model.bound_float_param, 0.5)
+
+        with self.assertRaises(ValueError):
+            self.model.bound_float_param = -2
+
+        with self.assertRaises(ValueError):
+            self.model.bound_float_param = 2
+
+        self.model.unsigned_integer_param = 10
+        with self.assertRaises(ValueError):
+            self.model.unsigned_integer_param = -2
+
+    def test_default(self):
+        self.assertEqual(self.model.bound_float_param, 0.0)
+        self.assertEqual(self.model.unsigned_integer_param, 1)
+
+        with self.assertRaises(ValueError):
+            class InvalidDefault(Structure):
+                param_1 = UnsignedInteger(default=-1)
+
+
+class TestSizedUnified(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            sized_list = SizedList(size=4, default=0)
+            sized_array = SizedNdArray(size=(2, 4), default=0)
+
+            sized_unsigned_list = SizedUnsignedList(size=4, default=1)
+            sized_unsigned_array = SizedUnsignedNdArray(size=(2, 4), default=1)
+
+            sized_list_full_default = SizedList(size=4, default=[1, 2, 3, 4])
+            sized_array_full_default = SizedNdArray(
+                size=(2, 4), default=[[1, 2, 3, 4], [5, 6, 7, 8]]
+            )
+
+        self.model = Model()
+
+    def test_values(self):
+        self.model.sized_list = [1, 2, 3, 4]
+        np.testing.assert_equal(self.model.sized_list, [1, 2, 3, 4])
+
+        self.model.sized_array = np.array([[1, 2, 3, 4], [5, 6, 7, 8]])
+        np.testing.assert_equal(self.model.sized_array, [[1, 2, 3, 4], [5, 6, 7, 8]])
+
+        self.model.sized_array = [[0, 1, 2, 3], [4, 5, 6, 7]]
+        np.testing.assert_equal(self.model.sized_array, [[0, 1, 2, 3], [4, 5, 6, 7]])
+
+        self.model.sized_unsigned_list = [1, 2, 3, 4]
+        np.testing.assert_equal(self.model.sized_unsigned_list, [1, 2, 3, 4])
+
+        with self.assertRaises(ValueError):
+            self.model.sized_unsigned_list = [-1, 2, 3, 4]
+
+        self.model.sized_unsigned_array = [[1, 2, 3, 4], [5, 6, 7, 8]]
+        np.testing.assert_equal(
+            self.model.sized_unsigned_array, [[1, 2, 3, 4], [5, 6, 7, 8]]
+        )
+
+        with self.assertRaises(ValueError):
+            self.model.sized_unsigned_array = [[-1, 2, 3, 4], [5, 6, 7, 8]]
+
+    def test_default(self):
+        np.testing.assert_equal(self.model.sized_list, [0, 0, 0, 0])
+        np.testing.assert_equal(self.model.sized_array, [[0, 0, 0, 0], [0, 0, 0, 0]])
+
+        np.testing.assert_equal(self.model.sized_unsigned_list, [1, 1, 1, 1])
+        np.testing.assert_equal(
+            self.model.sized_unsigned_array, [[1, 1, 1, 1], [1, 1, 1, 1]]
+        )
+
+        # Full default
+        ## List
+        np.testing.assert_equal(
+            self.model.sized_list_full_default, [1, 2, 3, 4]
+        )
+
+        with self.assertRaises(ValueError):
+            class InvalidDefaultSize(Structure):
+                param_1 = SizedList(size=4, default=[1, 2, 3])
+
+        ## Array
+        np.testing.assert_equal(
+            self.model.sized_array_full_default, [[1, 2, 3, 4], [5, 6, 7, 8]]
+        )
+        with self.assertRaises(ValueError):
+            class InvalidDefaultSize(Structure):
+                param_1 = SizedNdArray(
+                    size=(4, 2), default=[[1, 2, 3, 4], [5, 6, 7, 8], [10, 11, 12, 13]]
+                )
+
+        # Invalid range
+        with self.assertRaises(ValueError):
+            class InvalidDefaultRange(Structure):
+                param_1 = SizedUnsignedList(size=4, default=-1)
+
+
+class TestSizedDependent(unittest.TestCase):
+    """Previous test methods for dependently sized parameters."""
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            dep_1 = UnsignedInteger()
+            dep_2 = UnsignedInteger(default=3)
+
+            list_single_dep_param = SizedUnsignedList(
+                size='dep_1', default=1
+            )
+            array_single_dep_param = SizedUnsignedNdArray(
+                size='dep_1', default=1
+            )
+
+            list_double_dep_param = SizedUnsignedList(
+                size=('dep_1', 'dep_2'), default=1
+            )
+            array_double_dep_param = SizedUnsignedNdArray(
+                size=('dep_1', 'dep_2'), default=1
+            )
+
+            list_double_dep_with_int = SizedUnsignedList(
+                size=('dep_1', 2), default=2
+            )
+            array_double_dep_with_int = SizedUnsignedNdArray(
+                size=('dep_1', 2), default=2
+            )
+
+        self.model = Model()
+
+    def test_values(self):
+        # Missing dependency value
+        with self.assertRaises(ValueError):
+            self.model.list_single_dep_param = [2, 2]
+
+        with self.assertRaises(ValueError):
+            self.model.array_single_dep_param = [2, 2]
+
+        self.model.dep_1 = 2
+
+        # Single dependency
+        self.model.list_single_dep_param = [2, 2]
+        np.testing.assert_equal(self.model.list_single_dep_param, [2, 2])
+
+        self.model.array_single_dep_param = [2, 2]
+        np.testing.assert_equal(self.model.array_single_dep_param, [2, 2])
+
+        # Wrong shape
+        with self.assertRaises(ValueError):
+            self.model.list_single_dep_param = [2, 2, 2]
+
+        # Multiple dependencies
+        np.testing.assert_array_equal(
+            self.model.list_double_dep_param, np.ones((6,))
+        )
+        np.testing.assert_array_equal(
+            self.model.array_double_dep_param, np.ones((2, 3))
+        )
+
+        # Size error
+        with self.assertRaises(ValueError):
+            self.model.list_double_dep_param = np.ones((3, 3)).flatten().tolist()
+        with self.assertRaises(ValueError):
+            self.model.array_double_dep_param = np.ones((3, 3))
+
+        # Range error
+        with self.assertRaises(ValueError):
+            self.model.list_double_dep_param = (-1 * np.ones((2, 3))).flatten().tolist()
+        with self.assertRaises(ValueError):
+            self.model.array_double_dep_param = -1 * np.ones((2, 3))
+
+        # Dependencies with integer dimension
+        np.testing.assert_equal(self.model.list_double_dep_with_int, [2, 2, 2, 2])
+        np.testing.assert_equal(self.model.array_double_dep_with_int, [[2, 2], [2, 2]])
+
+    def test_default(self):
+        self.model.dep_1 = 2
+
+        np.testing.assert_equal(self.model.list_single_dep_param, [1, 1])
+        np.testing.assert_equal(self.model.array_single_dep_param, [1, 1])
+
+        # Full default
+        with self.assertRaises(ValueError):
+            class InvalidDefaultSizeList(Structure):
+                dep_1 = UnsignedInteger()
+                param_1 = SizedUnsignedList(size='dep_1', default=[1, 2, 3])
+
+        with self.assertRaises(ValueError):
+            class InvalidDefaultSizeArray(Structure):
+                param_1 = SizedUnsignedNdArray(
+                    size=(4, 'dep_1'), default=[[1, 2, 3, 4], [5, 6, 7, 8]]
+                )
+
+        # Range error
+        with self.assertRaises(ValueError):
+            class InvalidDefault(Structure):
+                list_single_dep_param = SizedUnsignedList(
+                    size='dep_1', default=-1
+                )
+
+
+class TestPolynomial(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            poly_param = Polynomial(n_coeff=2, default=1)
+            ndpoly_param = NdPolynomial(n_entries=2, n_coeff=4, default=1)
+
+            n_coeff = 4
+            poly_param_dep = Polynomial(size=('n_coeff'))
+
+            n_entries = 3
+            ndpoly_param_dep = NdPolynomial(size=('n_entries', 'n_coeff'))
+
+        self.model = Model()
+
+    def test_parameter(self):
+        with self.assertRaises(ValueError):
+            class TestDuplicateCoeffs(Structure):
                 n_coeff = 2
-                faulty = NdPolynomial(dep=('n_coeff'))
+                faulty = Polynomial(n_coeff=2, size=('n_coeff'))
 
         with self.assertRaises(ValueError):
-            class TestDuplicateCoeff(metaclass=StructMeta):
+            class TestMissingEntries(Structure):
+                n_coeff = 2
+                faulty = NdPolynomial(size=('n_coeff'))
+
+        with self.assertRaises(ValueError):
+            class TestDuplicateCoeff(Structure):
                 n_coeff = 2
                 entries = 2
-                faulty = NdPolynomial(n_entries=2, n_coeff=2, dep=('n_coeff'))
+                faulty = NdPolynomial(n_entries=2, n_coeff=2, size=('n_coeff'))
+
+        with self.assertRaises(ValueError):
+            class TestInvalidDefault(Structure):
+                faulty = NdPolynomial(n_entries=2, n_coeff=2, default=1)
+
+    def test_values(self):
+        # Single entry n_coeff
+        self.model.poly_param = 2
+        np.testing.assert_equal(self.model.poly_param, [2, 0])
+
+        self.model.poly_param = [3, 2]
+        np.testing.assert_equal(self.model.poly_param, [3, 2])
+
+        with self.assertRaises(ValueError):
+            self.model.poly_param = [3, 2, 1]
+
+        # Single entry with dependency
+        self.model.n_coeff = 3
+
+        with self.assertRaises(ValueError):
+            self.model.poly_param_dep = [1, 2, 3, 4]
+
+        self.model.poly_param_dep = [1, 2, 3]
+        np.testing.assert_equal(self.model.poly_param_dep, [1, 2, 3])
+
+        self.model.n_coeff = 4
+        self.model.poly_param_dep = [1, 2, 3, 4]
+        np.testing.assert_equal(self.model.poly_param_dep, [1, 2, 3, 4])
+
+        # Multiple entries
+        self.model.ndpoly_param = 2
+        np.testing.assert_equal(
+            self.model.ndpoly_param, [[2, 0, 0, 0], [2, 0, 0, 0]]
+        )
+
+        self.model.ndpoly_param = [3, 2]
+        np.testing.assert_equal(
+            self.model.ndpoly_param, [[3, 0, 0, 0], [2, 0, 0, 0]]
+        )
+
+        self.model.ndpoly_param = [[1, 2], [0, 1, 2]]
+        np.testing.assert_equal(
+            self.model.ndpoly_param, [[1, 2, 0., 0.], [0, 1, 2, 0]]
+        )
+
+        with self.assertRaises(ValueError):
+            self.model.ndpoly_param = [3, 2, 1]
+
+        with self.assertRaises(ValueError):
+            self.model.ndpoly_param = [[1], [1], [1]]
+
+        # Multiple entries with dependency
+        self.model.n_coeff = 3
+
+        with self.assertRaises(ValueError):
+            self.model.ndpoly_param_dep = [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
+
+        self.model.ndpoly_param_dep = 2
+        np.testing.assert_equal(
+            self.model.ndpoly_param_dep, [[2, 0, 0], [2, 0, 0], [2, 0, 0]]
+        )
+        self.model.n_coeff = 4
+
+        self.model.ndpoly_param_dep = [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
+        np.testing.assert_equal(
+            self.model.ndpoly_param_dep, [[1, 2, 3, 4], [1, 2, 3, 4], [1, 2, 3, 4]]
+        )
+
+        self.model.ndpoly_param_dep = [1, 2, 3]
+        np.testing.assert_equal(
+            self.model.ndpoly_param_dep, [[1, 0, 0, 0], [2, 0, 0, 0], [3, 0, 0, 0]]
+        )
+
+        self.model.ndpoly_param_dep = [[1, 2], [0, 1, 2], [0]]
+        np.testing.assert_equal(
+            self.model.ndpoly_param_dep, [[1, 2, 0, 0], [0, 1, 2, 0], [0, 0, 0, 0]]
+        )
+
+        with self.assertRaises(ValueError):
+            self.model.ndpoly_param_dep = [1, 2, 3, 4]
+
+        with self.assertRaises(ValueError):
+            self.model.ndpoly_param_dep = [[1], [1], [1], [1]]
+
+    def test_default(self):
+        np.testing.assert_equal(self.model.poly_param, [1, 0])
+
+        np.testing.assert_equal(self.model.ndpoly_param, None)
+
+
+class TestModulated(unittest.TestCase):
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        class Model(Structure):
+            n_mod = 4
+
+            modulated_list = DependentlyModulatedUnsignedList(size='n_mod')
+
+        self.model = Model()
+
+    def test_value(self):
+        self.model.modulated_list = [1, 2, 3, 4]
+
+        np.testing.assert_equal(self.model.modulated_list, [1, 2, 3, 4])
+
+        with self.assertRaises(ValueError):
+            self.model.modulated_list = [1, 2, 3, 4, 5]
+
+        self.model.n_mod = 5
+        with self.assertRaises(ValueError):
+            self.model.modulated_list
+
+
+class TestDimensionalized(unittest.TestCase):
+    def setUp(self):
+        class Model(Structure):
+            vector = Vector()
+            matrix = Matrix()
+
+        self.model = Model()
+
+    def test_value(self):
+        self.model.vector = [1, 2, 3]
+
+        with self.assertRaises(ValueError):
+            self.model.vector = [[1, 2, 3], [4, 5, 6]]
+
+        with self.assertRaises(ValueError):
+            self.model.matrix = [1, 2]
 
 
 if __name__ == '__main__':

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -453,8 +453,8 @@ class TestPolynomial(unittest.TestCase):
 
     def setUp(self):
         class Model(Structure):
-            poly_param = Polynomial(n_coeff=2, default=1)
-            ndpoly_param = NdPolynomial(n_entries=2, n_coeff=4, default=1)
+            poly_param = Polynomial(n_coeff=2, default=0)
+            ndpoly_param = NdPolynomial(n_entries=2, n_coeff=4)
 
             n_coeff = 4
             poly_param_dep = Polynomial(size=('n_coeff'))
@@ -565,7 +565,15 @@ class TestPolynomial(unittest.TestCase):
             self.model.ndpoly_param_dep = [[1], [1], [1], [1]]
 
     def test_default(self):
-        np.testing.assert_equal(self.model.poly_param, [1, 0])
+        """
+        Currently, only `0` is allowed as default value.
+
+        Notes
+        -----
+        Technically, default values would be possible from point of the NdPolynomial
+        class. However, due to its use as an Event Parameter, this is currently diabled.
+        """
+        np.testing.assert_equal(self.model.poly_param, [0, 0])
 
         np.testing.assert_equal(self.model.ndpoly_param, None)
 

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -80,14 +80,14 @@ solution_3_linear[500:701, 2] = np.linspace(1, 0, 201)
 q_const = np.ones(time.shape)
 
 q_interrupted = TimeLine()
-q_interrupted.add_section(Section(0, 30, 1, n_entries=1, degree=3))
-q_interrupted.add_section(Section(30, 40, 0, n_entries=1, degree=3))
-q_interrupted.add_section(Section(40, 100, 1, n_entries=1, degree=3))
+q_interrupted.add_section(Section(0, 30, [1, 0, 0, 0], is_polynomial=True))
+q_interrupted.add_section(Section(30, 40, [0, 0, 0, 0], is_polynomial=True))
+q_interrupted.add_section(Section(40, 100, [1, 0, 0, 0], is_polynomial=True))
 
 q_linear = TimeLine()
-q_linear.add_section(Section(0, 35, 0, n_entries=1, degree=3))
-q_linear.add_section(Section(35, 45, [0, 1/10], n_entries=1, degree=3))
-q_linear.add_section(Section(45, 100, 0, n_entries=1, degree=3))
+q_linear.add_section(Section(0, 35, [0, 0, 0, 0], is_polynomial=True))
+q_linear.add_section(Section(35, 45, [0, 1/10, 0, 0], is_polynomial=True))
+q_linear.add_section(Section(45, 100, [0, 0, 0, 0], is_polynomial=True))
 
 
 class TestSolution(unittest.TestCase):
@@ -440,6 +440,16 @@ class TestSliceSolution(unittest.TestCase):
         self.solution_species = SolutionIO(
             'simple', comp_2_3_species, time, solution_3_linear,
             q_const
+        )
+
+    def test_coordinates(self):
+        solution = slice_solution(
+            self.solution_gaussian, coordinates={'time': [30, 40]}
+        )
+
+        np.testing.assert_almost_equal(solution.time, np.linspace(30, 40, 101))
+        np.testing.assert_almost_equal(
+            self.solution_gaussian.solution[300:401, ...], solution.solution
         )
 
     def test_components(self):

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -466,7 +466,7 @@ class TestSliceSolution(unittest.TestCase):
         # Test with component that has > 1 species
         solution = slice_solution(self.solution_species, components='B')
         self.assertEqual(solution.component_system.names, ['B'])
-        self.assertEqual(solution.component_system.labels, ['B+', 'B-'])
+        self.assertEqual(solution.component_system.species, ['B+', 'B-'])
 
         np.testing.assert_equal(
             self.solution_species.solution[..., 1:], solution.solution
@@ -477,7 +477,7 @@ class TestSliceSolution(unittest.TestCase):
             self.solution_species, use_total_concentration_components=True
         )
         self.assertEqual(solution.component_system.names, ['A', 'B'])
-        self.assertEqual(solution.component_system.labels, ['A', 'B'])
+        self.assertEqual(solution.component_system.species, ['A', 'B'])
 
         np.testing.assert_equal(
             self.solution_species.solution[..., 0], solution.solution[:, 0]

--- a/tests/test_unit_operation.py
+++ b/tests/test_unit_operation.py
@@ -215,6 +215,8 @@ class Test_Unit_Operation(unittest.TestCase):
             poly_parameters, cstr.polynomial_parameters
         )
 
+        self.assertEqual(cstr.required_parameters, ['V'])
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_unit_operation.py
+++ b/tests/test_unit_operation.py
@@ -192,7 +192,7 @@ class Test_Unit_Operation(unittest.TestCase):
         parameters_expected = {
                 'flow_rate': np.array([1, 0, 0, 0]),
                 'porosity': total_porosity,
-                'flow_rate_filter': np.array([0, 0, 0, 0]),
+                'flow_rate_filter': 0,
                 'c': [0, 0],
                 'q': [],
                 'V': volume,
@@ -201,7 +201,7 @@ class Test_Unit_Operation(unittest.TestCase):
 
         sec_dep_parameters_expected = {
                 'flow_rate': np.array([1, 0, 0, 0]),
-                'flow_rate_filter': np.array([0, 0, 0, 0]),
+                'flow_rate_filter': 0,
         }
         np.testing.assert_equal(
             sec_dep_parameters_expected, cstr.section_dependent_parameters
@@ -209,7 +209,6 @@ class Test_Unit_Operation(unittest.TestCase):
 
         poly_parameters = {
                 'flow_rate': np.array([1, 0, 0, 0]),
-                'flow_rate_filter': np.array([0, 0, 0, 0]),
         }
         np.testing.assert_equal(
             poly_parameters, cstr.polynomial_parameters


### PR DESCRIPTION
Currently, there are several issues with indexing when adding Events and OptimizationVariables.

For `Events`, an `entry_index` can be specified. However, this is ambiguous for ndarrays. Consequently, it is currently not possible to add events that only modify a higher order polynomial coefficient.

For `OptimizationVariables`, there is an option to set a `component_index`, as well as a `polynomial_index`. However, this would then be strongly coupled to the `Process` structure. Also, it does not work when trying to optimize variables that are part of an ndarray (e.g. stoichiometric coefficients of chemical reactions).

This PR addresses these issues.

For this purpose, it was necessary to:
- [x] Overhaul the `dataStructure` module
    - [x] Overhaul the `Descriptor` protocol functionality
    - [x] Overhaul `Structure` base class
- [x] Overhaul `Event` indices
- [x] Overhaul `OptimizationVariable` indices


Open questions:
- [x] What to do when const. coefficient is not reset during process? => Value would continuously rise over consecutive cycles.

Other to-dos
- [x] Check method for duplicate variables in OptimizationProblem
- [x] Check functionality of FractionationOptimization
- [x] Improve docstrings
- [x] Test polynomial OptimizationVariables
