### PR TITLE
Add qNParEGO Ax MOO Interface

### DIFF
--- a/CADETProcess/optimization/__init__.py
+++ b/CADETProcess/optimization/__init__.py
@@ -107,14 +107,14 @@ from .pymooAdapter import NSGA2, U_NSGA3
 import importlib
 
 try:
-   from .axAdapater import BotorchModular, GPEI, NEHVI
+   from .axAdapater import BotorchModular, GPEI, NEHVI, qNParEGO
    ax_imported = True
 except ImportError:
    ax_imported = False
 
 
 def __getattr__(name):
-    if name in ('BotorchModular', 'GPEI', 'NEHVI'):
+    if name in ("BotorchModular", "GPEI", "NEHVI", "qNParEGO"):
         if ax_imported:
             module = importlib.import_module("axAdapter", package=__name__)
             return getattr(module, name)

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -38,7 +38,7 @@ SOO_TEST_KWARGS = {
 MOO_TEST_KWARGS = {
     "atol": 0.01,
     "rtol": 0.1,
-    "mismatch_tol": 0.33,  # 75 % of all solutions must lie on the pareto front
+    "mismatch_tol": 0.3333333333,  # 75 % of all solutions must lie on the pareto front
 }
 
 FTOL = 0.001
@@ -111,7 +111,7 @@ class qNParEGO(qNParEGO):
     n_init_evals = 50
     early_stopping_improvement_bar = 1e-4
     early_stopping_improvement_window = 10
-    n_max_evals = 60
+    n_max_evals = 70
 
 # =========================
 #   Test problem factory

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -8,7 +8,8 @@ from CADETProcess.optimization import (
     SLSQP,
     U_NSGA3,
     GPEI,
-    NEHVI
+    NEHVI,
+    qNParEGO
 )
 
 
@@ -106,6 +107,12 @@ class NEHVI(NEHVI):
     n_max_evals = 60
 
 
+class qNParEGO(qNParEGO):
+    n_init_evals = 50
+    early_stopping_improvement_bar = 1e-4
+    early_stopping_improvement_window = 10
+    n_max_evals = 60
+
 # =========================
 #   Test problem factory
 # =========================
@@ -139,6 +146,7 @@ def optimization_problem(request):
     U_NSGA3,
     GPEI,
     NEHVI,
+    qNParEGO
 ])
 def optimizer(request):
     return request.param()


### PR DESCRIPTION
As recommended by the `Ax` dev team, this PR adds the `qNParEGO` MOO interface that is useful for MOO problems with more than 7 objectives.

It currently fails the convergence tests labled `LinearConstraints`, `NonLinearConstraints` and `LinearNonLinearConstraints` because it has too many discrepancies between it's found solution and the optimal solution but passes all other tests.