### PR TITLE
Improve preprocessing time

### DIFF
--- a/CADETProcess/dynamicEvents/event.py
+++ b/CADETProcess/dynamicEvents/event.py
@@ -94,7 +94,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         self._durations = []
         self._lock = False
 
-    @property
+    @cached_property_if_locked
     def events(self):
         """list: All Events ordered by event time.
 
@@ -109,7 +109,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         """
         return sorted(self._events, key=lambda evt: evt.time)
 
-    @property
+    @cached_property_if_locked
     def events_dict(self):
         """dict: Events and Durations orderd by name."""
         evts = {evt.name: evt for evt in self.events}
@@ -276,7 +276,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         self._durations.remove(dur)
         self.__dict__.pop(duration_name)
 
-    @property
+    @cached_property_if_locked
     def durations(self):
         """List of all durations in the process."""
         return self._durations
@@ -392,29 +392,29 @@ class EventHandler(CachedPropertiesMixin, Structure):
         for indep in independent_events:
             self.events[dependent_event].remove_dependency(indep)
 
-    @property
+    @cached_property_if_locked
     def independent_events(self):
         """list: All events that are not dependent on other events."""
         return list(filter(lambda evt: evt.is_independent, self.events))
 
-    @property
+    @cached_property_if_locked
     def dependent_events(self):
         """list: All events that are dependent on other events."""
         return list(
             filter(lambda evt: evt.is_independent is False, self.events)
         )
 
-    @property
+    @cached_property_if_locked
     def event_parameters(self):
         """list: Event parameters."""
         return list({evt.parameter_path for evt in self.events})
 
-    @property
+    @cached_property_if_locked
     def event_performers(self):
         """list: Event peformers."""
         return list({evt.performer for evt in self.events})
 
-    @property
+    @cached_property_if_locked
     def event_times(self):
         """list: Time of events, sorted by Event time."""
         event_times = list({evt.time for evt in self.events})
@@ -422,7 +422,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
 
         return event_times
 
-    @property
+    @cached_property_if_locked
     def section_times(self):
         """list: Section times.
 

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -140,12 +140,9 @@ class CarouselBuilder(Structure):
 
                 flow_sheet.add_connection(origin, destination)
 
-        flow_rates = self.flow_sheet.get_flow_rates()
         for zone in self.zones:
             output_state = self.flow_sheet.output_states[zone]
             flow_sheet.set_output_state(zone.outlet_unit, output_state)
-
-            zone_flow_flow_rate = flow_rates[zone.name].total_out
 
     def _add_intra_zone_connections(self, flow_sheet):
         """Add connections within zones."""


### PR DESCRIPTION
As mentioned in #75, pre-processing can take a long time, especially for complex systems with many units and parameters. In this PR, we try to address some of the issues.

## Options
- [x] Improve flow rate calculations (see #67/#71)
- [x] Cache more properties
- [x] Avoid unnecessary checks (e66ec1b)
- [ ] From previous experience: locked properties can cause side effects. Need more thorough tests & thoughts
- [ ] Need feedback from Dennis

Consider further profiling to identify current bottlenecks and consider architecture changes that further speed this up