### PR TITLE
Add support for initial values with linear equality constraints 

### DIFF
--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -2691,6 +2691,13 @@ class OptimizationProblem(Structure):
             simplify=simplify,
         )
 
+        if self.n_linear_equality_constraints > 0:
+            problem = hopsy.add_equality_constraints(
+                problem,
+                self.Aeq,
+                self.beq
+            )
+
         return problem
 
     def create_initial_values(

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -2647,6 +2647,52 @@ class OptimizationProblem(Structure):
         """Prune cache with (intermediate) results."""
         self.cache.prune()
 
+    def create_hopsy_problem(self, simplify=False, use_custom_model=False):
+        """creates a hopsy problem from an optimization problem"""
+
+        class CustomModel():
+            def __init__(self, log_space_indices: list):
+                self.log_space_indices = log_space_indices
+
+            def compute_negative_log_likelihood(self, x):
+                return np.sum(np.log(x[self.log_space_indices]))
+
+        log_space_indices = []
+        for i, var in enumerate(self.variables):
+            if (
+                    isinstance(var._transform, NormLogTransform)
+                    or
+                    (
+                        isinstance(var._transform, AutoTransform) and
+                        var._transform.use_log
+                    )
+            ):
+                log_space_indices.append(i)
+
+        lp = hopsy.LP()
+        lp.reset()
+        lp.settings.thresh = 1e-15
+
+        if len(log_space_indices) and use_custom_model > 0:
+            model = CustomModel(log_space_indices)
+        else:
+            model = None
+
+        problem = hopsy.Problem(
+            self.A,
+            self.b,
+            model,
+        )
+
+        problem = hopsy.add_box_constraints(
+            problem,
+            self.lower_bounds,
+            self.upper_bounds,
+            simplify=simplify,
+        )
+
+        return problem
+
     def create_initial_values(
             self, n_samples=1, method='random', seed=None, burn_in=100000):
         """Create initial value within parameter space.
@@ -2681,50 +2727,12 @@ class OptimizationProblem(Structure):
         """
         burn_in = int(burn_in)
 
-        class CustomModel():
-            def __init__(self, log_space_indices: list):
-                self.log_space_indices = log_space_indices
-
-            def compute_negative_log_likelihood(self, x):
-                return np.sum(np.log(x[self.log_space_indices]))
-
-        log_space_indices = []
-        for i, var in enumerate(self.variables):
-            if (
-                    isinstance(var._transform, NormLogTransform)
-                    or
-                    (
-                        isinstance(var._transform, AutoTransform) and
-                        var._transform.use_log
-                    )
-            ):
-                log_space_indices.append(i)
-
         with warnings.catch_warnings():
             warnings.simplefilter("ignore")
 
-            lp = hopsy.LP()
-            lp.reset()
-            lp.settings.thresh = 1e-15
-
-            if len(log_space_indices) > 0:
-                model = CustomModel(log_space_indices)
-            else:
-                model = None
-
-            problem = hopsy.Problem(
-                self.A,
-                self.b,
-                model,
+            problem = self.create_hopsy_problem(
+                simplify=False, use_custom_model=True
             )
-
-            problem = hopsy.add_box_constraints(
-                problem,
-                self.lower_bounds,
-                self.upper_bounds,
-                simplify=False,
-            )
-
             # !!! Additional checks in place to handle PolyRound.round()
             # removing "small" dimensions.
             # Bug reported, Check for future release!

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -2751,6 +2751,8 @@ class OptimizationProblem(Structure):
                     chebyshev = chebyshev_rounded
                 else:
                     chebyshev = chebyshev_orig
+            else:
+                chebyshev = chebyshev_orig
 
             if n_samples == 1 and method == 'chebyshev':
                 values = np.array(chebyshev_orig, ndmin=2)

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -232,13 +232,7 @@ class OptimizerBase(Structure):
         if reinit_cache:
             self.optimization_problem.setup_cache()
 
-        if x0 is None:
-            if optimization_problem.n_linear_equality_constraints > 0:
-                raise CADETProcessError(
-                    "x0 should be set by the user if linear equality "
-                    "constraints are specified."
-                )
-        else:
+        if x0 is not None:
             x0check = np.array(x0, ndmin=2)
             for x in x0check:
                 if not optimization_problem.check_bounds(x):

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -88,6 +88,10 @@ class PymooInterface(OptimizerBase):
         pop = np.array(pop, ndmin=2)
 
         if len(pop) < pop_size:
+            warnings.warn(
+                "Initial population smaller than popsize. "
+                "Creating missing entries."
+            )
             n_remaining = pop_size - len(pop)
             remaining = optimization_problem.create_initial_values(
                 n_remaining, method='chebyshev', seed=self.seed,

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,7 +26,7 @@ install_requires =
     pathos>=0.2.8
     addict==2.3
     cadet-python>=0.14
-    hopsy>=1.3.0
+    hopsy>=1.4.0
     pymoo>=0.6
     numba>=0.55.1
     diskcache>=5.4.0


### PR DESCRIPTION
For optimization problems with linear equality constraints, initial values currently need to be specified manually. Since [v1.4.0](https://github.com/modsim/hopsy/blob/main/CHANGELOG.md), hopsy also supports linear equality constraints. This PR integrates this new feature into CADET-Process.

## Todo:
- [x] Add individual method to setup hopsy problem
- [x] Add linear equality constraints to hopsy problem
- [x] Remove checks
- [x] Add tests