### PR TITLE
Expose option to set precision for variables

### DIFF
--- a/CADETProcess/__init__.py
+++ b/CADETProcess/__init__.py
@@ -22,6 +22,7 @@ from .settings import Settings
 settings = Settings()
 
 from . import sysinfo
+from . import numerics
 from . import dataStructure
 from . import transform
 from . import plotting

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -13,6 +13,7 @@ from CADETProcess.dataStructure import Structure, String
 from CADETProcess.dataStructure import get_nested_value
 from CADETProcess.solution import SolutionBase
 from CADETProcess.comparison import DifferenceBase
+from CADETProcess.numerics import round_to_significant_digits
 
 
 class Comparator(Structure):
@@ -338,12 +339,7 @@ class Comparator(Structure):
             ax.legend(loc=1)
 
             m = metric.evaluate(solution_sliced, slice=False)
-            m = [
-                np.format_float_scientific(
-                    n, precision=2,
-                )
-                for n in m
-            ]
+            m = round_to_significant_digits(m, digits=2)
 
             text = f"{metric}: "
             if metric.n_metrics > 1:
@@ -356,7 +352,7 @@ class Comparator(Structure):
                 except AttributeError:
                     text += f"{m}"
             else:
-                text += m[0]
+                text += str(m[0])
 
             plotting.add_text(ax, text, fontsize=14)
 

--- a/CADETProcess/numerics.py
+++ b/CADETProcess/numerics.py
@@ -1,0 +1,68 @@
+import numpy as np
+
+
+def round_to_significant_digits(values: np.ndarray | list[float], digits: int) -> np.ndarray:
+    """
+    Round an array of numbers to the specified number of significant digits.
+
+    Parameters
+    ----------
+    values : np.ndarray | list[float]
+        Input array of floats to be rounded. Can be a NumPy array or a list of floats.
+    digits : int
+        Number of significant digits to retain. Must be greater than 0.
+
+    Returns
+    -------
+    np.ndarray
+        Array of values rounded to the specified significant digits.
+        The shape matches the input.
+
+    Notes
+    -----
+    - The function handles zero values by returning 0 directly, avoiding issues
+      with logarithms.
+    - Input arrays are automatically converted to `ndarray` if not already.
+
+    Examples
+    --------
+    >>> import numpy as np
+    >>> values = np.array([123.456, 0.001234, 98765, 0, -45.6789])
+    >>> round_to_significant_digits(values, 3)
+    array([ 123.   ,    0.00123, 98700.   ,    0.     ,  -45.7   ])
+
+    >>> values = [1.2345e-5, 6.789e3, 0.0]
+    >>> round_to_significant_digits(values, 2)
+    array([ 1.2e-05,  6.8e+03,  0.0e+00])
+    """
+
+    if digits is None:
+        return values
+
+    input_type = type(values)
+
+    values = np.asarray(values)  # Ensure input is a NumPy array
+
+    if digits <= 0:
+        raise ValueError("Number of significant digits must be greater than 0.")
+
+    # Mask for non-zero values
+    nonzero_mask = values != 0
+    result = np.zeros_like(values)  # Initialize result array
+
+    # For non-zero elements, calculate the scaling and apply rounding
+    if np.any(nonzero_mask):  # Check if there are any non-zero values
+        nonzero_values = values[nonzero_mask]
+        scales = digits - np.floor(np.log10(np.abs(nonzero_values))).astype(int) - 1
+
+        # Round each non-zero value individually
+        rounded_nonzero = [
+            round(v, int(scale)) for v, scale in zip(nonzero_values, scales)
+        ]
+
+        result[nonzero_mask] = rounded_nonzero  # Assign the rounded values back
+
+    if input_type is not np.ndarray:
+        result = input_type(result)
+
+    return result

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -2740,7 +2740,7 @@ class OptimizationProblem(Structure):
 
         for i, ind in enumerate(X_transformed):
             untransform[i, :] = [
-                var.untransform_fun(value)
+                var.untransform_fun(value, var.precision)
                 for value, var in zip(ind, self.independent_variables)
             ]
 
@@ -3672,11 +3672,11 @@ class OptimizationVariable:
     def transform(self):
         return self._transform
 
-    def transform_fun(self, x):
-        return self._transform.transform(x)
+    def transform_fun(self, x, *args, **kwargs):
+        return self._transform.transform(x, *args, **kwargs)
 
-    def untransform_fun(self, x):
-        return self._transform.untransform(x)
+    def untransform_fun(self, x, *args, **kwargs):
+        return self._transform.untransform(x, *args, **kwargs)
 
     def add_dependency(self, dependencies, transform):
         """Add dependency of Variable on other Variables.

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -331,7 +331,7 @@ class OptimizationProblem(Structure):
     def add_variable(
             self, name, evaluation_objects=-1, parameter_path=None,
             lb=-math.inf, ub=math.inf, transform=None, indices=None,
-            pre_processing=None):
+            precision=None, pre_processing=None):
         """Add optimization variable to the OptimizationProblem.
 
         The function encapsulates the creation of OptimizationVariable objects
@@ -358,6 +358,9 @@ class OptimizationProblem(Structure):
         indices : int  or tuple, optional
             Indices for variables that modify entries of a parameter array.
             If None, variable is assumed to be index independent.
+        precision : int, optional
+            Number of significant figures to which variable can be rounded.
+            If None, variable is not rounded. The default is None.
         pre_processing : callable, optional
             Additional step to process the value before setting it. This function must
             accept a single argument (the value) and return the processed value.
@@ -401,6 +404,7 @@ class OptimizationProblem(Structure):
             name, evaluation_objects, parameter_path,
             lb=lb, ub=ub, transform=transform,
             indices=indices,
+            precision=precision,
             pre_processing=pre_processing,
         )
 

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -282,7 +282,7 @@ class SolutionIO(SolutionBase):
         self._dm_dt_interpolated = None
 
     def update_transform(self):
-        self.transform = transform.NormLinearTransform(
+        self.transform = transform.NormLinearTransformer(
             np.min(self.solution, axis=0),
             np.max(self.solution, axis=0),
             allow_extended_input=True,

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -11,11 +11,11 @@ This module provides functionality for transforming data.
 .. autosummary::
     :toctree: generated/
 
-    TransformBase
-    NoTransform
-    NormLinearTransform
-    NormLogTransform
-    AutoTransform
+    TransformerBase
+    NullTransformer
+    NormLinearTransformer
+    NormLogTransformer
+    AutoTransformer
 
 """
 
@@ -29,7 +29,7 @@ from CADETProcess import plotting
 from CADETProcess.numerics import round_to_significant_digits
 
 
-class TransformBase(ABC):
+class TransformerBase(ABC):
     """
     Base class for parameter transformation.
 
@@ -65,11 +65,11 @@ class TransformBase(ABC):
 
     Examples
     --------
-    >>> class MyTransform(TransformBase):
+    >>> class MyTransformer(TransformerBase):
     ...     def transform(self, x):
     ...         return x ** 2
     ...
-    >>> t = MyTransform(lb_input=0, ub_input=10, lb=-100, ub=100)
+    >>> t = MyTransformer(lb_input=0, ub_input=10, lb=-100, ub=100)
     >>> t.transform(3)
     9
 
@@ -79,7 +79,7 @@ class TransformBase(ABC):
             self,
             lb_input=-np.inf, ub_input=np.inf,
             allow_extended_input=False, allow_extended_output=False):
-        """Initialize TransformBase
+        """Initialize TransformerBase
 
         Parameters
         ----------
@@ -275,14 +275,14 @@ class TransformBase(ABC):
         return self.__class__.__name__
 
 
-class NoTransform(TransformBase):
+class NullTransformer(TransformerBase):
     """A class that implements no transformation.
 
     Returns the input values without any transformation.
 
     See Also
     --------
-    TransformBase : The base class for parameter transformation.
+    TransformerBase : The base class for parameter transformation.
     """
 
     @property
@@ -330,7 +330,7 @@ class NoTransform(TransformBase):
         return x
 
 
-class NormLinearTransform(TransformBase):
+class NormLinearTransformer(TransformerBase):
     """A class that implements a normalized linear transformation.
 
     Transforms the input value to the range [0, 1] by normalizing it using
@@ -338,7 +338,7 @@ class NormLinearTransform(TransformBase):
 
     See Also
     --------
-    TransformBase : The base class for parameter transformation.
+    TransformerBase : The base class for parameter transformation.
 
     """
 
@@ -387,7 +387,7 @@ class NormLinearTransform(TransformBase):
         return (self.ub_input - self.lb_input) * x + self.lb_input
 
 
-class NormLogTransform(TransformBase):
+class NormLogTransformer(TransformerBase):
     """A class that implements a normalized logarithmic transformation.
 
     Transforms the input value to the range [0, 1] using a logarithmic
@@ -395,7 +395,7 @@ class NormLogTransform(TransformBase):
 
     See Also
     --------
-    TransformBase : The base class for parameter transformation.
+    TransformerBase : The base class for parameter transformation.
 
     """
 
@@ -457,43 +457,43 @@ class NormLogTransform(TransformBase):
                 self.lb_input * np.exp(x * np.log(self.ub_input/self.lb_input))
 
 
-class AutoTransform(TransformBase):
+class AutoTransformer(TransformerBase):
     """A class that implements an automatic parameter transformation.
 
     Transforms the input value to the range [0, 1] using either
-    the :class:`NormLinearTransform` or the :class:`NormLogTransform`
+    the :class:`NormLinearTransformer` or the :class:`NormLogTransformer`
     based on the input parameter space.
 
     Attributes
     ----------
-    linear : :class:`NormLinearTransform`
+    linear : :class:`NormLinearTransformer`
         Instance of the linear normalization transform.
-    log : :class:`NormLogTransform`
+    log : :class:`NormLogTransformer`
         Instance of the logarithmic normalization transform.
 
     See Also
     --------
-    TransformBase
-    NormLinearTransform
-    NormLogTransform
+    TransformerBase
+    NormLinearTransformer
+    NormLogTransformer
 
     """
 
     def __init__(self, *args, threshold=1000, **kwargs):
-        """Initialize an AutoTransform object.
+        """Initialize an AutoTransformer object.
 
         Parameters
         ----------
         *args : tuple
-            Arguments for the :class:`TransformBase` class.
+            Arguments for the :class:`TransformerBase` class.
         threshold : int, optional
             The maximum threshold to switch from linear to logarithmic
             transformation. The default is 1000.
         **kwargs : dict
-            Keyword arguments for the :class:`TransformBase` class.
+            Keyword arguments for the :class:`TransformerBase` class.
         """
-        self.linear = NormLinearTransform()
-        self.log = NormLogTransform()
+        self.linear = NormLinearTransformer()
+        self.log = NormLogTransformer()
 
         super().__init__(*args, **kwargs)
         self.threshold = threshold

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -566,9 +566,9 @@ class AutoTransform(TransformBase):
             The transformed output value(s).
         """
         if self.use_log:
-            return self.log.transform(x)
+            return self.log._transform(x)
         else:
-            return self.linear.transform(x)
+            return self.linear._transform(x)
 
     def _untransform(self, x):
         """Untransforms the output value to input value.
@@ -584,6 +584,6 @@ class AutoTransform(TransformBase):
             The untransformed output value(s).
         """
         if self.use_log:
-            return self.log.untransform(x)
+            return self.log._untransform(x)
         else:
-            return self.linear.untransform(x)
+            return self.linear._untransform(x)

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -26,6 +26,7 @@ from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 
 from CADETProcess import plotting
+from CADETProcess.numerics import round_to_significant_digits
 
 
 class TransformBase(ABC):
@@ -186,7 +187,7 @@ class TransformBase(ABC):
         """
         pass
 
-    def untransform(self, x, precision=None):
+    def untransform(self, x, significant_digits=None):
         """Transform the output parameter space to the input parameter space.
 
         Applies the transformation function _untransform to x after performing output
@@ -197,7 +198,7 @@ class TransformBase(ABC):
         ----------
         x : {float, array}
             Output parameter values.
-        precision : int, optional
+        significant_digits : int, optional
             Number of significant figures to which variable can be rounded.
             If None, variable is not rounded. The default is None.
 
@@ -206,7 +207,7 @@ class TransformBase(ABC):
         {float, array}
             Transformed parameter values.
         """
-        x_ = float(np.format_float_positional(x, precision=precision, fractional=False))
+        x_ = round_to_significant_digits(x, digits=significant_digits)
 
         if (
                 not self.allow_extended_output and
@@ -214,7 +215,7 @@ class TransformBase(ABC):
             raise ValueError("Value exceeds output bounds.")
 
         x_ = self._untransform(x_)
-        x_ = float(np.format_float_positional(x_, precision=precision, fractional=False))
+        x_ = round_to_significant_digits(x_, digits=significant_digits)
 
         if (
                 not self.allow_extended_input and

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -186,7 +186,7 @@ class TransformBase(ABC):
         """
         pass
 
-    def untransform(self, x):
+    def untransform(self, x, precision=None):
         """Transform the output parameter space to the input parameter space.
 
         Applies the transformation function _untransform to x after performing output
@@ -197,23 +197,31 @@ class TransformBase(ABC):
         ----------
         x : {float, array}
             Output parameter values.
+        precision : int, optional
+            Number of significant figures to which variable can be rounded.
+            If None, variable is not rounded. The default is None.
 
         Returns
         -------
         {float, array}
             Transformed parameter values.
         """
+        x_ = float(np.format_float_positional(x, precision=precision, fractional=False))
+
         if (
                 not self.allow_extended_output and
-                not np.all((self.lb <= x) * (x <= self.ub))):
+                not np.all((self.lb <= x_) * (x_ <= self.ub))):
             raise ValueError("Value exceeds output bounds.")
-        x = self._untransform(x)
+
+        x_ = self._untransform(x_)
+        x_ = float(np.format_float_positional(x_, precision=precision, fractional=False))
+
         if (
                 not self.allow_extended_input and
-                not np.all((self.lb_input <= x) * (x <= self.ub_input))):
+                not np.all((self.lb_input <= x_) * (x_ <= self.ub_input))):
             raise ValueError("Value exceeds input bounds.")
 
-        return x
+        return x_
 
     @abstractmethod
     def _untransform(self, x):

--- a/tests/optimization_problem_fixtures.py
+++ b/tests/optimization_problem_fixtures.py
@@ -160,7 +160,7 @@ class LinearConstraintsSooTestProblem(TestProblem):
             self,
             transform=None,
             has_evaluator=False,
-            precision=None,
+            significant_digits=None,
             *args,
             **kwargs
             ):
@@ -168,7 +168,7 @@ class LinearConstraintsSooTestProblem(TestProblem):
         super().__init__('linear_constraints_single_objective', *args, **kwargs)
         self.setup_variables(
             transform=transform,
-            precision=precision
+            significant_digits=significant_digits
         )
         self.setup_linear_constraints()
         if has_evaluator:
@@ -181,27 +181,27 @@ class LinearConstraintsSooTestProblem(TestProblem):
         else:
             self.add_objective(self._objective_function)
 
-    def setup_variables(self, transform, precision=None):
+    def setup_variables(self, transform, significant_digits=None):
         self.add_variable(
             'var_0',
             lb=-2,
             ub=2,
             transform=transform,
-            precision=precision,
+            significant_digits=significant_digits,
         )
         self.add_variable(
             'var_1',
             lb=-2,
             ub=2,
             transform=transform,
-            precision=precision,
+            significant_digits=significant_digits,
         )
         self.add_variable(
             'var_2',
             lb=0,
             ub=2,
             transform="log",
-            precision=precision,
+            significant_digits=significant_digits,
         )
 
     def setup_linear_constraints(self):
@@ -381,10 +381,23 @@ class LinearEqualityConstraintsSooTestProblem(TestProblem):
         self.setup_linear_constraints()
         self.add_objective(self._objective_function)
 
-    def setup_variables(self: OptimizationProblem, transform=None, precision=None):
-        self.add_variable('var_0', lb=-5, ub=5, transform=transform, precision=precision)
-        self.add_variable('var_1', lb=-5, ub=5, transform=transform, precision=precision)
-        self.add_variable('var_2', lb=-5, ub=5, transform=transform, precision=precision)
+    def setup_variables(
+            self: OptimizationProblem,
+            transform=None,
+            significant_digits=None
+            ):
+        self.add_variable(
+            'var_0', lb=-5, ub=5,
+            transform=transform, significant_digits=significant_digits
+        )
+        self.add_variable(
+            'var_1', lb=-5, ub=5,
+            transform=transform, significant_digits=significant_digits
+        )
+        self.add_variable(
+            'var_2', lb=-5, ub=5,
+            transform=transform, significant_digits=significant_digits
+        )
 
     def setup_linear_constraints(self):
         self.add_linear_equality_constraint(

--- a/tests/optimization_problem_fixtures.py
+++ b/tests/optimization_problem_fixtures.py
@@ -156,10 +156,20 @@ class Rosenbrock(TestProblem):
 
 
 class LinearConstraintsSooTestProblem(TestProblem):
-    def __init__(self, transform=None, has_evaluator=False, *args, **kwargs):
+    def __init__(
+            self,
+            transform=None,
+            has_evaluator=False,
+            precision=None,
+            *args,
+            **kwargs
+            ):
         self.test_abs_tol = 0.1
         super().__init__('linear_constraints_single_objective', *args, **kwargs)
-        self.setup_variables(transform=transform)
+        self.setup_variables(
+            transform=transform,
+            precision=precision
+        )
         self.setup_linear_constraints()
         if has_evaluator:
             eval_fun = lambda x: x
@@ -171,10 +181,28 @@ class LinearConstraintsSooTestProblem(TestProblem):
         else:
             self.add_objective(self._objective_function)
 
-    def setup_variables(self, transform):
-        self.add_variable('var_0', lb=-2, ub=2, transform=transform)
-        self.add_variable('var_1', lb=-2, ub=2, transform=transform)
-        self.add_variable('var_2', lb=0, ub=2, transform="log")
+    def setup_variables(self, transform, precision=None):
+        self.add_variable(
+            'var_0',
+            lb=-2,
+            ub=2,
+            transform=transform,
+            precision=precision,
+        )
+        self.add_variable(
+            'var_1',
+            lb=-2,
+            ub=2,
+            transform=transform,
+            precision=precision,
+        )
+        self.add_variable(
+            'var_2',
+            lb=0,
+            ub=2,
+            transform="log",
+            precision=precision,
+        )
 
     def setup_linear_constraints(self):
         self.add_linear_constraint(['var_0', 'var_1'], [-1, -0.5], 0)
@@ -353,10 +381,10 @@ class LinearEqualityConstraintsSooTestProblem(TestProblem):
         self.setup_linear_constraints()
         self.add_objective(self._objective_function)
 
-    def setup_variables(self: OptimizationProblem, transform=None):
-        self.add_variable('var_0', lb=-5, ub=5, transform=transform)
-        self.add_variable('var_1', lb=-5, ub=5, transform=transform)
-        self.add_variable('var_2', lb=-5, ub=5, transform=transform)
+    def setup_variables(self: OptimizationProblem, transform=None, precision=None):
+        self.add_variable('var_0', lb=-5, ub=5, transform=transform, precision=precision)
+        self.add_variable('var_1', lb=-5, ub=5, transform=transform, precision=precision)
+        self.add_variable('var_2', lb=-5, ub=5, transform=transform, precision=precision)
 
     def setup_linear_constraints(self):
         self.add_linear_equality_constraint(

--- a/tests/optimization_problem_fixtures.py
+++ b/tests/optimization_problem_fixtures.py
@@ -11,7 +11,6 @@ import warnings
 import numpy as np
 
 from CADETProcess.optimization import OptimizationProblem, OptimizationResults
-from CADETProcess.transform import NormLinearTransform, NormLogTransform
 
 __all__ = [
     'Rosenbrock',

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -1,0 +1,71 @@
+import numpy as np
+import pytest
+from CADETProcess.numerics import round_to_significant_digits
+
+
+def test_basic_functionality():
+    values = np.array([123.456, 0.001234, 98765])
+    expected = np.array([123.0, 0.00123, 98800.0])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_handling_zeros():
+    values = np.array([0, 0.0, -0.0])
+    expected = np.array([0.0, 0.0, -0.0])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_negative_numbers():
+    values = np.array([-123.456, -0.001234, -98765])
+    expected = np.array([-123.0, -0.00123, -98800.0])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_large_numbers():
+    values = np.array([1.23e10, 9.87e15])
+    expected = np.array([1.23e10, 9.87e15])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_small_numbers():
+    values = np.array([1.23e-10, 9.87e-15])
+    expected = np.array([1.23e-10, 9.87e-15])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_mixed_values():
+    values = np.array([123.456, 0, -0.001234, 9.8765e-5])
+    expected = np.array([123.0, 0.0, -0.00123, 9.88e-5])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_invalid_digits():
+    with pytest.raises(ValueError, match="Number of significant digits must be greater than 0."):
+        round_to_significant_digits(np.array([123.456]), 0)
+
+
+def test_empty_array():
+    values = np.array([])
+    expected = np.array([])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_array_equal(result, expected)
+
+
+def test_non_array_input():
+    values = [123.456, 0.001234, 98765]  # List input
+    expected = np.array([123.0, 0.00123, 98800.0])
+    result = round_to_significant_digits(values, 3)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)
+
+
+def test_none_digits():
+    values = [123.456, 0.001234, 98765]  # List input
+    expected = np.array([123.456, 0.001234, 98765])
+    result = round_to_significant_digits(values, None)
+    np.testing.assert_allclose(result, expected, rtol=1e-6)

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -162,6 +162,28 @@ class Test_OptimizationVariable(unittest.TestCase):
                 indices=2
             )
 
+    def test_significant_digits(self):
+        var_no_precision = OptimizationVariable(
+            'not_rounded_variable',
+            evaluation_objects=[self.evaluation_object],
+            parameter_path='scalar_param',
+            significant_digits=None
+        )
+        var_no_precision.value = 1.1234
+        np.testing.assert_equal(var_no_precision.value, 1.1234)
+        np.testing.assert_equal(self.evaluation_object.scalar_param, 1.1234)
+
+        var_with_precision = OptimizationVariable(
+            'rounded_variable',
+            evaluation_objects=[self.evaluation_object],
+            parameter_path='scalar_param',
+            significant_digits=2
+        )
+        var_with_precision.value = 1.1234
+        np.testing.assert_equal(var_with_precision.value, 1.1)
+        np.testing.assert_equal(self.evaluation_object.scalar_param, 1.1)
+
+
     def test_sized_list_single(self):
         """
         Extra test for array with single entry.

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,14 +1,14 @@
 import unittest
 
 from CADETProcess.transform import (
-    NoTransform, NormLinearTransform, NormLogTransform, AutoTransform
+    NullTransformer, NormLinearTransformer, NormLogTransformer, AutoTransformer
 )
 
 
-class Test_Transform(unittest.TestCase):
+class Test_Transformer(unittest.TestCase):
 
     def test_input_range(self):
-        transform = NormLinearTransform(0, 100)
+        transform = NormLinearTransformer(0, 100)
 
         with self.assertRaises(ValueError):
             in_ = -10
@@ -19,7 +19,7 @@ class Test_Transform(unittest.TestCase):
             out = transform.transform(in_)
 
     def test_output_range(self):
-        transform = NormLinearTransform(0, 100)
+        transform = NormLinearTransformer(0, 100)
 
         with self.assertRaises(ValueError):
             in_ = -1
@@ -30,7 +30,7 @@ class Test_Transform(unittest.TestCase):
             out = transform.untransform(in_)
 
     def test_no_transform(self):
-        transform = NoTransform(0, 100)
+        transform = NullTransformer(0, 100)
         self.assertAlmostEqual(transform.lb, 0)
         self.assertAlmostEqual(transform.ub, 100)
 
@@ -45,7 +45,7 @@ class Test_Transform(unittest.TestCase):
         self.assertAlmostEqual(out_expected, out)
 
     def test_linear(self):
-        transform = NormLinearTransform(0, 100)
+        transform = NormLinearTransformer(0, 100)
         self.assertAlmostEqual(transform.lb, 0)
         self.assertAlmostEqual(transform.ub, 1)
 
@@ -81,7 +81,7 @@ class Test_Transform(unittest.TestCase):
 
     def test_log(self):
         """Missing: Special case for lb_input <= 0"""
-        transform = NormLogTransform(1, 1000)
+        transform = NormLogTransformer(1, 1000)
         self.assertAlmostEqual(transform.lb, 0)
         self.assertAlmostEqual(transform.ub, 1)
 
@@ -128,12 +128,12 @@ class Test_Transform(unittest.TestCase):
     def test_auto(self):
         threshold = 1000
 
-        transform = AutoTransform(1, 100, threshold=threshold)
+        transform = AutoTransformer(1, 100, threshold=threshold)
         self.assertTrue(transform.use_linear)
         self.assertFalse(transform.use_log)
 
         # Expect Log behaviour
-        transform = AutoTransform(1, 1001, threshold=threshold)
+        transform = AutoTransformer(1, 1001, threshold=threshold)
         self.assertFalse(transform.use_linear)
         self.assertTrue(transform.use_log)
 


### PR DESCRIPTION
This PR allows two things:
- Exposing a `precision` attribute of the `OptimizationVariable` which can be used to round its value (which can be useful when dealing with floating point issues of even for termination criteria.
- Passing this precision to the transform functions when determining bounds of the variables. This could maybe help with the issues we're experiencing with `COBYLA`.

## To do
- [>] Check if this helps with `COBYLA` -> maybe but since `COBYLA` will be replaced by `COBYQA` in the mid-term let's focus on this another day
- [x] rename from `precision` to `significant_digits`
- [x] Finish tests
