### PR TITLE
Add fractionation metric

### DIFF
--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -84,7 +84,7 @@ class Comparator(Structure):
         return self._metrics
 
     @property
-    def n_diffference_metrics(self):
+    def n_difference_metrics(self):
         """int: Number of difference metrics in the Comparator."""
         return len(self.metrics)
 
@@ -242,11 +242,11 @@ class Comparator(Structure):
         tuple
             A tuple of the comparison figure(s) and axes object(s).
         """
-        if self.n_diffference_metrics == 0:
+        if self.n_difference_metrics == 0:
             return (None, None)
 
         comparison_fig_all, comparison_axs_all = plotting.setup_figure(
-            n_rows=self.n_diffference_metrics,
+            n_rows=self.n_difference_metrics,
             squeeze=False
         )
 
@@ -255,7 +255,7 @@ class Comparator(Structure):
 
         comparison_fig_ind: list[Figure] = []
         comparison_axs_ind: list[Axes] = []
-        for i in range(self.n_diffference_metrics):
+        for i in range(self.n_difference_metrics):
             fig, axs = plt.subplots()
             comparison_fig_ind.append(fig)
             comparison_axs_ind.append(axs)

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -231,11 +231,12 @@ class DifferenceBase(MetricBase):
         @wraps(func)
         def wrapper(self, solution, *args, **kwargs):
             solution = copy.deepcopy(solution)
-            solution.resample(
-                self._reference.time[0],
-                self._reference.time[-1],
-                len(self._reference.time),
-            )
+            if self.resample:
+                solution.resample(
+                    self._reference.time[0],
+                    self._reference.time[-1],
+                    len(self._reference.time),
+                )
             if self.normalize and not solution.is_normalized:
                 solution.normalize()
             if self.smooth and not solution.is_smoothed:

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -109,6 +109,7 @@ class DifferenceBase(MetricBase):
             start=None,
             end=None,
             transform=None,
+            only_transforms_array=True,
             resample=True,
             smooth=False,
             normalize=False):
@@ -131,6 +132,8 @@ class DifferenceBase(MetricBase):
             End time of solution slice to be considerd. The default is None.
         transform : callable, optional
             Function to transform solution. The default is None.
+        only_transforms_array: bool, optional
+            If True, only transform np array of solution object. The default is True.
         resample : bool, optional
             If True, resample data. The default is True.
         smooth : bool, optional
@@ -146,6 +149,7 @@ class DifferenceBase(MetricBase):
         self.start = start
         self.end = end
         self.transform = transform
+        self.only_transforms_array = only_transforms_array
         self.resample = resample
         self.smooth = smooth
         self.normalize = normalize
@@ -247,7 +251,11 @@ class DifferenceBase(MetricBase):
         def wrapper(self, solution, *args, **kwargs):
             if self.transform is not None:
                 solution = copy.deepcopy(solution)
-                solution.solution = self.transform(solution.solution)
+
+                if self.only_transforms_array:
+                    solution.solution = self.transform(solution.solution)
+                else:
+                    solution = self.transform(solution)
 
             value = func(self, solution, *args, **kwargs)
             return value

--- a/CADETProcess/dataStructure/cache.py
+++ b/CADETProcess/dataStructure/cache.py
@@ -23,6 +23,19 @@ class cached_property_if_locked(property):
 
 
 class CachedPropertiesMixin(Structure):
+    """
+    Mixin class for caching properties in a structured object.
+
+    This class is designed to be used as a mixin in conjunction with other classes
+    inheriting from `Structure`. It provides functionality for caching properties and
+    managing a lock state to control the caching behavior.
+
+    Notes
+    -----
+    - To prevent the return of outdated state, the cache is cleared whenever the `lock`
+      state is changed.
+    """
+
     _lock = Bool(default=False)
 
     def __init__(self, *args, **kwargs):
@@ -31,6 +44,7 @@ class CachedPropertiesMixin(Structure):
 
     @property
     def lock(self):
+        """bool: If True, properties are cached. False otherwise."""
         return self._lock
 
     @lock.setter

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -18,6 +18,9 @@ from CADETProcess import SimulationResults
 from CADETProcess.fractionation.fractions import Fraction, FractionPool
 
 
+__all__ = ["Fractionator"]
+
+
 class Fractionator(EventHandler):
     """Class for Chromatogram Fractionation.
 

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -21,11 +21,16 @@ from CADETProcess.fractionation.fractions import Fraction, FractionPool
 class Fractionator(EventHandler):
     """Class for Chromatogram Fractionation.
 
-    To set Events for starting and ending a fractionation it inherits from the
-    EventHandler class. It defines a ranking list for components as a
-    DependentlySizedUnsignedList with the number of components as dependent
-    size. The time_signal to fractionate is defined. If no ranking is set,
-    every component is equivalently.
+    This class is responsible for setting events for starting and ending fractionation,
+    handling multiple chromatograms, and calculating various performance metrics.
+
+    Attributes
+    ----------
+    name : String
+        Name of the fractionator, defaulting to 'Fractionator'.
+    performance_keys : list
+        Keys for performance metrics including mass, concentration, purity, recovery,
+        productivity, and eluent consumption.
 
     """
 
@@ -136,7 +141,7 @@ class Fractionator(EventHandler):
         """ComponentSystem: The component system of the chromatograms."""
         return self.chromatograms[0].component_system
 
-    def call_by_chrom_name(func):
+    def _call_by_chrom_name(func):
         """Decorator to enable calling functions with chromatogram object or name."""
         @wraps(func)
         def wrapper(self, chrom, *args, **kwargs):
@@ -329,7 +334,7 @@ class Fractionator(EventHandler):
         """
         return self._fractionation_states
 
-    @call_by_chrom_name
+    @_call_by_chrom_name
     def set_fractionation_state(self, chrom, state):
         """Set fractionation states of Chromatogram.
 
@@ -436,7 +441,7 @@ class Fractionator(EventHandler):
         start : float
             start time of the fraction
         start : float
-            start time of the fraction
+            end time of the fraction
 
         Returns
         -------

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -449,9 +449,9 @@ class Fractionator(EventHandler):
             Chromatogram fraction
 
         """
-        mass = self.chromatograms[chrom_index].fraction_mass(start, end)
-        volume = self.chromatograms[chrom_index].fraction_volume(start, end)
-        return Fraction(mass, volume)
+        fraction = self.chromatograms[chrom_index].create_fraction(start, end)
+
+        return fraction
 
     def add_fraction(self, fraction, target):
         """Add Fraction to the FractionPool of target component.

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -16,27 +16,31 @@ class Fraction(Structure):
     Attributes
     ----------
     mass : np.ndarray
-        The mass of each component in the fraction. The array is 1-dimensional.
+        Mass of each component in the fraction.
     volume : float
-        The volume of the fraction.
+        Volume of the fraction.
+
+    Properties
+    ----------
+    n_comp : int
+        Number of components in the fraction.
+    fraction_mass : np.ndarray
+        Cumulative mass of all species in the fraction.
+    purity : np.ndarray
+        Purity of the fraction, with invalid values set to zero.
+    concentration : np.ndarray
+        Component concentrations of the fraction, with invalid values set to zero.
+
+    See Also
+    --------
+    CADETProcess.fractionation.FractionPool
+    CADETProcess.fractionation.Fractionator
     """
 
     mass = Vector()
     volume = UnsignedFloat()
 
-    def __init__(self, mass, volume):
-        """Initialize a Fraction instance.
-
-        Parameters
-        ----------
-        mass : numpy.ndarray
-            The mass of each component in the fraction.
-            The array should be 1-dimensional.
-        volume : float
-            The volume of the fraction.
-        """
-        self.mass = mass
-        self.volume = volume
+    _parameters = ['mass', 'volume']
 
     @property
     def n_comp(self):
@@ -106,6 +110,23 @@ class FractionPool(Structure):
     n_comp : int
         The number of components each fraction in the pool should have.
 
+    Properties
+    ----------
+    fractions : list
+        List of fractions in the pool.
+    n_fractions : int
+        Number of fractions in the pool.
+    volume : float
+        Total volume of all fractions in the pool.
+    mass : np.ndarray
+        Cumulative mass of each component in the pool.
+    pool_mass : float
+        Total mass of all components in the pool.
+    purity : np.ndarray
+        Overall purity of the pool, with invalid values set to zero.
+    concentration : np.ndarray
+        Average concentration of the pool, with invalid values set to zero.
+
     See Also
     --------
     CADETProcess.fractionation.Fraction
@@ -114,7 +135,9 @@ class FractionPool(Structure):
 
     n_comp = UnsignedInteger()
 
-    def __init__(self, n_comp):
+    _parameters = ['n_comp']
+
+    def __init__(self, n_comp, *args, **kwargs):
         """Initialize a FractionPool instance.
 
         Parameters
@@ -124,6 +147,8 @@ class FractionPool(Structure):
         """
         self._fractions = []
         self.n_comp = n_comp
+
+        super().__init__(*args, **kwargs)
 
     def add_fraction(self, fraction):
         """Add a fraction to the fraction pool.

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -7,6 +7,9 @@ from CADETProcess.dataStructure import (
 )
 
 
+__all__ = ["Fraction", "FractionPool"]
+
+
 class Fraction(Structure):
     """A class representing a fraction of a mixture.
 

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -39,8 +39,10 @@ class Fraction(Structure):
 
     mass = Vector()
     volume = UnsignedFloat()
+    start = UnsignedFloat()
+    end = UnsignedFloat()
 
-    _parameters = ['mass', 'volume']
+    _parameters = ['mass', 'volume', 'start', 'end']
 
     @property
     def n_comp(self):

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -33,7 +33,7 @@ __all__ = ['SimulationResults']
 
 
 class SimulationResults(Structure):
-    """Class for storing simulation results including the solver configuration
+    """Class for storing simulation results including the solver configuration.
 
     Attributes
     ----------

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -450,6 +450,28 @@ class SolutionIO(SolutionBase):
 
         return self.solution_interpolated.integral(start, end)
 
+    def create_fraction(self, start=None, end=None):
+        """Create fraction in interval [start, end].
+
+        Parameters
+        ----------
+        start : float
+            Start time of the fraction
+
+        end: float
+            End time of the fraction
+
+        Returns
+        -------
+        fraction : Fraction
+            Fraction
+
+        """
+        from CADETProcess.fractionation import Fraction
+        mass = self.fraction_mass(start, end)
+        volume = self.fraction_volume(start, end)
+        return Fraction(mass, volume)
+
     def fraction_mass(self, start=None, end=None):
         """Component mass in a fraction interval
 

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -470,7 +470,7 @@ class SolutionIO(SolutionBase):
         from CADETProcess.fractionation import Fraction
         mass = self.fraction_mass(start, end)
         volume = self.fraction_volume(start, end)
-        return Fraction(mass, volume)
+        return Fraction(mass, volume, start, end)
 
     def fraction_mass(self, start=None, end=None):
         """Component mass in a fraction interval


### PR DESCRIPTION
## To do
- [>] Change registration of metrics in `Comparator` (would allow subclassing), closes #36 (moved to #102)
- [x] Add `start`/`end` times to `Fraction` class (missing: check end > start)
- [ ] Add `FractionationReference` class
  - [x] Time for `Fraction` must be provided!
  - [ ] Warning for overlaps
  - [ ] Volume (when compared with `SolutionIO`), define tolerance
  - [x] Slicing (components, time etc.)
  - [ ] Plot methods
- [x] Add `validate_reference_type` to DifferenceMetrics (e.g. `FractionationReference` for FractionationSSE/Slide)
- [x] Implement `FractionationSSE`
  - [x] Create fractions from solution
  - [x] Calculate SSE