### PR TITLE
Fix calculation of conversion rates for MSSMA model

### DIFF
--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -697,7 +697,7 @@ class MultistateStericMassAction(BindingBaseClass):
     @property
     def _conversion_entries(self):
         n = 0
-        for state in self.bound_states[1:]:
+        for state in self.bound_states:
             n += state**2
 
         return n


### PR DESCRIPTION
As referenced [here](https://forum.cadet-web.de/t/reference-simulation-for-multi-state-sma/818/8), the number of conversion rate entries should include all components.