### PR TITLE
67 improving flowrate calculation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@ log/
 diskcache_*
 results_*
 *.egg-info
+.vscode

--- a/tests/test_flow_sheet.py
+++ b/tests/test_flow_sheet.py
@@ -11,6 +11,21 @@ from CADETProcess.processModel import FlowSheet
 
 
 def setup_single_cstr_flow_sheet(component_system=None):
+    """
+    Set up a simple `FlowSheet` with a single Continuous Stirred Tank Reactor (CSTR).
+
+    Parameters
+    ----------
+    component_system : ComponentSystem, optional
+        The component system for the CSTR.
+        Defaults to a system with two components if None.
+
+    Returns
+    -------
+    FlowSheet
+        A flow sheet with a single CSTR unit.
+
+    """
     if component_system is None:
         component_system = ComponentSystem(2)
 
@@ -23,6 +38,22 @@ def setup_single_cstr_flow_sheet(component_system=None):
 
 
 def setup_batch_elution_flow_sheet(component_system=None):
+    """
+    Set up a `FlowSheet` for a typical batch elution process.
+
+    Parameters
+    ----------
+    component_system : ComponentSystem, optional
+        The component system for the batch elution process.
+        Defaults to a system with two components if None.
+
+    Returns
+    -------
+    FlowSheet
+        A flow sheet configured for batch elution processes, including feed and eluent
+        inlets, a column, and an outlet.
+
+    """
     if component_system is None:
         component_system = ComponentSystem(2)
 
@@ -46,6 +77,22 @@ def setup_batch_elution_flow_sheet(component_system=None):
 
 
 def setup_ssr_flow_sheet(component_system=None):
+    """
+    Set up a `FlowSheet` for a steady state recycling (SSR) process.
+
+    Parameters
+    ----------
+    component_system : ComponentSystem, optional
+        The component system for the SSR process.
+        Defaults to a system with two components if None.
+
+    Returns
+    -------
+    FlowSheet
+        A flow sheet configured for SSR elution, including feed and eluent inlets, a
+        mixer tank, a column, and an outlet.
+
+    """
     if component_system is None:
         component_system = ComponentSystem(2)
 
@@ -76,7 +123,8 @@ def setup_ssr_flow_sheet(component_system=None):
     return flow_sheet
 
 
-class Test_flow_sheet(unittest.TestCase):
+class TestFlowSheet(unittest.TestCase):
+    """Test general functionatlity of `FlowSheet` class."""
 
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
@@ -490,7 +538,18 @@ class Test_flow_sheet(unittest.TestCase):
                 }
             )
 
+
 class TestCstrFlowRate(unittest.TestCase):
+    """
+    Test `Cstr` behaviour.
+
+    Notes
+    -----
+    When the `flow_rate` parameter of the `Cstr` is not explicitly set, it is treated
+    just like any other `UnitOperation`. I.e., q_in == q_out. In contrast, when a value
+    is set, it has properties similar to an `Inlet`.
+    """
+
     def __init__(self, methodName='runTest'):
         super().__init__(methodName)
 

--- a/tests/test_flow_sheet.py
+++ b/tests/test_flow_sheet.py
@@ -538,6 +538,32 @@ class TestCstrFlowRate(unittest.TestCase):
         cstr_out_expected = [1., 1., 0., 0.]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
+    def test_no_flow(self):
+        self.flow_sheet.inlet.flow_rate = 0
+
+        flow_rates = self.flow_sheet.get_flow_rates()
+
+        cstr_in = flow_rates['cstr']['total_in']
+        cstr_in_expected = [0., 0., 0., 0.]
+        np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
+
+        cstr_out = flow_rates['cstr']['total_out']
+        cstr_out_expected = [0., 0., 0., 0.]
+        np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
+
+        self.flow_sheet.inlet.flow_rate = 0
+        self.flow_sheet.cstr.flow_rate = 0
+
+        flow_rates = self.flow_sheet.get_flow_rates()
+
+        cstr_in = flow_rates['cstr']['total_in']
+        cstr_in_expected = [0., 0., 0., 0.]
+        np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
+
+        cstr_out = flow_rates['cstr']['total_out']
+        cstr_out_expected = [0., 0., 0., 0.]
+        np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
+
     def test_holdup(self):
         self.flow_sheet.inlet.flow_rate = 1
         self.flow_sheet.cstr.flow_rate = 0
@@ -568,6 +594,281 @@ class TestCstrFlowRate(unittest.TestCase):
         cstr_out = flow_rates['cstr']['total_out']
         cstr_out_expected = [2., 2., 0., 0.]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
+
+
+class TestFlowRateMatrix(unittest.TestCase):
+    """Test calculation of flow rates with another simple testcase by @daklauss"""
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        self.component_system = ComponentSystem(1)
+
+        flow_sheet = FlowSheet(self.component_system)
+
+        inlet = Inlet(self.component_system, name='inlet')
+        cstr1 = Cstr(self.component_system, name='cstr1')
+        cstr2 = Cstr(self.component_system, name='cstr2')
+        outlet1 = Outlet(self.component_system, name='outlet1')
+        outlet2 = Outlet(self.component_system, name='outlet2')
+
+        flow_sheet.add_unit(inlet)
+        flow_sheet.add_unit(cstr1)
+        flow_sheet.add_unit(cstr2)
+
+        flow_sheet.add_unit(outlet1)
+        flow_sheet.add_unit(outlet2)
+
+        flow_sheet.add_connection(inlet, cstr1)
+        flow_sheet.add_connection(inlet, cstr2)
+
+        flow_sheet.add_connection(cstr1, outlet1)
+        flow_sheet.add_connection(cstr2, outlet2)
+
+        flow_sheet.add_connection(cstr2, cstr1)
+
+        flow_sheet.set_output_state(inlet, [0.3, 0.7])
+        flow_sheet.set_output_state(cstr2, [0.5, 0.5])
+
+        self.flow_sheet = flow_sheet
+
+    def test_matrix_example(self):
+        self.flow_sheet.inlet.flow_rate = [1]
+
+        expected_flow_rates = {
+            'inlet': {
+                'total_out': (1, 0, 0, 0),
+                'destinations': {
+                    'cstr1': (0.3, 0, 0, 0),
+                    'cstr2': (0.7, 0, 0, 0),
+                },
+            },
+            'cstr1': {
+                'total_in': (0.65, 0, 0, 0),
+                'total_out': (0.65, 0, 0, 0),
+                'origins': {
+                    'inlet': (0.3, 0, 0, 0),
+                    'cstr2': (0.35, 0, 0, 0),
+                },
+                'destinations': {
+                    'outlet1': (0.65, 0, 0, 0),
+                },
+            },
+            'cstr2': {
+                'total_in': (0.7, 0, 0, 0),
+                'total_out': (0.7, 0, 0, 0),
+                'origins': {
+                    'inlet': (0.7, 0, 0, 0),
+                },
+                'destinations': {
+                    'cstr1': (0.35, 0, 0, 0),
+                    'outlet2': (0.35, 0, 0, 0),
+                },
+            },
+            'outlet1': {
+                'origins': {
+                    'cstr1': (0.65, 0, 0, 0),
+                },
+                'total_in': (0.65, 0, 0, 0),
+            },
+
+            'outlet2': {
+                'origins': {
+                    'cstr2': (0.35, 0, 0, 0),
+                },
+                'total_in': (0.35, 0, 0, 0),
+                }
+        }
+
+        calc_flow_rate = self.flow_sheet.get_flow_rates()
+
+        def assert_almost_equal_dict(
+                dict_actual, dict_expected, decimal=7, verbose=True):
+            """Helper function to assert nested dicts are (almost) equal.
+
+            Because of floating point calculations, it is necessary to use
+            `np.assert_almost_equal` to check the flow rates. However, this does not
+            work well with nested dicts which is why this helper function was written.
+
+            Parameters
+            ----------
+            dict_actual : dict
+                The object to check.
+            dict_expected : dict
+                The expected object.
+            decimal : int, optional
+                Desired precision, default is 7.
+            err_msg : str, optional
+                The error message to be printed in case of failure.
+            verbose : bool, optional
+                If True, the conflicting values are appended to the error message.
+
+            """
+            for key in dict_actual:
+                if isinstance(dict_actual[key], dict):
+                    assert_almost_equal_dict(dict_actual[key], dict_expected[key])
+                else:
+                    np.testing.assert_almost_equal(
+                        dict_actual[key], dict_expected[key],
+                        decimal=decimal,
+                        err_msg=f'Dicts are not equal in key {key}.',
+                        verbose=verbose
+                    )
+
+        assert_almost_equal_dict(calc_flow_rate, expected_flow_rates)
+
+
+class TestFlowRateSelfMatrix(unittest.TestCase):
+    """Test special case where one unit is connected to itself."""
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+        self.component_system = ComponentSystem(1)
+
+        flow_sheet = FlowSheet(self.component_system)
+
+        inlet = Inlet(self.component_system, name='inlet')
+        cstr = Cstr(self.component_system, name='cstr')
+        outlet = Outlet(self.component_system, name='outlet')
+
+        flow_sheet.add_unit(inlet)
+        flow_sheet.add_unit(cstr)
+        flow_sheet.add_unit(outlet)
+
+        flow_sheet.add_connection(inlet, cstr)
+        flow_sheet.add_connection(cstr, outlet)
+
+        flow_sheet.add_connection(cstr, cstr)
+
+        flow_sheet.set_output_state(cstr, [0.5, 0.5])
+
+        self.flow_sheet = flow_sheet
+
+    def test_matrix_self_example(self):
+        self.flow_sheet.inlet.flow_rate = [1]
+
+        expected_flow_rates = {
+            'inlet': {
+                'total_out': (1, 0, 0, 0),
+                'destinations': {
+                    'cstr': (1, 0, 0, 0)
+                },
+            },
+            'cstr': {
+                'total_in': (2, 0, 0, 0),
+                'total_out': (2, 0, 0, 0),
+                'origins': {
+                    'inlet': (1, 0, 0, 0),
+                    'cstr': (1, 0, 0, 0),
+                },
+                'destinations': {
+                    'outlet': (1, 0, 0, 0),
+                    'cstr': (1, 0, 0, 0)
+                },
+            },
+            'outlet': {
+                'total_in': (1, 0, 0, 0),
+                'origins': {
+                    'cstr': (1, 0, 0, 0)
+                }
+            }
+        }
+        calc_flow_rate = self.flow_sheet.get_flow_rates()
+        np.testing.assert_equal(calc_flow_rate, expected_flow_rates)
+
+
+class TestSingularFlowMatrix(unittest.TestCase):
+    """Test cases with disconnected flow circles
+
+    Notes
+    -----
+    `FlowSheet`: `Inlet` connected to an `Outlet` and two `Cstr`s connected to each
+    other but not with the other units.
+
+    """
+
+    def __init__(self, methodName='runTest'):
+        super().__init__(methodName)
+
+    def setUp(self):
+
+        self.component_system = ComponentSystem(1)
+
+        flow_sheet = FlowSheet(self.component_system)
+
+        inlet = Inlet(self.component_system, name='inlet')
+        cstr1 = Cstr(self.component_system, name='cstr1')
+        cstr2 = Cstr(self.component_system, name='cstr2')
+        outlet = Outlet(self.component_system, name='outlet')
+
+        flow_sheet.add_unit(inlet)
+        flow_sheet.add_unit(cstr1)
+        flow_sheet.add_unit(cstr2)
+        flow_sheet.add_unit(outlet)
+
+        flow_sheet.add_connection(inlet, outlet)
+
+        flow_sheet.add_connection(cstr1, cstr2)
+        flow_sheet.add_connection(cstr2, cstr1)
+
+        self.flow_sheet = flow_sheet
+
+    def test_expelled_cicuit(self):
+        # Throw error even without flow, because system is singular
+        flow_sheet = self.flow_sheet
+
+        with self.assertRaises(CADETProcessError):
+            flow_sheet.get_flow_rates()
+
+        flow_sheet.inlet.flow_rate = [1]
+
+        with self.assertRaises(CADETProcessError):
+            flow_sheet.get_flow_rates()
+
+    def test_expelled_circuit_with_flow(self):
+        # Solvable because both disconnected circles have their own flow rates
+        expected_flow_rates = {
+            'inlet': {
+                'total_out': (1, 0, 0, 0),
+                'destinations': {
+                    'outlet': (1, 0, 0, 0)
+                },
+            },
+            'cstr1': {
+                'total_in': (1, 0, 0, 0),
+                'total_out': (1, 0, 0, 0),
+                'origins': {
+                    'cstr2': (1, 0, 0, 0),
+                },
+                'destinations': {
+                    'cstr2': (1, 0, 0, 0)
+                },
+            },
+            'cstr2': {
+                'total_in': (1, 0, 0, 0),
+                'total_out': (1, 0, 0, 0),
+                'origins': {
+                    'cstr1': (1, 0, 0, 0),
+                },
+                'destinations': {
+                    'cstr1': (1, 0, 0, 0)
+                },
+            },
+            'outlet': {
+                'total_in': (1, 0, 0, 0),
+                'origins': {
+                    'inlet': (1, 0, 0, 0)
+                }
+            }
+        }
+
+        flow_sheet = self.flow_sheet
+        flow_sheet.inlet.flow_rate = [1]
+        flow_sheet.cstr1.flow_rate = [1]
+
+        np.testing.assert_equal(flow_sheet.get_flow_rates(), expected_flow_rates)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Optimized the calculation of the Flowrates in `get_flow_rates( )`of every unit operations by creating a matrix as described in [https://forum.cadet-web.de/t/improving-the-flowrate-calculation/795](url) and solving it by using numpy.linalg.solve.
Rewrote pretty much the whole function including generation of the return dict.

The former  `solve_flow_rates( )` got removed because it became unnecessary.

Also added a new testcase i used for implementing the new calculation method. 

I was a little bit to greedy with black and pylint ....

PS. i added `.vscode` to `.gitignore` because my vscode created some weird files for testing i didn't want to comit

## TODOS: 
- [x] Review documentation
- [x] Cleanup commits @schmoelder
- [x] Check case where unit is only connected to itself (undefined solution if no given q_out)
  - [x] Add check/raise exception
  - [x] Add testcase  