### PR TITLE
Allow specifying objectives as maximization problem 

### DIFF
--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -226,11 +226,12 @@ class FractionationOptimizer():
 
         purity = Purity()
         purity.n_metrics = frac.component_system.n_comp
-        constraint_bounds = -np.array(purity_required, ndmin=1)
-        constraint_bounds = constraint_bounds.tolist()
         opt.add_nonlinear_constraint(
-            purity, n_nonlinear_constraints=len(constraint_bounds),
-            bounds=constraint_bounds, requires=frac_evaluator
+            purity,
+            n_nonlinear_constraints=len(purity_required),
+            bounds=purity_required,
+            comparison_operator='ge',
+            requires=frac_evaluator,
         )
 
         for evt in frac.events:

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -149,6 +149,8 @@ class FractionationOptimizer():
             allow_empty_fractions=True,
             ranking=1,
             obj_fun=None,
+            minimize=True,
+            bad_metrics=None,
             n_objectives=1):
         """Set up the OptimizationProblem for optimizing the fractionation times.
 
@@ -169,6 +171,12 @@ class FractionationOptimizer():
             Alternative objective function.
             If no function is provided, the fraction mass is maximized.
             The default is None.
+        bad_metrics : float or list of floats, optional
+            Values to be returned if evaluation of objective function failes.
+            The default is 0.
+        minimize : bool, optional
+            If True, the obj_fun is assumed to return a value that is to be minimized.
+            The default it True.
         n_objectives : int
             Number of objectives. The default is 1.
 
@@ -205,9 +213,15 @@ class FractionationOptimizer():
 
         if obj_fun is None:
             obj_fun = Mass(ranking=ranking)
+            minimize = False
+            bad_metrics = 0
+
         opt.add_objective(
-            obj_fun, requires=frac_evaluator, n_objectives=n_objectives,
-            bad_metrics=0
+            obj_fun,
+            requires=frac_evaluator,
+            n_objectives=n_objectives,
+            minimize=minimize,
+            bad_metrics=bad_metrics,
         )
 
         purity = Purity()
@@ -255,6 +269,8 @@ class FractionationOptimizer():
             ranking=1,
             obj_fun=None,
             n_objectives=1,
+            bad_metrics=0,
+            minimize=True,
             allow_empty_fractions=True,
             ignore_failed=False,
             return_optimization_results=False,
@@ -281,6 +297,12 @@ class FractionationOptimizer():
             If is None, the mass of all components is maximized.
         n_objectives : int, optional
             Number of objectives returned by obj_fun. The default is 1.
+        bad_metrics : float or list of floats, optional
+            Values to be returned if evaluation of objective function failes.
+            The default is 0.
+        minimize : bool, optional
+            If True, the obj_fun is assumed to return a value that is to be minimized.
+            The default it True.
         allow_empty_fractions: bool, optional
             If True, allow empty fractions. The default is True.
         ignore_failed : bool, optional
@@ -343,7 +365,14 @@ class FractionationOptimizer():
         )
 
         opt, x0 = self._setup_optimization_problem(
-            frac, purity_required, allow_empty_fractions, ranking, obj_fun, n_objectives
+            frac,
+            purity_required,
+            allow_empty_fractions,
+            ranking,
+            obj_fun,
+            n_objectives,
+            bad_metrics,
+            minimize,
         )
 
         # Lock to enable caching

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -106,7 +106,12 @@ class CADETProcessRunner(Runner):
         objective_labels = self.optimization_problem.objective_labels
         obj_fun = self.optimization_problem.evaluate_objectives_population
 
-        F = obj_fun(X, untransform=True, parallelization_backend=self.parallelization_backend)
+        F = obj_fun(
+            X,
+            untransform=True,
+            ensure_minimization=True,
+            parallelization_backend=self.parallelization_backend
+        )
 
         # Calculate nonlinear constraints
         # Explore if adding a small amount of noise to the result helps BO
@@ -318,7 +323,7 @@ class AxInterface(OptimizerBase):
 
         self.run_post_processing(
             X_transformed=X,
-            F=F,
+            F_minimized=F,
             G=G,
             CV=CV,
             current_generation=self.ax_experiment.num_trials,

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -42,14 +42,16 @@ class Individual(Structure):
         Independent variable values in transformed space.
     f : list
         Objective values.
+    f_min : list
+        Minimized objective values.
     g : list
         Nonlinear constraint values.
-    m : list
-        Meta score values.
     cv : list
         Nonlinear constraints violation.
     cv_tol : float
         Tolerance for constraints violation.
+    m : list
+        Meta score values.
 
     See Also
     --------
@@ -59,10 +61,11 @@ class Individual(Structure):
     x = Vector()
     x_transformed = Vector()
     f = Vector()
+    f_min = Vector()
     g = Vector()
-    m = Vector()
     cv = Vector()
     cv_tol = Float()
+    m = Vector()
 
     def __init__(
             self,
@@ -70,29 +73,33 @@ class Individual(Structure):
             f=None,
             g=None,
             m=None,
+            x_transformed=None,
+            f_min=None,
             cv=None,
             cv_tol=0,
-            x_transformed=None,
             independent_variable_names=None,
             objective_labels=None,
             contraint_labels=None,
             meta_score_labels=None,
             variable_names=None):
         self.x = x
-        self.f = f
-        self.g = g
-        self.m = m
+        if x_transformed is None:
+            x_transformed = x
+            independent_variable_names = variable_names
+        self.x_transformed = x_transformed
 
+        self.f = f
+        if f_min is None:
+            f_min = f
+        self.f_min = f_min
+
+        self.g = g
         if g is not None and cv is None:
             cv = g
         self.cv = cv
         self.cv_tol = cv_tol
 
-        if x_transformed is None:
-            x_transformed = x
-            independent_variable_names = variable_names
-
-        self.x_transformed = x_transformed
+        self.m = m
 
         if isinstance(variable_names, np.ndarray):
             variable_names = [s.decode() for s in variable_names]
@@ -165,6 +172,10 @@ class Individual(Structure):
         """tuple: Individual dimensions (n_x, n_f, n_g)"""
         return (self.n_x, self.n_f, self.n_g, self.n_m)
 
+    @property
+    def objectives_minimization_factors(self):
+        return self.f_min / self.f
+
     def dominates(self, other):
         """Determine if individual dominates other.
 
@@ -195,8 +206,8 @@ class Individual(Structure):
             self_values = self.m
             other_values = other.m
         else:
-            self_values = self.f
-            other_values = other.f
+            self_values = self.f_min
+            other_values = other.f_min
 
         if np.any(self_values > other_values):
             return False

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -52,6 +52,8 @@ class Individual(Structure):
         Tolerance for constraints violation.
     m : list
         Meta score values.
+    m_min : list
+        Minimized meta score values.
 
     See Also
     --------
@@ -66,6 +68,7 @@ class Individual(Structure):
     cv = Vector()
     cv_tol = Float()
     m = Vector()
+    m_min = Vector()
 
     def __init__(
             self,
@@ -77,6 +80,7 @@ class Individual(Structure):
             f_min=None,
             cv=None,
             cv_tol=0,
+            m_min=None,
             independent_variable_names=None,
             objective_labels=None,
             contraint_labels=None,
@@ -100,6 +104,9 @@ class Individual(Structure):
         self.cv_tol = cv_tol
 
         self.m = m
+        if m_min is None:
+            m_min = m
+        self.m_min = m_min
 
         if isinstance(variable_names, np.ndarray):
             variable_names = [s.decode() for s in variable_names]
@@ -169,12 +176,16 @@ class Individual(Structure):
 
     @property
     def dimensions(self):
-        """tuple: Individual dimensions (n_x, n_f, n_g)"""
+        """tuple: Individual dimensions (n_x, n_f, n_g, n_m)"""
         return (self.n_x, self.n_f, self.n_g, self.n_m)
 
     @property
     def objectives_minimization_factors(self):
         return self.f_min / self.f
+
+    @property
+    def meta_scores_minimization_factors(self):
+        return self.m_min / self.m
 
     def dominates(self, other):
         """Determine if individual dominates other.

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -429,12 +429,15 @@ class OptimizerBase(Structure):
         CV = np.array(CV, ndmin=2)
 
         if self.optimization_problem.n_meta_scores > 0:
-            M = self.optimization_problem.evaluate_meta_scores_population(
+            M_min = self.optimization_problem.evaluate_meta_scores_population(
                 X_transformed,
                 untransform=True,
+                ensure_minimization=True,
                 parallelization_backend=self.parallelization_backend,
             )
+            M = self.optimization_problem.transform_maximization(M_min, scores='meta_scores')
         else:
+            M_min = len(X_transformed)*[None]
             M = len(X_transformed)*[None]
 
         if self.optimization_problem.n_nonlinear_constraints == 0:
@@ -442,12 +445,12 @@ class OptimizerBase(Structure):
             CV = len(X_transformed)*[None]
 
         population = Population()
-        for x_transformed, f, f_min, g, cv, m in zip(X_transformed, F, F_min, G, CV, M):
+        for x_transformed, f, f_min, g, cv, m, m_min in zip(X_transformed, F, F_min, G, CV, M, M_min):
             x = self.optimization_problem.get_dependent_values(
                 x_transformed, untransform=True
             )
             ind = Individual(
-                x, f, g, m, x_transformed, f_min, cv, self.cv_tol,
+                x, f, g, m, x_transformed, f_min, cv, self.cv_tol, m_min,
                 self.optimization_problem.independent_variable_names,
                 self.optimization_problem.objective_labels,
                 self.optimization_problem.nonlinear_constraint_labels,

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -94,6 +94,10 @@ class Population():
         return self.individuals[0].objectives_minimization_factors
 
     @property
+    def meta_scores_minimization_factors(self):
+        return self.individuals[0].meta_scores_minimization_factors
+
+    @property
     def variable_names(self):
         """list: Names of the optimization variables."""
         if self.individuals[0].variable_names is None:
@@ -327,30 +331,44 @@ class Population():
 
     @property
     def m(self):
-        """np.array: All evaluated metas core values."""
+        """np.array: All evaluated meta scores."""
         if self.dimensions[3] > 0:
             return np.array([ind.m for ind in self.individuals])
 
     @property
+    def m_minimized(self):
+        """np.array: All evaluated meta scores, transformed to be minimized."""
+        if self.dimensions[3] > 0:
+            return np.array([ind.m_min for ind in self.individuals])
+
+    @property
+    def m_best(self):
+        """np.array: Best meta scores."""
+        if self.dimensions[3] > 0:
+            m_best = np.min(self.m_minimized, axis=0)
+            return np.multiply(self.meta_scores_minimization_factors, m_best)
+
+    @property
     def m_min(self):
-        """np.array: Minimum meta score values."""
+        """np.array: Minimum meta scores."""
         if self.dimensions[3] > 0:
             return np.min(self.m, axis=0)
 
     @property
     def m_max(self):
-        """np.array: Maximum meta score values."""
+        """np.array: Maximum meta scores."""
         if self.dimensions[3] > 0:
             return np.max(self.m, axis=0)
 
     @property
     def m_avg(self):
-        """np.array: Average meta score values."""
-        return np.mean(self.m, axis=0)
+        """np.array: Average meta scores."""
+        if self.dimensions[3] > 0:
+            return np.mean(self.m, axis=0)
 
     @property
     def is_feasilbe(self):
-        """np.array: Average meta score values."""
+        """np.array: False if any constraint is not met. True otherwise."""
         return np.array([ind.is_feasible for ind in self.individuals])
 
     def setup_objectives_figure(self, include_meta=True, plot_individual=False):

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -278,6 +278,12 @@ class Population():
             return np.array([ind.g for ind in self.individuals])
 
     @property
+    def g_best(self):
+        """np.array: Best nonlinear constraint values."""
+        indices = np.argmin(self.cv, axis=0)
+        return [self.g[ind, i] for i, ind in enumerate(indices)]
+
+    @property
     def g_min(self):
         """np.array: Minimum nonlinear constraint values."""
         if self.dimensions[2] > 0:
@@ -292,7 +298,8 @@ class Population():
     @property
     def g_avg(self):
         """np.array: Average nonlinear constraint values."""
-        return np.mean(self.g, axis=0)
+        if self.dimensions[2] > 0:
+            return np.mean(self.g, axis=0)
 
     @property
     def cv(self):
@@ -315,7 +322,8 @@ class Population():
     @property
     def cv_avg(self):
         """np.array: Average nonlinear constraint violation values."""
-        return np.mean(self.cv, axis=0)
+        if self.dimensions[2] > 0:
+            return np.mean(self.cv, axis=0)
 
     @property
     def m(self):

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -90,6 +90,10 @@ class Population():
         return self.individuals[0].dimensions
 
     @property
+    def objectives_minimization_factors(self):
+        return self.individuals[0].objectives_minimization_factors
+
+    @property
     def variable_names(self):
         """list: Names of the optimization variables."""
         if self.individuals[0].variable_names is None:
@@ -240,6 +244,17 @@ class Population():
     def f(self):
         """np.array: All evaluated objective function values."""
         return np.array([ind.f for ind in self.individuals])
+
+    @property
+    def f_minimized(self):
+        """np.array: All evaluated objective function values, transformed to be minimized."""
+        return np.array([ind.f_min for ind in self.individuals])
+
+    @property
+    def f_best(self):
+        """np.array: Best objective values."""
+        f_best = np.min(self.f_minimized, axis=0)
+        return np.multiply(self.objectives_minimization_factors, f_best)
 
     @property
     def f_min(self):

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -238,6 +238,7 @@ class PymooProblem(Problem):
             F = opt.evaluate_objectives_population(
                 X,
                 untransform=True,
+                ensure_minimization=True,
                 parallelization_backend=self.parallelization_backend,
             )
             out["F"] = np.array(F)

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -253,6 +253,11 @@ class OptimizationResults(Structure):
         return np.cumsum(n_evals)
 
     @property
+    def f_best_history(self):
+        """np.array: Best objective values per generation."""
+        return np.array([pop.f_best for pop in self.meta_fronts])
+
+    @property
     def f_min_history(self):
         """np.array: Minimum objective values per generation."""
         return np.array([pop.f_min for pop in self.meta_fronts])
@@ -637,7 +642,7 @@ class OptimizationResults(Structure):
 
         if target == 'objectives':
             funcs = self.optimization_problem.objectives
-            values_min = self.f_min_history
+            values_min = self.f_best_history
             values_avg = self.f_avg_history
         elif target == 'nonlinear_constraints':
             funcs = self.optimization_problem.nonlinear_constraints

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -273,6 +273,11 @@ class OptimizationResults(Structure):
         return np.array([pop.f_avg for pop in self.meta_fronts])
 
     @property
+    def g_best_history(self):
+        """np.array: Best nonlinear constraint per generation."""
+        return np.array([pop.g_best for pop in self.meta_fronts])
+
+    @property
     def g_min_history(self):
         """np.array: Minimum nonlinear constraint values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
@@ -646,7 +651,7 @@ class OptimizationResults(Structure):
             values_avg = self.f_avg_history
         elif target == 'nonlinear_constraints':
             funcs = self.optimization_problem.nonlinear_constraints
-            values_min = self.g_min_history
+            values_min = self.g_best_history
             values_avg = self.g_avg_history
         elif target == 'meta_scores':
             funcs = self.optimization_problem.meta_scores

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -326,8 +326,13 @@ class OptimizationResults(Structure):
             return np.array([pop.cv_avg for pop in self.meta_fronts])
 
     @property
+    def m_best_history(self):
+        """np.array: Best meta scores per generation."""
+        return np.array([pop.m_best for pop in self.meta_fronts])
+
+    @property
     def m_min_history(self):
-        """np.array: Minimum meta score values per generation."""
+        """np.array: Minimum meta scores per generation."""
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
@@ -335,7 +340,7 @@ class OptimizationResults(Structure):
 
     @property
     def m_max_history(self):
-        """np.array: Maximum meta score values per generation."""
+        """np.array: Maximum meta scores per generation."""
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
@@ -343,7 +348,7 @@ class OptimizationResults(Structure):
 
     @property
     def m_avg_history(self):
-        """np.array: Average meta score values per generation."""
+        """np.array: Average meta scores per generation."""
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
@@ -655,7 +660,7 @@ class OptimizationResults(Structure):
             values_avg = self.g_avg_history
         elif target == 'meta_scores':
             funcs = self.optimization_problem.meta_scores
-            values_min = self.m_min_history
+            values_min = self.m_best_history
             values_avg = self.m_avg_history
         else:
             raise CADETProcessError("Unknown target.")

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -78,7 +78,9 @@ class SciPyInterface(OptimizerBase):
             raise CADETProcessError("Can only handle single objective.")
 
         def objective_function(x):
-            return optimization_problem.evaluate_objectives(x, untransform=True)[0]
+            return optimization_problem.evaluate_objectives(
+                x, untransform=True, ensure_minimization=True,
+            )[0]
 
         def callback_function(x, state=None):
             """Internal callback to report progress after evaluation.
@@ -94,7 +96,11 @@ class SciPyInterface(OptimizerBase):
             self.n_evals += 1
 
             x = x.tolist()
-            f = optimization_problem.evaluate_objectives(x, untransform=True)
+            f = optimization_problem.evaluate_objectives(
+                x,
+                untransform=True,
+                ensure_minimization=True,
+            )
             g = optimization_problem.evaluate_nonlinear_constraints(
                 x, untransform=True
             )

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -165,17 +165,13 @@ class SciPyInterface(OptimizerBase):
         )
 
     def get_constraint_objects(self, optimization_problem):
-        """Defines the constraints of the optimization_problem and resturns
-        them into a list.
-
-        First defines the lincon, the linequon and the nonlincon constraints.
-        Returns the constrainst in a list.
+        """Return constraints as objets.
 
         Returns
         -------
         constraint_objects : list
-            List containing  a sorted list of all constraints of an
-            optimization_problem, if they're not None.
+            List containing lists of all constraint types of the optimization_problem.
+            If type of constraints is not defined, it is replaced with None.
 
         See Also
         --------
@@ -192,16 +188,13 @@ class SciPyInterface(OptimizerBase):
         return [con for con in constraints if con is not None]
 
     def get_lincon_obj(self, optimization_problem):
-        """Returns the optimized linear constraint as an object.
-
-        Sets the lower and upper bounds of the optimization_problem and returns
-        optimized linear constraints. Keep_feasible is set to True.
+        """Return the linear constraints as an object.
 
         Returns
         -------
         lincon_obj : LinearConstraint
-            Linear Constraint object with optimized upper and lower bounds of b
-            of the optimization_problem.
+            Linear Constraint object with lower and upper bounds of b of the
+            optimization_problem.
 
         See Also
         --------
@@ -220,20 +213,13 @@ class SciPyInterface(OptimizerBase):
         )
 
     def get_lineqcon_obj(self, optimization_problem):
-        """Returns the optimized linear equality constraints as an object.
-
-        Checks the length of the beq first, before setting the bounds of the
-        constraint. Sets the lower and upper bounds of the
-        optimization_problem and returns optimized linear equality constraints.
-        Keep_feasible is set to True.
+        """Return the linear equality constraints as an object.
 
         Returns
         -------
-        None: bool
-            If the length of the beq of the optimization_problem is equal zero.
         lineqcon_obj : LinearConstraint
-            Linear equality Constraint object with optimized upper and lower
-            bounds of beq of the optimization_problem.
+            Linear equality Constraint object with lower and upper bounds of beq of the
+            optimization_problem.
 
         See Also
         --------
@@ -253,29 +239,12 @@ class SciPyInterface(OptimizerBase):
         )
 
     def get_nonlincon_obj(self, optimization_problem):
-        """Returns the optimized nonlinear constraints as an object.
-
-        Checks the length of the nonlinear_constraints first, before setting
-        the bounds of the constraint. Tries to set the bounds from the list
-        nonlinear_constraints from the optimization_problem for the lower
-        bounds and sets the upper bounds for the length of the
-        nonlinear_constraints list. If a TypeError is excepted it sets the
-        lower bound by the first entry of the nonlinear_constraints list and
-        the upper bound to infinity. Then a local variable named
-        finite_diff_rel_step is defined. After setting the bounds it returns
-        the optimized nonlinear constraints as an object with the
-        finite_diff_rel_step and the jacobian matrix. The jacobian matrix is
-        got by calling the method nonlinear_constraint_jacobian from the
-        optimization_problem. Keep_feasible is set to True.
+        """Return the optimized nonlinear constraints as an object.
 
         Returns
         -------
-        None: bool
-            If the length of the nonlinear_constraints of the
-            optimization_problem is equal zero.
-        nonlincon_obj : NonlinearConstraint
-            Linear equality Constraint object with optimized upper and lower
-            bounds of beq of the optimization_problem.
+        nonlincon_obj : list
+            Nonlinear constraint violation objects with bounds the optimization_problem.
 
         See Also
         --------
@@ -306,11 +275,11 @@ class SciPyInterface(OptimizerBase):
             in the main loop.
             """
             constr = optimize.NonlinearConstraint(
-                lambda x: opt.evaluate_nonlinear_constraints(x, untransform=True)[i],
-                lb=-np.inf, ub=opt.nonlinear_constraints_bounds[i],
+                lambda x: opt.evaluate_nonlinear_constraints_violation(x, untransform=True)[i],
+                lb=-np.inf, ub=0,
                 finite_diff_rel_step=self.finite_diff_rel_step,
                 keep_feasible=True
-                )
+            )
             return constr
 
         constraints = []

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -361,7 +361,7 @@ class Purity(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return - performance.purity
+        return performance.purity
 
 
 class Concentration(PerformanceIndicator):

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -309,7 +309,7 @@ class Mass(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return - performance.mass
+        return performance.mass
 
 
 class Recovery(PerformanceIndicator):
@@ -322,7 +322,7 @@ class Recovery(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return - performance.recovery
+        return performance.recovery
 
 
 class Productivity(PerformanceIndicator):
@@ -335,7 +335,7 @@ class Productivity(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return - performance.productivity
+        return performance.productivity
 
 
 class EluentConsumption(PerformanceIndicator):
@@ -348,7 +348,7 @@ class EluentConsumption(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return - performance.eluent_consumption
+        return performance.eluent_consumption
 
 
 class Purity(PerformanceIndicator):
@@ -374,7 +374,7 @@ class Concentration(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return - performance.concentration
+        return performance.concentration
 
 
 class PerformanceProduct(PerformanceIndicator):
@@ -391,7 +391,7 @@ class PerformanceProduct(PerformanceIndicator):
 
     def _evaluate(self, performance):
         return \
-            - performance.productivity \
+            performance.productivity \
             * performance.recovery \
             * performance.eluent_consumption
 

--- a/docs/source/user_guide/process_evaluation/fractionation.md
+++ b/docs/source/user_guide/process_evaluation/fractionation.md
@@ -224,8 +224,8 @@ $$
 p = \frac{\sum_i^{n_{comp}}w_i \cdot p_i}{\sum_i^{n_{comp}}(w_i)}
 $$
 
-It is also important to remember that by convention, objectives are minimized.
-Since in this example, the product of mass and concentration should be maximized, the value of the objective function is multiplied by $-1$.
+It is important to remember that by default, objectives are minimized.
+To register a function that is to be maximized, add the `minimize=False` flag.
 Also, the number of objectives the function returns needs to be specified.
 
 ```{code-cell} ipython3
@@ -233,12 +233,13 @@ from CADETProcess.performance import RankedPerformance
 ranking = [1, 1]
 def alternative_objective(performance):
 	performance = RankedPerformance(performance, ranking)
-	return - performance.mass * performance.concentration
+	return performance.mass * performance.concentration
 
 fractionator = fractionation_optimizer.optimize_fractionation(
 	simulation_results, purity_required=[0.95, 0.95],
 	obj_fun=alternative_objective,
     n_objectives=1,
+    minimize=False,
 )
 
 print(fractionator.performance)

--- a/examples/batch_elution/optimization_multi.md
+++ b/examples/batch_elution/optimization_multi.md
@@ -67,21 +67,24 @@ productivity = Productivity()
 optimization_problem.add_objective(
     productivity,
     n_objectives=2,
-    requires=[process_simulator, frac_opt]
+    requires=[process_simulator, frac_opt],
+    minimize=False,
 )
 
 recovery = Recovery()
 optimization_problem.add_objective(
     recovery,
     n_objectives=2,
-    requires=[process_simulator, frac_opt]
+    requires=[process_simulator, frac_opt],
+    minimize=False,
 )
 
 eluent_consumption = EluentConsumption()
 optimization_problem.add_objective(
     eluent_consumption,
     n_objectives=2,
-    requires=[process_simulator, frac_opt]
+    requires=[process_simulator, frac_opt],
+    minimize=False,
 )
 ```
 

--- a/examples/batch_elution/optimization_multi.py
+++ b/examples/batch_elution/optimization_multi.py
@@ -69,21 +69,24 @@ productivity = Productivity()
 optimization_problem.add_objective(
     productivity,
     n_objectives=2,
-    requires=[process_simulator, frac_opt]
+    requires=[process_simulator, frac_opt],
+    minimize=False,
 )
 
 recovery = Recovery()
 optimization_problem.add_objective(
     recovery,
     n_objectives=2,
-    requires=[process_simulator, frac_opt]
+    requires=[process_simulator, frac_opt],
+    minimize=False,
 )
 
 eluent_consumption = EluentConsumption()
 optimization_problem.add_objective(
     eluent_consumption,
     n_objectives=2,
-    requires=[process_simulator, frac_opt]
+    requires=[process_simulator, frac_opt],
+    minimize=False,
 )
 
 

--- a/examples/batch_elution/optimization_single.md
+++ b/examples/batch_elution/optimization_single.md
@@ -80,7 +80,7 @@ ranking = [1, 1]
 performance = PerformanceProduct(ranking=ranking)
 
 optimization_problem.add_objective(
-    performance, requires=[process_simulator, frac_opt]
+    performance, requires=[process_simulator, frac_opt], minimize=False,
 )
 ```
 

--- a/examples/batch_elution/optimization_single.py
+++ b/examples/batch_elution/optimization_single.py
@@ -82,7 +82,7 @@ ranking = [1, 1]
 performance = PerformanceProduct(ranking=ranking)
 
 optimization_problem.add_objective(
-    performance, requires=[process_simulator, frac_opt]
+    performance, requires=[process_simulator, frac_opt], minimize=False,
 )
 
 # %% [markdown]


### PR DESCRIPTION
Currently, all objective functions are expected to return a value that is to be minimized.
However, in reality, objectives are often to be maximized (e.g. a productivity).

This PR adds a new flag to the `add_objectives` method. If `maximize is False`, the result will automatically be multiplied with `-1` internally to convert the maximization problem to a minimization problem.
For reporting, the original value is then used.

Moreover, for nonlinear constraints, the user can now specify a `comparison_operator` (default='le') which is used to compare the output of the nonlinear constraint function with the specified bounds.
In any case, the "true" value of the nonlinear constraint function, as well as the constraint violation are stored for reporting, where positive values indicate the constraint is *not* satisfied.

## To do
pending #114 
- [x] Add `minimize` flag.
- [x] Add flag for nonlinear constraints
- [x] Update documentation (e.g. custom method for fractionation)
