### PR TITLE
Always inherit cadet path

### DIFF
--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -460,8 +460,7 @@ class Cadet(SimulatorBase):
         cadet = CadetAPI()
         # Because the initialization in __init__ isn't guaranteed to be called in multiprocessing
         #  situations, ensure that the cadet_path has actually been set.
-        if not hasattr(cadet, "cadet_path"):
-            cadet.cadet_path = self.cadet_path
+        cadet.cadet_path = self.cadet_path
         return cadet
 
     def save_to_h5(self, process, file_path):


### PR DESCRIPTION
Previously, the cadet path set in `Cadet(install_path="path")` was not inherited into cadet instances created from the run() method. 

When this code section below was written, the `CadetAPI()` call did not auto-detect a `cadet_path`. Therefore `not hasattr(cadet, "cadet_path")` was `True`.

```
    def get_new_cadet_instance(self):
        cadet = CadetAPI()
        # Because the initialization in __init__ isn't guaranteed to be called in multiprocessing
        #  situations, ensure that the cadet_path has actually been set.
        if not hasattr(cadet, "cadet_path"):
            cadet.cadet_path = self.cadet_path
        return cadet
```

Now that `CadetAPI()` autodetects CADET, the `cadet_path` set in `Cadet(install_path="path")` is no longer inherited. This PR changes that.