### PR TITLE
Fix bad initial value for Yamamoto method

### DIFF
--- a/CADETProcess/tools/yamamoto.py
+++ b/CADETProcess/tools/yamamoto.py
@@ -255,7 +255,7 @@ def _fit_yamamoto(log_c_salt_at_max_M, log_gradient_slope, lambda_):
         return yamamoto_equation(c_s, lambda_, nu, k_eq)
 
     results, pcov = curve_fit(
-        yamamoto_wrapper, log_c_salt_at_max_M, log_gradient_slope, bounds=bounds
+        yamamoto_wrapper, log_c_salt_at_max_M, log_gradient_slope, bounds=bounds, p0=(1, 1)
     )
 
     return results


### PR DESCRIPTION
Change initial value from the automatic middle of the boundary space (500 & 500) to (1, 1), as an initial value of 500 can lead to numerical errors.

Also adapted yamamoto.py to PEP8.