### PR TITLE
Fix/evaluation objects in objectives

### DIFF
--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -3478,6 +3478,13 @@ class Objective(Structure):
                     f'{self.name}_{i}'
                     for i in range(self.n_metrics)
                 ]
+
+        if len(self.evaluation_objects) > 1:
+            labels = [
+                f"{eval_obj}_{l}"
+                for l in labels
+                for eval_obj in self.evaluation_objects
+            ]
         return labels
 
     @labels.setter
@@ -3569,6 +3576,14 @@ class NonlinearConstraint(Structure):
                     f'{self.name}_{i}'
                     for i in range(self.n_metrics)
                 ]
+
+        if len(self.evaluation_objects) > 1:
+            labels = [
+                f"{eval_obj}_{l}"
+                for l in labels
+                for eval_obj in self.evaluation_objects
+            ]
+
         return labels
 
     @labels.setter
@@ -3761,6 +3776,14 @@ class MetaScore(Structure):
                     f'{self.name}_{i}'
                     for i in range(self.n_metrics)
                 ]
+
+        if len(self.evaluation_objects) > 1:
+            labels = [
+                f"{eval_obj}_{l}"
+                for l in labels
+                for eval_obj in self.evaluation_objects
+            ]
+
         return labels
 
     @labels.setter

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -743,7 +743,7 @@ class OptimizationProblem(Structure):
             requires = [func]
 
         self.set_variables(x)
-        evaluation_objects = self.evaluation_objects
+        evaluation_objects = func.evaluation_objects
 
         if len(evaluation_objects) == 0:
             evaluation_objects = [None]

--- a/docs/source/user_guide/optimization/optimization_problem.md
+++ b/docs/source/user_guide/optimization/optimization_problem.md
@@ -354,7 +354,8 @@ The callback signature may include any of the following arguments:
 Introspection is used to determine which of the signatures above to invoke.
 
 ```{code-cell} ipython3
-def callback(individual, evaluation_object, callbacks_dir):
+def callback(results, individual, evaluation_object, callbacks_dir):
+    print(results)
     print(individual.x, individual.f)
     print(evaluation_object)
     print(callbacks_dir)

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -1270,6 +1270,23 @@ class Test_MultiEvaluationObjects(unittest.TestCase):
 
         np.testing.assert_allclose(f, f_expected)
 
+    def test_names(self):
+        names_expected = ['single_obj_1', 'single_obj_2', 'multi_obj']
+        names = self.optimization_problem.objective_names
+        self.assertEqual(names, names_expected)
+
+    def test_labels(self):
+        labels_expected = [
+            'foo_single_obj_1',
+            'bar_single_obj_1',
+            'single_obj_2',
+            'foo_multi_obj_0',
+            'bar_multi_obj_0',
+            'foo_multi_obj_1',
+            'bar_multi_obj_1'
+        ]
+        labels = self.optimization_problem.objective_labels
+        self.assertEqual(labels, labels_expected)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR addresses two main issues related to OptimizationProblem:

- Ensure that only registered evaluation objects are evaluated when associated with a specific objective function.
- Fix the incorrect labeling of objective functions when multiple evaluation objects are involved.

## Details

- Previously, all evaluation objects added to an OptimizationProblem were evaluated, regardless of whether they were registered to a particular objective function. This PR modifies the behavior to only evaluate the registered evaluation objects.
- The PR also corrects the objective labels returned when multiple evaluation objects are added to an OptimizationProblem.