### PR TITLE
Fix indices for optimization of sized parameters with size==1

### DIFF
--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -784,11 +784,6 @@ def get_inhomogeneous_shape(value):
 
     for i in value:
         i_shape = get_inhomogeneous_shape(i)
-        # if len(i_shape) == 0:
-        #     i_shape = (1, )
-
-        # i_shape = (1, ) + i_shape
-
         shape.append(i_shape)
 
     return shape

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -630,15 +630,18 @@ class MultiTimeLine():
 
 def generate_indices(shape, indices=None):
     """
-    Generate indices for indexing a parameter array from a list of indices.
+    Generate tuples representing indices for an array with a given shape.
+
+    This method allows specifying a list of indices where each entry can also contain
+    slices.
 
     Parameters
     ----------
-    parameter : array_like
-        An array which is to be indexed. Scalar parameters are not supported.
-    indices : array_like
-        A 2D array or list of lists, where each inner list is a set of indices
-        into the 'parameter' array. None can be used in place of a full slice (:).
+    shape : tuple of int
+        The shape of the array to be indexed.
+    indices : list of list of int, optional
+        A list where each sub-list contains indices for one dimension of the array.
+        'None' indicates a full slice (':') for that dimension.
 
     Raises
     ------
@@ -658,9 +661,8 @@ def generate_indices(shape, indices=None):
     >>> generate_indices(parameter, indices)
     [(0, 1), (1, 2)]
     """
-    size = np.prod(shape)
-    if size == 1:
-        raise ValueError("Scalar parameters cannot have index slices.")
+    if not shape:
+        raise ValueError("Shape must not be empty, scalar parameters are not supported.")
 
     if indices is None:
         indices = np.s_[:]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -39,6 +39,7 @@ class TestPerformer(Structure):
     switch = Switch(valid=[-1, 1], default=1)
     sized_tuple = SizedTuple(size=2, default=(1, 1))
     array_1d = SizedList(size=4, default=0)
+    array_1d_single = SizedList(size=1, default=0)
     ndarray = SizedNdArray(size=(2, 4), default=0)
     ndarray_no_default = SizedNdArray(size=(2, 4))
     array_1d_poly = Polynomial(n_coeff=4, default=0)
@@ -50,6 +51,7 @@ class TestPerformer(Structure):
         'sized_tuple',
         'switch',
         'array_1d',
+        'array_1d_single',
         'ndarray',
         'ndarray_no_default',
         'array_1d_poly',
@@ -60,6 +62,7 @@ class TestPerformer(Structure):
         'scalar_float',
         'sized_tuple',
         'array_1d',
+        'array_1d_single',
         'ndarray',
         'ndarray_no_default',
         'array_1d_poly',
@@ -173,6 +176,42 @@ class Test_Events(unittest.TestCase):
         with self.assertRaises(IndexError):
             evt = event_handler.add_event(
                 'param_has_no_indices', 'performer.scalar_float', 1, time=0, indices=1
+            )
+
+    def test_event_array_1d_single(self):
+        """
+        Extra test for array with single entry.
+
+        See also: https://github.com/fau-advanced-separations/CADET-Process/pull/68
+        """
+        event_handler = self.event_handler
+
+        # No index
+        evt = event_handler.add_event('trivial', 'performer.array_1d_single', 1, time=0)
+        self.assertEqual(evt.state, 1)
+        self.assertEqual(evt.full_state, [1])
+        self.assertEqual(evt.n_entries, 1)
+        self.assertEqual(evt.indices, [(slice(None, None, None),)])
+        self.assertEqual(evt.full_indices, [(0,)])
+        self.assertEqual(evt.n_indices, 1)
+        self.assertEqual(event_handler.performer.array_1d_single, [1])
+
+        # Explicit Index
+        evt = event_handler.add_event(
+            'trivial_1', 'performer.array_1d_single', 2, time=0, indices=0
+        )
+        self.assertEqual(evt.state, 2)
+        self.assertEqual(evt.full_state, [2])
+        self.assertEqual(evt.n_entries, 1)
+        self.assertEqual(evt.indices, [(0, )])
+        self.assertEqual(evt.full_indices, [(0,)])
+        self.assertEqual(evt.n_indices, 1)
+        self.assertEqual(event_handler.performer.array_1d_single, [2])
+
+        # Raise Error for exceeding indices
+        with self.assertRaises(IndexError):
+            evt = event_handler.add_event(
+                'param_has_no_indices', 'performer.array_1d_single', 1, time=0, indices=1
             )
 
     def test_event_1D(self):

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -22,6 +22,7 @@ class EvaluationObject(Structure):
     scalar_param = Float(default=1)
     list_param = List()
     sized_list_param = SizedList(size=2, default=[1, 2])
+    sized_list_param_single = SizedList(size=1, default=1)
     sized_list_param_no_default = SizedList(size=2)
     nd_array = SizedNdArray(size=(2, 2))
     polynomial_param = Polynomial(n_coeff=2, default=0)
@@ -33,6 +34,7 @@ class EvaluationObject(Structure):
         'scalar_param',
         'list_param',
         'sized_list_param',
+        'sized_list_param_single',
         'sized_list_param_no_default',
         'nd_array',
         'polynomial_param',
@@ -160,6 +162,44 @@ class Test_OptimizationVariable(unittest.TestCase):
                 evaluation_objects=[self.evaluation_object],
                 parameter_path='uninitialized',
                 indices=2
+            )
+
+    def test_sized_list_single(self):
+        """
+        Extra test for array with single entry.
+
+        See also: https://github.com/fau-advanced-separations/CADET-Process/pull/68
+        """
+        # No indices
+        var = OptimizationVariable(
+            'sized_list_param_single',
+            evaluation_objects=[self.evaluation_object],
+            parameter_path='sized_list_param_single',
+        )
+        np.testing.assert_equal(var.indices, [[(slice(None, None, None),)]])
+        var.value = 1
+        np.testing.assert_equal(var.value, 1)
+        np.testing.assert_equal(self.evaluation_object.sized_list_param_single, [1])
+
+        # Explicit index
+        var = OptimizationVariable(
+            'sized_list_param_single',
+            evaluation_objects=[self.evaluation_object],
+            parameter_path='sized_list_param_single',
+            indices=0,
+        )
+        np.testing.assert_equal(var.indices, [[(0, )]])
+        var.value = 2
+        np.testing.assert_equal(var.value, 2)
+        np.testing.assert_equal(self.evaluation_object.sized_list_param_single, [2])
+
+        # Raise Exception for exceeding index
+        with self.assertRaises(IndexError):
+            var = OptimizationVariable(
+                'sized_list_param_single',
+                evaluation_objects=[self.evaluation_object],
+                parameter_path='sized_list_param_single',
+                indices=1,
             )
 
     def test_nd_array(self):

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -2,7 +2,42 @@ import unittest
 
 import numpy as np
 
+from CADETProcess.dynamicEvents.section import generate_indices
 from CADETProcess.dynamicEvents import Section, TimeLine, MultiTimeLine
+
+
+class TestGenerateIndices(unittest.TestCase):
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def test_generate_indices(self):
+        shape = (3, 3)
+
+        indices = [[0, 1], [1, 2]]
+        indices_tuple_expected = [(0, 1), (1, 2)]
+        indices_tuple = generate_indices(shape, indices)
+        np.testing.assert_equal(indices_tuple, indices_tuple_expected)
+
+        indices = np.s_[:]
+        indices_tuple_expected = [(slice(None, None, None),)]
+        indices_tuple = generate_indices(shape, indices)
+        np.testing.assert_equal(indices_tuple, indices_tuple_expected)
+
+        indices = np.s_[0, :]
+        indices_tuple_expected = [(0, slice(None, None, None))]
+        indices_tuple = generate_indices(shape, indices)
+        np.testing.assert_equal(indices_tuple, indices_tuple_expected)
+
+        indices = [np.s_[0, :], [1, 1]]
+        indices_tuple_expected = [(0, slice(None, None, None)), (1, 1)]
+        indices_tuple = generate_indices(shape, indices)
+        np.testing.assert_equal(indices_tuple, indices_tuple_expected)
+
+        with self.assertRaises(IndexError):
+            _ = generate_indices(shape, indices=[3, 3])
+
+        with self.assertRaises(ValueError):
+            _ = generate_indices((), indices=[[0, 1], [1, 2]])
 
 
 class TestSection(unittest.TestCase):


### PR DESCRIPTION
An issue was reported [on the forum](https://forum.cadet-web.de/t/optimization-error-while-fiting-parameters-to-data/794) where a user tried adding an optimization variable for a sized parameter with a single entry (e.g. when `n_comp == 1`) and an error was raised.

E.g.

```
optimization_problem = OptimizationProblem('fit_param', use_diskcache=False)

optimization_problem.add_evaluation_object(process)

optimization_problem.add_variable(
    name='film_diffusion', 
    parameter_path='flow_sheet.column.film_diffusion',
    indices=0,      # <-- I've tried with and without this
    lb=1e-10, ub=1.0,
    transform='auto'
)

optimization_problem.add_variable(
    name='axial_dispersion', 
    parameter_path='flow_sheet.column.axial_dispersion',
    lb=1e-10, ub=0.1, transform='auto'
)
```

Raises:
```
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
Cell In[14], line 5
      1 optimization_problem = OptimizationProblem('fit_param', use_diskcache=False)
      3 optimization_problem.add_evaluation_object(process)
----> 5 optimization_problem.add_variable(
      6     name='film_diffusion', 
      7     parameter_path='flow_sheet.column.film_diffusion',
      8     indices=0, 
      9     lb=1e-10, ub=1.0,
     10     transform='auto'
     11 )
     13 optimization_problem.add_variable(
     14     name='axial_dispersion', 
     15     parameter_path='flow_sheet.column.axial_dispersion',
     16     lb=1e-10, ub=0.1, transform='auto'
     17 )
     19 # optimization_problem.add_variable(
     20 #     name='isotherm_constant', 
     21 #     parameter_path='flow_sheet.column.binding_model.adsorption_rate',
     22 #     lb=1e-2, ub=10.0,
     23 #     transform='auto'
     24 # )

File ~\miniconda3\envs\cadet\lib\site-packages\CADETProcess\optimization\optimizationProblem.py:347, in OptimizationProblem.add_variable(self, name, evaluation_objects, parameter_path, lb, ub, transform, indices)
    342 if parameter_path is not None and len(evaluation_objects) == 0:
    343     raise ValueError(
    344         "Cannot set parameter_path for variable without evaluation object "
    345     )
--> 347 var = OptimizationVariable(
    348     name, evaluation_objects, parameter_path,
    349     lb=lb, ub=ub, transform=transform,
    350     indices=indices,
    351 )
    353 self._variables.append(var)
    355 with warnings.catch_warnings():

File ~\miniconda3\envs\cadet\lib\site-packages\CADETProcess\optimization\optimizationProblem.py:2962, in OptimizationVariable.__init__(self, name, evaluation_objects, parameter_path, lb, ub, transform, indices, precision)
   2960     self.evaluation_objects = evaluation_objects
   2961     self.parameter_path = parameter_path
-> 2962     self.indices = indices
   2963 else:
   2964     self.evaluation_objects = None

File ~\miniconda3\envs\cadet\lib\site-packages\CADETProcess\optimization\optimizationProblem.py:3169, in OptimizationVariable.indices(self, indices)
   3167     _ = self.indices
   3168 except (ValueError, TypeError) as e:
-> 3169     raise e

File ~\miniconda3\envs\cadet\lib\site-packages\CADETProcess\optimization\optimizationProblem.py:3167, in OptimizationVariable.indices(self, indices)
   3165 # Since indices are constructed on `get`, call the property here:
   3166 try:
-> 3167     _ = self.indices
   3168 except (ValueError, TypeError) as e:
   3169     raise e

File ~\miniconda3\envs\cadet\lib\site-packages\CADETProcess\optimization\optimizationProblem.py:3126, in OptimizationVariable.indices(self)
   3124 parameter_shape = self._get_parameter_shape(eval_obj)
   3125 if isinstance(parameter_shape, tuple):
-> 3126     eval_ind = generate_indices(parameter_shape, eval_ind)
   3127 else:
   3128     if not isinstance(eval_ind, list):

File ~\miniconda3\envs\cadet\lib\site-packages\CADETProcess\dynamicEvents\section.py:663, in generate_indices(shape, indices)
    661 size = np.prod(shape)
    662 if size == 1:
--> 663     raise ValueError("Scalar parameters cannot have index slices.")
    665 if indices is None:
    666     indices = np.s_[:]

ValueError: Scalar parameters cannot have index slices.
```

This PR addresses this issue. For this purpose, @ronald-jaepel created a hotfix which simply removes a check. While this works, it might have unforeseen consequences.

The function [`generate_indices`](https://github.com/fau-advanced-separations/CADET-Process/blob/d45d0d13d153a65be86c6b3b225e785d05411fd4/CADETProcess/dynamicEvents/section.py#L631) is only used internally and generally, size is checked before calling it. However, I'll have to setup some tests to verify this.