### PR TITLE
Fix missing prop_cycler error

### DIFF
--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -665,9 +665,10 @@ class SolutionIO(SolutionBase):
         local_purity_components = solution.local_purity_components * 100
         local_purity_species = solution.local_purity_species * 100
 
+        colors = iter(plt.rcParams["axes.prop_cycle"].by_key()["color"])
         species_index = 0
         for i, comp in enumerate(solution.component_system.components):
-            color = next(ax._get_lines.prop_cycler)['color']
+            color = next(colors)
             if hide_labels:
                 label = None
             else:


### PR DESCRIPTION
Found a second spot in solution.py that referenced `ax._get_lines.prop_cycler` and replaced it with `plt.rcParams["axes.prop_cycle"].by_key()["color"]`