### PR TITLE
Improve handling of initial values

### DIFF
--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -577,7 +577,7 @@ class OptimizationProblem(Structure):
         """
         if len(x) != self.n_variables:
             raise CADETProcessError(
-                f'Expected {self.n_variables} value(s)'
+                f'Expected {self.n_variables} value(s), got {len(x)}'
             )
 
         x_independent = []
@@ -2555,21 +2555,21 @@ class OptimizationProblem(Structure):
 
         return flag
 
-    def transform(self, x):
-        """Transform the optimization variables from untransformed parameter space.
+    def transform(self, x_independent):
+        """Transform the independent optimization variables from untransformed parameter space.
 
         Parameters
         ----------
-        x : list
-            Value of the optimization variables in untransformed space.
+        x_independent : list
+            Value of the independent optimization variables in untransformed space.
 
         Returns
         -------
         list
             Optimization variables in transformed parameter space.
         """
-        x = np.array(x)
-        x_2d = np.array(x, ndmin=2)
+        x_independent = np.array(x_independent)
+        x_2d = np.array(x_independent, ndmin=2)
         transform = np.zeros(x_2d.shape)
 
         for i, ind in enumerate(x_2d):
@@ -2578,7 +2578,7 @@ class OptimizationProblem(Structure):
                 for value, var in zip(ind, self.independent_variables)
             ]
 
-        return transform.reshape(x.shape).tolist()
+        return transform.reshape(x_independent.shape).tolist()
 
     def untransform(self, x_transformed):
         """Untransform the optimization variables from transformed parameter space.
@@ -2716,7 +2716,7 @@ class OptimizationProblem(Structure):
             random: Any random valid point in the parameter space.
         seed : int, optional
             Seed to initialize random numbers. Only used if method == 'random'
-        burn_in: int, optional
+        burn_in : int, optional
             Number of samples that are created to ensure uniform sampling.
             The actual initial values are then drawn from this set.
             The default is 100000.

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -2837,11 +2837,7 @@ class OptimizationProblem(Structure):
 
             ind = self.get_dependent_values(ind)
 
-            if not self.check_bounds(ind):
-                continue
-            if not self.check_linear_constraints(ind):
-                continue
-            if not self.check_linear_equality_constraints(ind):
+            if not self.check_individual(ind, silent=True):
                 continue
 
             if not include_dependent_variables:
@@ -2953,6 +2949,39 @@ class OptimizationProblem(Structure):
 
             if not self.check_linear_constraints_dependency():
                 flag = False
+
+        return flag
+
+    @untransforms
+    @gets_dependent_values
+    def check_individual(self, x, silent=False):
+        """Check if individual is valid.
+
+        Parameters
+        ----------
+        x : list
+            Value of the optimization variables in untransformed space.
+
+        Returns
+        -------
+        bool
+            True if the individual is valid correctly, False otherwise.
+
+        """
+        flag = True
+
+        if not self.check_bounds(x):
+            if not silent:
+                warnings.warn("Individual does not satisfy bounds.")
+            flag = False
+        if not self.check_linear_constraints(x):
+            if not silent:
+                warnings.warn("Individual does not satisfy linear constraints.")
+            flag = False
+        if not self.check_linear_equality_constraints(x):
+            if not silent:
+                warnings.warn("Individual does not satisfy linear equality constraints.")
+            flag = False
 
         return flag
 

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -1585,7 +1585,7 @@ class OptimizationProblem(Structure):
             callback._current_iteration = current_iteration
 
             try:
-                self._evaluate(ind.x, callback, force)
+                self._evaluate(ind.x_transformed, callback, force, untransform=True)
             except CADETProcessError:
                 self.logger.warning(
                     f'Evaluation of {callback} failed at {ind.x}.'

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -56,7 +56,7 @@ class PymooInterface(OptimizerBase):
         optimization_problem : OptimizationProblem
             DESCRIPTION.
         x0 : list, optional
-            Initial population
+            Initial population of independent variables in untransformed space.
 
         Returns
         -------

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -284,17 +284,12 @@ class RepairIndividuals(Repair):
         # Check if linear (equality) constraints are met
         X_new = None
         for i, ind in enumerate(X):
-            if (
-                    not self.optimization_problem.check_linear_constraints(
-                        ind, untransform=True, get_dependent_values=True
-                    )
-                    or
-                    not self.optimization_problem.check_linear_equality_constraints(
-                        ind, untransform=True, get_dependent_values=True
-                    )
-            ):
+            if not self.optimization_problem.check_individual(
+                    ind, untransform=True, get_dependent_values=True):
                 if X_new is None:
-                    X_new = self.optimization_problem.create_initial_values(len(X), include_dependent_variables=False)
+                    X_new = self.optimization_problem.create_initial_values(
+                        len(X), include_dependent_variables=False
+                    )
                 x_new = X_new[i, :]
                 X[i, :] = self.optimization_problem.transform(x_new)
 

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -73,29 +73,10 @@ class PymooInterface(OptimizerBase):
         pop_size = self.get_population_size(optimization_problem)
 
         if x0 is not None:
-            x0 = np.array(x0, ndmin=2)
-
-            n_dependent_variables = optimization_problem.n_dependent_variables
-            n_independent_variables = optimization_problem.n_independent_variables
-            n_variables = n_dependent_variables + n_independent_variables
-
-            if x0.shape[1] != n_variables and x0.shape[1] != n_independent_variables:
-                raise ValueError(
-                    f"x0 for optimization problem is expected to be of length "
-                    f"{n_independent_variables} or"
-                    f"{n_variables}. Got {x0.shape[1]}"
-                )
-
-            if n_dependent_variables > 0 and x0.shape[1] == n_variables:
-                x0 = [optimization_problem.get_independent_values(ind) for ind in x0]
-                warnings.warn(
-                    "x0 contains dependent values. Will recompute dependencies for consistency."
-                )
-
             pop = x0
         else:
             pop = optimization_problem.create_initial_values(
-                pop_size, seed=self.seed, include_dependent_variables=True
+                pop_size, seed=self.seed, include_dependent_variables=False
             )
 
         pop = np.array(pop, ndmin=2)
@@ -107,7 +88,7 @@ class PymooInterface(OptimizerBase):
             )
             n_remaining = pop_size - len(pop)
             remaining = optimization_problem.create_initial_values(
-                n_remaining, seed=self.seed, include_dependent_variables=True
+                n_remaining, seed=self.seed, include_dependent_variables=False
             )
             pop = np.vstack((pop, remaining))
         elif len(pop) > pop_size:

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -73,6 +73,25 @@ class PymooInterface(OptimizerBase):
         pop_size = self.get_population_size(optimization_problem)
 
         if x0 is not None:
+            x0 = np.array(x0, ndmin=2)
+
+            n_dependent_variables = optimization_problem.n_dependent_variables
+            n_independent_variables = optimization_problem.n_independent_variables
+            n_variables = n_dependent_variables + n_independent_variables
+
+            if x0.shape[1] != n_variables and x0.shape[1] != n_independent_variables:
+                raise ValueError(
+                    f"x0 for optimization problem is expected to be of length "
+                    f"{n_independent_variables} or"
+                    f"{n_variables}. Got {x0.shape[1]}"
+                )
+
+            if n_dependent_variables > 0 and x0.shape[1] == n_variables:
+                x0 = [optimization_problem.get_independent_values(ind) for ind in x0]
+                warnings.warn(
+                    "x0 contains dependent values. Will recompute dependencies for consistency."
+                )
+
             pop = x0
         else:
             pop = optimization_problem.create_initial_values(

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -95,7 +95,7 @@ class PymooInterface(OptimizerBase):
             pop = x0
         else:
             pop = optimization_problem.create_initial_values(
-                pop_size, method='chebyshev', seed=self.seed, include_dependent_variables=True
+                pop_size, seed=self.seed, include_dependent_variables=True
             )
 
         pop = np.array(pop, ndmin=2)
@@ -107,7 +107,7 @@ class PymooInterface(OptimizerBase):
             )
             n_remaining = pop_size - len(pop)
             remaining = optimization_problem.create_initial_values(
-                n_remaining, method='chebyshev', seed=self.seed, include_dependent_variables=True
+                n_remaining, seed=self.seed, include_dependent_variables=True
             )
             pop = np.vstack((pop, remaining))
         elif len(pop) > pop_size:

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -95,7 +95,7 @@ class PymooInterface(OptimizerBase):
             pop = x0
         else:
             pop = optimization_problem.create_initial_values(
-                pop_size, method='chebyshev', seed=self.seed
+                pop_size, method='chebyshev', seed=self.seed, include_dependent_variables=True
             )
 
         pop = np.array(pop, ndmin=2)
@@ -107,7 +107,7 @@ class PymooInterface(OptimizerBase):
             )
             n_remaining = pop_size - len(pop)
             remaining = optimization_problem.create_initial_values(
-                n_remaining, method='chebyshev', seed=self.seed
+                n_remaining, method='chebyshev', seed=self.seed, include_dependent_variables=True
             )
             pop = np.vstack((pop, remaining))
         elif len(pop) > pop_size:
@@ -294,7 +294,7 @@ class RepairIndividuals(Repair):
                     )
             ):
                 if X_new is None:
-                    X_new = self.optimization_problem.create_initial_values(len(X))
+                    X_new = self.optimization_problem.create_initial_values(len(X), include_dependent_variables=False)
                 x_new = X_new[i, :]
                 X[i, :] = self.optimization_problem.transform(x_new)
 

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -72,17 +72,11 @@ class PymooInterface(OptimizerBase):
         """
         pop_size = self.get_population_size(optimization_problem)
 
-        # equality constraints make it more difficult to find feasible samples
-        # in the parameter space. Therefore increase burnin
-        # this gets very expensive with lots of constraints
-        burn_in = 1e5 * 10 ** optimization_problem.n_linear_equality_constraints
-
         if x0 is not None:
             pop = x0
         else:
             pop = optimization_problem.create_initial_values(
-                pop_size, method='chebyshev', seed=self.seed,
-                burn_in=burn_in
+                pop_size, method='chebyshev', seed=self.seed
             )
 
         pop = np.array(pop, ndmin=2)
@@ -94,8 +88,7 @@ class PymooInterface(OptimizerBase):
             )
             n_remaining = pop_size - len(pop)
             remaining = optimization_problem.create_initial_values(
-                n_remaining, method='chebyshev', seed=self.seed,
-                burn_in=burn_in
+                n_remaining, method='chebyshev', seed=self.seed
             )
             pop = np.vstack((pop, remaining))
         elif len(pop) > pop_size:
@@ -282,8 +275,7 @@ class RepairIndividuals(Repair):
                     )
             ):
                 if X_new is None:
-                    burn_in = 1e5 * 10 ** self.optimization_problem.n_linear_equality_constraints
-                    X_new = self.optimization_problem.create_initial_values(len(X), burn_in)
+                    X_new = self.optimization_problem.create_initial_values(len(X))
                 x_new = X_new[i, :]
                 X[i, :] = self.optimization_problem.transform(x_new)
 

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -59,7 +59,7 @@ class SciPyInterface(OptimizerBase):
             Optimization results including optimization_problem and solver
             configuration.
         x0 : list, optional
-            Initial values.
+            Initial values of independent variables in untransformed space.
 
         See Also
         --------

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -108,7 +108,7 @@ class SciPyInterface(OptimizerBase):
 
         if x0 is None:
             x0 = optimization_problem.create_initial_values(
-                1, method='chebyshev', include_dependent_variables=False
+                1, include_dependent_variables=False
             )[0]
 
         x0_transformed = optimization_problem.transform(x0)

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -107,7 +107,9 @@ class SciPyInterface(OptimizerBase):
             return False
 
         if x0 is None:
-            x0 = optimization_problem.create_initial_values(1, method='chebyshev')[0]
+            x0 = optimization_problem.create_initial_values(
+                1, method='chebyshev', include_dependent_variables=False
+            )[0]
 
         x0_transformed = optimization_problem.transform(x0)
 

--- a/docs/source/user_guide/optimization/optimization_problem.md
+++ b/docs/source/user_guide/optimization/optimization_problem.md
@@ -313,7 +313,7 @@ optimization_problem.create_initial_values()
 Alternatively, the Chebyshev center of the polytope can be computed, which is the center of the largest Euclidean ball that is fully contained within that polytope.
 
 ```{code-cell} ipython3
-optimization_problem.create_initial_values(method='chebyshev')
+optimization_problem.get_chebyshev_center()
 ```
 
 It is also possible to generate multiple samples at once.

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -850,10 +850,10 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         variables = self.optimization_problem.variable_names
         self.assertEqual(variables_expected, variables)
 
-    def test_initial_values(self):
+    def test_initial_values_without_dependencies(self):
         x0_chebyshev_expected = [[0.79289322, 0.20710678, 0.5]]
         x0_chebyshev = self.optimization_problem.create_initial_values(
-            1, method='chebyshev'
+            1, method='chebyshev', include_dependent_variables=False
         )
         np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
 
@@ -879,12 +879,12 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
 
         x0_seed_1_expected = [[0.7311044, 0.1727515, 0.1822629]]
         x0_seed_1 = self.optimization_problem.create_initial_values(
-            1, method='random', seed=1
+            1, method='random', seed=1, include_dependent_variables=False
         )
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(
-            1, method='random'
+            1, method='random', include_dependent_variables=False
         )
 
         with self.assertRaises(AssertionError):
@@ -906,12 +906,79 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
             [0.8359314486227345, 0.39493879515319996, 0.8128182754300088]
         ]
         x0_seed_10 = self.optimization_problem.create_initial_values(
-            10, method='random', seed=1
+            10, method='random', seed=1, include_dependent_variables=False
         )
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, method='random'
+            10, method='random', include_dependent_variables=False
+        )
+
+        with self.assertRaises(AssertionError):
+            np.testing.assert_almost_equal(x0_seed_10_random, x0_seed_10_expected)
+
+    def test_initial_values(self):
+        x0_chebyshev_expected = [[0.79289322, 0.20710678, 0.2071068, 0.5]]
+        x0_chebyshev = self.optimization_problem.create_initial_values(
+            1, method='chebyshev', include_dependent_variables=True
+        )
+        np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
+
+        variables_expected = [
+            0.7928932188134523,
+            0.2071067811865475,
+            0.2071067811865475,
+            0.4999999999999999
+        ]
+        variables = self.optimization_problem.get_dependent_values(
+            x0_chebyshev[0, [0, 1, 3]]
+        )
+        np.testing.assert_almost_equal(variables, variables_expected)
+
+        self.assertTrue(
+            self.optimization_problem.check_linear_constraints(
+                x0_chebyshev[0, :], get_dependent_values=False
+            )
+        )
+        self.assertTrue(
+            self.optimization_problem.check_linear_constraints(variables)
+        )
+
+        x0_seed_1_expected = [[0.7311044, 0.1727515, 0.1727515, 0.1822629]]
+        x0_seed_1 = self.optimization_problem.create_initial_values(
+            1, method='random', seed=1, include_dependent_variables=True
+        )
+        np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
+
+        x0_seed_1_random = self.optimization_problem.create_initial_values(
+            1, method='random', include_dependent_variables=True
+        )
+
+        with self.assertRaises(AssertionError):
+            np.testing.assert_almost_equal(x0_seed_1_random, x0_seed_1_expected)
+
+        with self.assertRaises(AssertionError):
+            np.testing.assert_almost_equal(x0_seed_1_random, x0_chebyshev_expected)
+
+        x0_seed_10_expected = [
+            [0.7311043824888657, 0.1727515432673712, 0.1727515432673712, 0.18226293643057073],
+            [0.9836918383919191, 0.8152389217047241, 0.8152389217047241, 0.8560016844195478],
+            [0.7358144798470049, 0.2574714423019172, 0.2574714423019172, 0.49387609464567295],
+            [0.34919171897183954, 0.05751800197656948, 0.05751800197656948, 0.3237260675631758],
+            [0.9265061673265441, 0.4857572549618687, 0.4857572549618687, 0.8149444448089398],
+            [0.9065669851023331, 0.1513817591204391, 0.1513817591204391, 0.7710992332649812],
+            [0.8864554240066591, 0.4771068979697068, 0.4771068979697068, 0.5603893963194555],
+            [0.6845940550232432, 0.2843172686185149, 0.2843172686185149, 0.6792904559788712],
+            [0.923735889273789, 0.6890814170651027, 0.6890814170651027, 0.7366940211809302],
+            [0.8359314486227345, 0.39493879515319996, 0.39493879515319996, 0.8128182754300088]
+        ]
+        x0_seed_10 = self.optimization_problem.create_initial_values(
+            10, method='random', seed=1, include_dependent_variables=True
+        )
+        np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
+
+        x0_seed_10_random = self.optimization_problem.create_initial_values(
+            10, method='random', include_dependent_variables=True
         )
 
         with self.assertRaises(AssertionError):

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -737,21 +737,19 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
             self.optimization_problem.add_linear_constraint('var_0', [])
 
     def test_initial_values(self):
-        x0_chebyshev_expected = [[0.2928932, 0.7071068]]
-        x0_chebyshev = self.optimization_problem.create_initial_values(
-            1, method='chebyshev'
+        x0_chebyshev_expected = [0.2928932, 0.7071068]
+        x0_chebyshev = self.optimization_problem.get_chebyshev_center(
+            include_dependent_variables=True
         )
         np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
 
         x0_seed_1_expected = [[0.5666524, 0.8499365]]
         x0_seed_1 = self.optimization_problem.create_initial_values(
-            1, method='random', seed=1
+            1, seed=1
         )
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
-        x0_seed_1_random = self.optimization_problem.create_initial_values(
-            1, method='random'
-        )
+        x0_seed_1_random = self.optimization_problem.create_initial_values(1)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_1_random, x0_seed_1_expected)
@@ -772,13 +770,11 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
             [0.5365699848069944, 0.6516012021958184]
         ]
         x0_seed_10 = self.optimization_problem.create_initial_values(
-            10, method='random', seed=1
+            10, seed=1
         )
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
-        x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, method='random'
-        )
+        x0_seed_10_random = self.optimization_problem.create_initial_values(10)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_10_random, x0_seed_10_expected)
@@ -851,9 +847,9 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         self.assertEqual(variables_expected, variables)
 
     def test_initial_values_without_dependencies(self):
-        x0_chebyshev_expected = [[0.79289322, 0.20710678, 0.5]]
-        x0_chebyshev = self.optimization_problem.create_initial_values(
-            1, method='chebyshev', include_dependent_variables=False
+        x0_chebyshev_expected = [0.79289322, 0.20710678, 0.5]
+        x0_chebyshev = self.optimization_problem.get_chebyshev_center(
+            include_dependent_variables=False
         )
         np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
 
@@ -864,13 +860,13 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
             0.4999999999999999
         ]
         variables = self.optimization_problem.get_dependent_values(
-            x0_chebyshev[0, :]
+            x0_chebyshev
         )
         np.testing.assert_almost_equal(variables, variables_expected)
 
         self.assertTrue(
             self.optimization_problem.check_linear_constraints(
-                x0_chebyshev[0, :], get_dependent_values=True
+                x0_chebyshev, get_dependent_values=True
             )
         )
         self.assertTrue(
@@ -879,12 +875,12 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
 
         x0_seed_1_expected = [[0.7311044, 0.1727515, 0.1822629]]
         x0_seed_1 = self.optimization_problem.create_initial_values(
-            1, method='random', seed=1, include_dependent_variables=False
+            1, seed=1, include_dependent_variables=False
         )
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(
-            1, method='random', include_dependent_variables=False
+            1, include_dependent_variables=False
         )
 
         with self.assertRaises(AssertionError):
@@ -906,52 +902,52 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
             [0.8359314486227345, 0.39493879515319996, 0.8128182754300088]
         ]
         x0_seed_10 = self.optimization_problem.create_initial_values(
-            10, method='random', seed=1, include_dependent_variables=False
+            10, seed=1, include_dependent_variables=False
         )
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, method='random', include_dependent_variables=False
+            10, include_dependent_variables=False
         )
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_10_random, x0_seed_10_expected)
 
     def test_initial_values(self):
-        x0_chebyshev_expected = [[0.79289322, 0.20710678, 0.2071068, 0.5]]
-        x0_chebyshev = self.optimization_problem.create_initial_values(
-            1, method='chebyshev', include_dependent_variables=True
+        x0_chebyshev_expected = [0.79289322, 0.20710678, 0.2071068, 0.5]
+        x0_chebyshev = self.optimization_problem.get_chebyshev_center(
+            include_dependent_variables=True
         )
+
         np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
 
-        variables_expected = [
+        independent_variables_expected = [
             0.7928932188134523,
-            0.2071067811865475,
             0.2071067811865475,
             0.4999999999999999
         ]
-        variables = self.optimization_problem.get_dependent_values(
-            x0_chebyshev[0, [0, 1, 3]]
+        independent_variables = self.optimization_problem.get_independent_values(
+            x0_chebyshev
         )
-        np.testing.assert_almost_equal(variables, variables_expected)
+        np.testing.assert_almost_equal(independent_variables, independent_variables_expected)
 
         self.assertTrue(
             self.optimization_problem.check_linear_constraints(
-                x0_chebyshev[0, :], get_dependent_values=False
+                x0_chebyshev, get_dependent_values=False
             )
         )
         self.assertTrue(
-            self.optimization_problem.check_linear_constraints(variables)
+            self.optimization_problem.check_linear_constraints(x0_chebyshev)
         )
 
         x0_seed_1_expected = [[0.7311044, 0.1727515, 0.1727515, 0.1822629]]
         x0_seed_1 = self.optimization_problem.create_initial_values(
-            1, method='random', seed=1, include_dependent_variables=True
+            1, seed=1, include_dependent_variables=True
         )
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(
-            1, method='random', include_dependent_variables=True
+            1, include_dependent_variables=True
         )
 
         with self.assertRaises(AssertionError):
@@ -973,12 +969,12 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
             [0.8359314486227345, 0.39493879515319996, 0.39493879515319996, 0.8128182754300088]
         ]
         x0_seed_10 = self.optimization_problem.create_initial_values(
-            10, method='random', seed=1, include_dependent_variables=True
+            10, seed=1, include_dependent_variables=True
         )
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, method='random', include_dependent_variables=True
+            10, include_dependent_variables=True
         )
 
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
Solve inconsistencies if x0 includes dependent variables. 

Now: 
x0 expects only independents in untransformed space. Will recompute dependents with warning if provided. 
`optimization_problem.create_initial_values()` has optional flag `include_dependent_variables=True` to return dependent variables.

ToDos:
- [x] move chebychev to own method
- [x] migrate checks for x0 from pymoo adapter to optimizer.optimize
- [x] add more tests for initial values with dependencies in testing suite
- [x] Check documentation (especially where `create_initial_values` is used)