### PR TITLE
Improve optimization post processing

### DIFF
--- a/CADETProcess/__init__.py
+++ b/CADETProcess/__init__.py
@@ -20,6 +20,7 @@ from . import log
 from .settings import Settings
 settings = Settings()
 
+from . import sysinfo
 from . import dataStructure
 from . import transform
 from . import plotting

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -42,7 +42,7 @@ class ParameterBase(Descriptor):
     Tuple
     Float
     String
-    Dict
+    Dictionary
     """
 
     def __init__(
@@ -378,7 +378,7 @@ class Typed(ParameterBase):
     Tuple
     Float
     String
-    Dict
+    Dictionary
     """
 
     def __init__(self, *args, ty=None, **kwargs):
@@ -568,15 +568,8 @@ class List(Typed):
     ty = list
 
 
-class Dict(Typed):
-    """
-    Parameter descriptor constrained to dictionary (`dict`) values.
-
-    Notes
-    -----
-    When integrating with libraries like `addict`, be cautious about potential
-    name collisions with `addict.Dict`.
-    """
+class Dictionary(Typed):
+    """Parameter descriptor constrained to dictionary (`dict`) values."""
 
     ty = dict
 

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -200,7 +200,7 @@ class FractionationOptimizer():
         opt.add_evaluation_object(frac)
 
         frac_evaluator = FractionationEvaluator()
-        opt.add_evaluator(frac_evaluator, cache=True)
+        opt.add_evaluator(frac_evaluator)
 
         if obj_fun is None:
             obj_fun = Mass(ranking=ranking)

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -312,11 +312,11 @@ class AxInterface(OptimizerBase):
             CV = None
 
         # Ideally, the current optimum w.r.t. single and multi objective can be
-        # obtained at this point and passed to run_post_generation_processing.
+        # obtained at this point and passed to run_post_processing.
         # with X_opt_transformed. Implementation is pending.
         # See: https://github.com/fau-advanced-separations/CADET-Process/issues/53
 
-        self.run_post_generation_processing(
+        self.run_post_processing(
             X_transformed=X,
             F=F,
             G=G,

--- a/CADETProcess/optimization/cache.py
+++ b/CADETProcess/optimization/cache.py
@@ -130,7 +130,7 @@ class ResultsCache():
         if close:
             self.close()
 
-    def prune(self, tag='temp'):
+    def prune(self, tag):
         """Remove tagged entries from cache.
 
         Parameters

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -2630,7 +2630,8 @@ class OptimizationProblem(Structure):
         return \
             self.cached_evaluators + \
             self.objectives + \
-            self.nonlinear_constraints
+            self.nonlinear_constraints + \
+            self.meta_scores
 
     @property
     def cache_directory(self):

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -252,7 +252,9 @@ class OptimizerBase(Structure):
 
         self.run(self.optimization_problem, x0, *args, **kwargs)
 
-        self.results.time_elapsed = time.time() - start
+        time_elapsed = time.time() - start
+        self.results.time_elapsed = time_elapsed
+        self.results.cpu_time = self.n_cores * time_elapsed
 
         if delete_cache:
             optimization_problem.delete_cache(reinit=True)

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -536,7 +536,7 @@ class OptimizerBase(Structure):
 
         """
         population = self._create_population(X_transformed, F, G, CV)
-        self.results.update_population(population)
+        self.results.update(population)
 
         pareto_front = self._create_pareto_front(X_opt_transformed)
         self.results.update_pareto(pareto_front)

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -249,10 +249,9 @@ class OptimizerBase(Structure):
         plt.switch_backend('agg')
 
         start = time.time()
-
         self.run(self.optimization_problem, x0, *args, **kwargs)
-
         time_elapsed = time.time() - start
+
         self.results.time_elapsed = time_elapsed
         self.results.cpu_time = self.n_cores * time_elapsed
 
@@ -260,6 +259,8 @@ class OptimizerBase(Structure):
             optimization_problem.delete_cache(reinit=True)
 
         plt.switch_backend(backend)
+
+        self.run_final_processing()
 
         return self.results
 
@@ -482,12 +483,19 @@ class OptimizerBase(Structure):
 
         return meta_front
 
-    def _evaluate_callbacks(self, current_generation):
+    def _evaluate_callbacks(self, current_generation, sub_dir=None):
+        if sub_dir is not None:
+            callbacks_dir = self.callbacks_dir / sub_dir
+            callbacks_dir.mkdir(exist_ok=True, parents=True)
+        else:
+            callbacks_dir = self.callbacks_dir
+
         for callback in self.optimization_problem.callbacks:
             if self.optimization_problem.n_callbacks > 1:
-                _callbacks_dir = self.callbacks_dir / str(callback)
+                _callbacks_dir = callbacks_dir / str(callback)
             else:
-                _callbacks_dir = self.callbacks_dir
+                _callbacks_dir = callbacks_dir
+
             callback.cleanup(_callbacks_dir, current_generation)
             callback._callbacks_dir = _callbacks_dir
 
@@ -552,13 +560,18 @@ class OptimizerBase(Structure):
 
         self._evaluate_callbacks(current_generation)
 
-        self.results.save_results()
+        self.results.save_results('checkpoint')
 
         for x in self.results.population_all.x:
             if x not in self.results.meta_front.x:
                 self.optimization_problem.prune_cache(str(x))
 
         self._log_results(current_generation)
+
+    def run_final_processing(self):
+        self.results.plot_figures(show=False)
+        # self._evaluate_callbacks(0, 'final')
+        self.results.save_results('final')
 
     @property
     def options(self):

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -499,7 +499,7 @@ class OptimizerBase(Structure):
         self.logger.info(
             f'Finished Generation {current_generation}.'
         )
-        for ind in self.results.pareto_front:
+        for ind in self.results.meta_front:
             message = f'x: {ind.x}, f: {ind.f}'
 
             if self.optimization_problem.n_nonlinear_constraints > 0:

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -552,7 +552,9 @@ class OptimizerBase(Structure):
 
         self.results.save_results()
 
-        self.optimization_problem.prune_cache()
+        for x in self.results.population_all.x:
+            if x not in self.results.meta_front.x:
+                self.optimization_problem.prune_cache(str(x))
 
         self._log_results(current_generation)
 

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -166,7 +166,7 @@ class PymooInterface(OptimizerBase):
 
             # Post generation processing
             X_opt = algorithm.opt.get("X").tolist()
-            self.run_post_generation_processing(X, F, G, CV, algorithm.n_gen-1, X_opt)
+            self.run_post_processing(X, F, G, CV, algorithm.n_gen-1, X_opt)
 
         if algorithm.n_gen >= n_max_gen:
             exit_message = 'Max number of generations exceeded.'

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -136,42 +136,26 @@ class OptimizationResults(Structure):
         else:
             return self._meta_fronts[-1]
 
-    def update_individual(self, individual):
+    def update(self, new):
         """Update Results.
 
         Parameters
         ----------
-        individual : Individual
-            Latest individual.
+        new : Individual, Population
+            New results
 
         Raises
         ------
         CADETProcessError
-            If individual is not an instance of Individual
+            If new is not an instance of Individual or Population
         """
-        if not isinstance(individual, Individual):
-            raise CADETProcessError("Expected Individual")
-
-        population = Population()
-        population.add_individual(individual)
-        self._populations.append(population)
-        self.population_all.add_individual(individual, ignore_duplicate=True)
-
-    def update_population(self, population):
-        """Update Results.
-
-        Parameters
-        ----------
-        population : Population
-            Current population
-
-        Raises
-        ------
-        CADETProcessError
-            If population is not an instance of Population
-        """
-        if not isinstance(population, Population):
-            raise CADETProcessError("Expected Population")
+        if isinstance(new, Individual):
+            population = Population()
+            population.add_individual(new)
+        elif isinstance(new, Population):
+            population = new
+        else:
+            raise CADETProcessError("Expected Population or Individual")
         self._populations.append(population)
         self.population_all.update(population)
 
@@ -800,7 +784,7 @@ class OptimizationResults(Structure):
 
         for pop_dict in data['populations'].values():
             pop = Population.from_dict(pop_dict)
-            self.update_population(pop)
+            self.update(pop)
 
         self._pareto_fronts = [
             ParetoFront.from_dict(d) for d in data['pareto_fronts'].values()

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -741,7 +741,7 @@ class OptimizationResults(Structure):
                     f'{plot_directory / figname}.png'
                 )
 
-    def save_results(self):
+    def save_results(self, name):
         if self.results_directory is not None:
             self._update_csv(self.population_last, 'results_all', mode='a')
             self._update_csv(self.population_last, 'results_last', mode='w')
@@ -751,7 +751,7 @@ class OptimizationResults(Structure):
 
             results = H5()
             results.root = Dict(self.to_dict())
-            results.filename = self.results_directory / 'checkpoint.h5'
+            results.filename = self.results_directory / f'{name}.h5'
             results.save()
 
     def to_dict(self):
@@ -763,6 +763,7 @@ class OptimizationResults(Structure):
             Results as a dictionary with populations stored as list of dictionaries.
         """
         data = Dict()
+        data.system_information = self.system_information
         data.optimizer_state = self.optimizer_state
         data.population_all_id = str(self.population_all.id)
         data.populations = {i: pop.to_dict() for i, pop in enumerate(self.populations)}
@@ -773,6 +774,9 @@ class OptimizationResults(Structure):
             data.meta_fronts = {
                 i: front.to_dict() for i, front in enumerate(self.meta_fronts)
             }
+        if self.time_elapsed is not None:
+            data.time_elapsed = self.time_elapsed
+            data.cpu_time = self.cpu_time
 
         return data
 

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -14,10 +14,11 @@ from cadet import H5
 from CADETProcess import plotting
 from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    NdArray, String, UnsignedInteger, UnsignedFloat
+    Dictionary, NdArray, String, UnsignedInteger, UnsignedFloat
 )
 
 from CADETProcess import CADETProcessError
+from CADETProcess.sysinfo import system_information
 from CADETProcess.optimization import Individual, Population, ParetoFront
 
 
@@ -54,6 +55,8 @@ class OptimizationResults(Structure):
     exit_flag = UnsignedInteger()
     exit_message = String()
     time_elapsed = UnsignedFloat()
+    cpu_time = UnsignedFloat()
+    system_information = Dictionary()
 
     def __init__(
             self, optimization_problem, optimizer,
@@ -75,6 +78,8 @@ class OptimizationResults(Structure):
             self._meta_fronts = None
 
         self.results_directory = None
+
+        self.system_information = system_information
 
     @property
     def results_directory(self):

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -102,7 +102,7 @@ class SciPyInterface(OptimizerBase):
                 x, untransform=True
             )
 
-            self.run_post_evaluation_processing(x, f, g, cv, self.n_evals)
+            self.run_post_processing(x, f, g, cv, self.n_evals)
 
             return False
 

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -19,13 +19,13 @@ import copy
 import os
 
 import numpy as np
-import addict
+from addict import Dict
 
 from CADETProcess import CADETProcessError
 from CADETProcess import settings
 from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    Dict, String, List, UnsignedInteger, UnsignedFloat
+    Dictionary, String, List, UnsignedInteger, UnsignedFloat
 )
 
 
@@ -72,13 +72,13 @@ class SimulationResults(Structure):
     """
 
     solver_name = String()
-    solver_parameters = Dict()
+    solver_parameters = Dictionary()
     exit_flag = UnsignedInteger()
     exit_message = String()
     time_elapsed = UnsignedFloat()
-    solution_cycles = Dict()
-    sensitivity_cycles = Dict()
-    system_state = Dict()
+    solution_cycles = Dictionary()
+    sensitivity_cycles = Dictionary()
+    system_state = Dictionary()
     chromatograms = List()
 
     def __init__(
@@ -140,7 +140,7 @@ class SimulationResults(Structure):
 
         time_complete = self.time_complete
 
-        solution = addict.Dict()
+        solution = Dict()
         for unit, solutions in self.solution_cycles.items():
             for sol, cycles in solutions.items():
                 solution[unit][sol] = copy.deepcopy(cycles[0])
@@ -165,7 +165,7 @@ class SimulationResults(Structure):
 
         time_complete = self.time_complete
 
-        sensitivity = addict.Dict()
+        sensitivity = Dict()
         for unit, sensitivities in self.sensitivity_cycles.items():
             for sens_name, sensitivities in sensitivities.items():
                 for sens, cycles in sensitivities.items():

--- a/CADETProcess/sysinfo.py
+++ b/CADETProcess/sysinfo.py
@@ -1,0 +1,20 @@
+import platform
+import psutil
+
+uname = platform.uname()
+cpu_freq = psutil.cpu_freq()
+memory = psutil.virtual_memory()
+memory_total = psutil._common.bytes2human(memory.total)
+
+system_information = {
+    'system': uname.system,
+    'release': uname.release,
+    'machine': uname.machine,
+    'processor': uname.processor,
+    'n_cores': psutil.cpu_count(logical=True),
+    'n_cores_physical': psutil.cpu_count(logical=False),
+    'max_frequency': cpu_freq.max,
+    'min_frequency': cpu_freq.min,
+    'memory_total': memory_total,
+
+}

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ install_requires =
     numba>=0.55.1
     diskcache>=5.4.0
     joblib>=1.3.0
+    psutil>=5.9.8
 
 [options.extras_require]
 testing =

--- a/tests/test_optimization_results.py
+++ b/tests/test_optimization_results.py
@@ -23,7 +23,7 @@ def setup_optimization_results(
 
         for gen in range(n_gen):
             pop = setup_population(n_ind, n_vars, n_obj, n_nonlin, n_meta, rng)
-            optimization_results.update_population(pop)
+            optimization_results.update(pop)
             optimization_results.update_pareto()
             if n_meta > 0:
                 optimization_results.update_meta()


### PR DESCRIPTION
Closes #99.

## To do
- [x] Unify post_generation/post_evaluation_processing
- [x] Improve cache pruning: Keep members of pareto front for future evaluations (e.g. callbacks)
- [/] Evaluate callbacks in parallel (was already working)
- [x] Always run post_processing / callbacks for final generation (relevant when evaluation frequencies != 1)
- [x] Store optimization results, including run and system information after termination (use checkpoint as template)

---

In future, I might want to revisit caching. I'm still not happy with how it's handled, i.e. which object "holds" the cache. Right now, it's the OptimizationProblem. However, it might also be a good idea to just optionally pass in a cache object on evaluation call.