### PR TITLE
Fix callbacks with dependencies

### DIFF
--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -1585,7 +1585,7 @@ class OptimizationProblem(Structure):
             callback._current_iteration = current_iteration
 
             try:
-                self._evaluate(ind.x, callback, force)
+                self._evaluate(ind.x_transformed, callback, force, untransform=True)
             except CADETProcessError:
                 self.logger.warning(
                     f'Evaluation of {callback} failed at {ind.x}.'


### PR DESCRIPTION
As discussed [here](https://forum.cadet-web.de/t/callbacks-while-having-dependent-variables/844/4). 
Untransform x when evaluating callbacks.