### PR TITLE
Fix/use minutes

### DIFF
--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -271,24 +271,24 @@ class Comparator(Structure):
 
     def plot_comparison(
             self,
-            simulation_results: list[SimulationResults],
+            simulation_results: SimulationResults,
             axs: Axes | list[Axes] | None = None,
             figs: Figure | list[Figure] | None = None,
             file_name: str | None = None,
             show: bool = True,
             plot_individual: bool = False,
-            use_minutes: bool = True,
+            x_axis_in_minutes: bool = True,
             ) -> tuple[list[Figure], list[Axes]]:
         """
         Plot the comparison of the simulation results with the reference data.
 
         Parameters
         ----------
-        simulation_results : list of SimulationResults
-            List of simulation results to compare to reference data.
-        axs : list of AxesSubplot, optional
+        simulation_results : SimulationResults
+            Simulation results to compare to reference data.
+        axs : list of Axes, optional
             List of subplot axes to use for plotting the metrics.
-        figs : list of Figure, optional
+        figs : list of Figures, optional
             List of figures to use for plotting the metrics.
         file_name : str, optional
             Name of the file to save the figure to.
@@ -296,8 +296,8 @@ class Comparator(Structure):
             If True, displays the figure(s) on the screen.
         plot_individual : bool, optional
             If True, generates a separate figure for each metric.
-        use_minutes : bool, optional
-            Option to use x-aches (time) in minutes, default is set to True.
+        x_axis_in_minutes: bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
 
         Returns
         -------
@@ -331,7 +331,7 @@ class Comparator(Structure):
                 'label': 'reference',
             }
             ref_time = metric.reference.time
-            if use_minutes:
+            if x_axis_in_minutes:
                 ref_time = ref_time / 60
 
             plotting.add_overlay(ax, metric.reference.solution, ref_time, **plot_args)

--- a/CADETProcess/dynamicEvents/event.py
+++ b/CADETProcess/dynamicEvents/event.py
@@ -6,6 +6,7 @@ from addict import Dict
 import numpy as np
 from matplotlib.axes import Axes
 
+
 from CADETProcess import CADETProcessError
 
 from CADETProcess.dataStructure import Structure, frozen_attributes
@@ -772,7 +773,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
 
         return flag
 
-    def plot_events(self, use_minutes: bool = True) -> list[Axes]:
+    def plot_events(self, x_axis_in_minutes: bool = True) -> list[Axes]:
         """
         Plot parameter state as a function of time.
 
@@ -782,38 +783,40 @@ class EventHandler(CachedPropertiesMixin, Structure):
 
         Parameters
         ----------
-        use_minutes: bool, optional
-            Option to use x-aches (time) in minutes, default is set to True.
+        x_axis_in_minutes: bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
 
         Returns
         -------
-        list of matplotlib.Axes
-            List of axes objects, each containing a plot of the parameter state.
+        list[Axes]
+            List of Axes objects, each containing a plot of the parameter state.
 
         Notes
         -----
         The time is divided into 1001 linearly spaced points between 0 and the cycle
         time for the evaluation of the parameter state.
         """
-        time = np.linspace(0, self.cycle_time, 1001)
+        time_s = np.linspace(0, self.cycle_time, 1001)
 
-        if use_minutes:
-            time = time / 60
+        time_ax = time_s
+        if x_axis_in_minutes:
+            time_ax = time_ax / 60
+
         axs: list[Axes] = []
 
         for parameter, tl in self.parameter_timelines.items():
             fig, ax = plotting.setup_figure()
 
-            y = tl.value(time)
+            y = tl.value(time_s)
 
             layout = plotting.Layout()
             layout.title = str(parameter)
             layout.x_label = "$time~/~s$"
-            if use_minutes:
+            if x_axis_in_minutes:
                 layout.x_label = "$time~/~min$"
             layout.y_label = '$state$'
 
-            ax.plot(time, y)
+            ax.plot(time_ax, y)
 
             plotting.set_layout(ax, layout)
 

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -6,7 +6,6 @@ from numpy import VisibleDeprecationWarning
 import scipy
 from matplotlib.axes import Axes
 
-
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import NdPolynomial
@@ -407,15 +406,15 @@ class TimeLine():
         return self.section_times[-1]
 
     @plotting.create_and_save_figure
-    def plot(self, ax, use_minutes: bool = True) -> Axes:
+    def plot(self, ax, x_axis_in_minutes: bool = True) -> Axes:
         """Plot the state of the timeline over time.
 
         Parameters
         ----------
         ax : Axes
             The axes to plot on.
-        use_minutes : bool, optional
-            Option to use x-aches (time) in minutes, default is set to True.
+        x_axis_in_minutes: bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
 
         Returns
         -------
@@ -427,7 +426,7 @@ class TimeLine():
         time = np.linspace(start, end, 1001)
         y = self.value(time)
 
-        if use_minutes:
+        if x_axis_in_minutes:
             time = time / 60
             start = start / 60
             end = end / 60
@@ -435,7 +434,9 @@ class TimeLine():
         ax.plot(time, y)
 
         layout = plotting.Layout()
-        layout.x_label = '$time~/~min$'
+        layout.x_label = '$time~/~s$'
+        if x_axis_in_minutes:
+            layout.x_label = '$time~/~min$'
         layout.y_label = '$state$'
         layout.x_lim = (start, end)
         layout.y_lim = (np.min(y), 1.1*np.max(y))

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -230,8 +230,8 @@ class Fractionator(EventHandler):
     def plot_fraction_signal(
             self,
             chromatogram: SolutionIO | None = None,
-            use_minutes: bool = True,
-            ax: Axes = None,
+            x_axis_in_minutes: bool = True,
+            ax: Axes | None = None,
             *args,
             **kwargs,
             ) -> Axes:
@@ -241,9 +241,9 @@ class Fractionator(EventHandler):
         ----------
         chromatogram : SolutionIO, optional
             Chromatogram to be plotted. If None, the first one is plotted.
-        ax : Axes
-            Axes to plot on.
-        use_minutes: bool, optional
+        ax : Axes, optional
+            Axes to plot on. If None, a new figure is created.
+        x_axis_in_minutes: bool, optional
             Option to use x-aches (time) in minutes, default is set to True.
 
         Returns
@@ -268,18 +268,20 @@ class Fractionator(EventHandler):
 
         try:
             start = kwargs['start']
-            if use_minutes:
+            if x_axis_in_minutes:
                 start = start / 60
         except KeyError:
             start = 0
         try:
             end = kwargs['end']
-            if use_minutes:
+            if x_axis_in_minutes:
                 end = end / 60
         except KeyError:
             end = np.max(chromatogram.time)
 
-        _,  ax = chromatogram.plot(show=False, ax=ax, *args, **kwargs)
+        _, ax = chromatogram.plot(
+            show=False, ax=ax, x_axis_in_minutes=x_axis_in_minutes, *args, **kwargs
+        )
 
         y_max = 1.1*np.max(chromatogram.solution)
 
@@ -296,7 +298,7 @@ class Fractionator(EventHandler):
             sec_start = sec.start
             sec_end = sec.end
 
-            if use_minutes:
+            if x_axis_in_minutes:
                 sec_start = sec_start / 60
                 sec_end = sec_end / 60
 

--- a/CADETProcess/processModel/discretization.py
+++ b/CADETProcess/processModel/discretization.py
@@ -12,7 +12,7 @@ class for all other classes in this module and defines some common parameters.
 Specific parameters for each scheme are defined as attributes of each class.
 
 """
-from CADETProcess.dataStructure import Structure
+from CADETProcess.dataStructure import Structure, frozen_attributes
 from CADETProcess.dataStructure import (
     Bool, Switch,
     RangedInteger, UnsignedInteger, UnsignedFloat,
@@ -30,6 +30,7 @@ __all__ = [
 ]
 
 
+@frozen_attributes
 class DiscretizationParametersBase(Structure):
     """Base class for storing discretization parameters.
 
@@ -553,6 +554,7 @@ class GRMDiscretizationDG(DGMixin):
         return self.npar + 1
 
 
+@frozen_attributes
 class WenoParameters(Structure):
     """Discretization parameters for the WENO scheme.
 
@@ -588,6 +590,7 @@ class WenoParameters(Structure):
     _parameters = ['boundary_model', 'weno_eps', 'weno_order']
 
 
+@frozen_attributes
 class ConsistencySolverParameters(Structure):
     """A class for defining the consistency solver parameters for Cadet.
 

--- a/CADETProcess/processModel/discretization.py
+++ b/CADETProcess/processModel/discretization.py
@@ -105,9 +105,6 @@ class DGMixin(DiscretizationParametersBase):
 class LRMDiscretizationFV(DiscretizationParametersBase):
     """Discretization parameters of the FV version of the LRM.
 
-    This class stores parameters for the Lax-Richtmyer-Morton (LRM) flux-based
-    finite volume discretization.
-
     Attributes
     ----------
     ncol : UnsignedInteger, optional

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -513,7 +513,7 @@ class SolutionIO(SolutionBase):
         return mass
 
     def fraction_volume(self, start=None, end=None):
-        """Volume of a fraction interval
+        """Volume of a fraction interval.
 
         Parameters
         ----------

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -30,6 +30,7 @@ Method to slice a Solution:
 import copy
 
 import numpy as np
+from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 from scipy.interpolate import PchipInterpolator
 from scipy import integrate
@@ -536,32 +537,38 @@ class SolutionIO(SolutionBase):
     @plotting.create_and_save_figure
     def plot(
             self,
-            start=None,
-            end=None,
-            components=None,
-            layout=None,
-            y_max=None,
-            ax=None,
+            start: float | None = None,
+            end: float | None = None,
+            components: list[str] | None = None,
+            layout: plotting.Layout | None = None,
+            y_max: float | None = None,
+            x_axis_in_minutes: bool = True,
+            ax: Axes | None = None,
             *args,
             **kwargs,
-            ):
+            ) -> Axes:
         """Plot the entire time_signal for each component.
 
         Parameters
         ----------
         start : float, optional
-            Start time for plotting. The default is 0.
+            Start time for plotting in seconds. If None is provided, the first data
+            point will be used as the start time. The default is None.
         end : float, optional
-            End time for plotting.
-        components : list, optional.
+            End time for plotting in seconds. If None is provided, the last data point
+            will be used as the end time. The default is None.
+        components : list of str, optional
             List of components to be plotted. If None, all components are plotted.
-        layout : plotting.Layout
-            Plot layout options.
+            The default is None.
+        layout : plotting.Layout, optional
+            Plot layout options. The default is None.
         y_max : float, optional
-            Maximum value of y axis.
-            If None, value is automatically deferred from solution.
-        ax : Axes
-            Axes to plot on.
+            Maximum value of the y-axis. If None, the value is automatically
+            determined from the data. The default is None.
+        x_axis_in_minutes : bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
+        ax : Axes, optional
+            Axes to plot on. If None, a new figure is created.
 
         Returns
         -------
@@ -583,16 +590,20 @@ class SolutionIO(SolutionBase):
             coordinates={'time': [start, end]}
         )
 
-        x = solution.time / 60
+        x = solution.time
+        if x_axis_in_minutes:
+            x = x / 60
+            if start is not None:
+                start = start / 60
+            if end is not None:
+                end = end / 60
 
         if layout is None:
             layout = plotting.Layout()
-            layout.x_label = '$time~/~min$'
+            layout.x_label = '$time~/~s$'
+            if x_axis_in_minutes:
+                layout.x_label = '$time~/~min$'
             layout.y_label = '$c~/~mM$'
-            if start is not None:
-                start /= 60
-            if end is not None:
-                end /= 60
             layout.x_lim = (start, end)
         if y_max is not None:
             layout.y_lim = (None, y_max)
@@ -604,24 +615,29 @@ class SolutionIO(SolutionBase):
     @plotting.create_and_save_figure
     def plot_purity(
             self,
-            start=None,
-            end=None,
-            components=None,
-            layout=None,
-            y_max=None,
-            plot_components_purity=True,
-            plot_species_purity=False,
-            alpha=1, hide_labels=False,
-            show_legend=True,
-            ax=None):
+            start: float | None = None,
+            end: float | None = None,
+            components: list[str] | None = None,
+            layout: plotting.Layout | None = None,
+            y_max: float | None = None,
+            x_axis_in_minutes: bool = True,
+            plot_components_purity: bool = True,
+            plot_species_purity: bool = False,
+            alpha: float = 1,
+            hide_labels: bool = False,
+            show_legend: bool = True,
+            ax: Axes | None = None,
+            ) -> Axes:
         """Plot local purity for each component of the concentration profile.
 
         Parameters
         ----------
         start : float, optional
-            Start time for plotting. The default is 0.
+            Start time for plotting in seconds. If None is provided, the first data
+            point will be used as the start time. The default is None.
         end : float, optional
-            End time for plotting.
+            End time for plotting in seconds. If None is provided, the last data point
+            will be used as the end time. The default is None.
         components : list, optional.
             List of components to be plotted. If None, all components are plotted.
             Note that if components are excluded, they will also not be considered in
@@ -631,6 +647,8 @@ class SolutionIO(SolutionBase):
         y_max : float, optional
             Maximum value of y axis.
             If None, value is automatically deferred from solution.
+        x_axis_in_minutes : bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
         plot_components_purity : bool, optional
             If True, plot purity of total component concentration. The default is True.
         plot_species_purity : bool, optional
@@ -673,11 +691,19 @@ class SolutionIO(SolutionBase):
                 "Purity undefined for systems with less than 2 components."
             )
 
-        x = solution.time / 60
+        x = solution.time
+        if x_axis_in_minutes:
+            x = x / 60
+            if start is not None:
+                start = start / 60
+            if end is not None:
+                end = end / 60
 
         if layout is None:
             layout = plotting.Layout()
-            layout.x_label = r'$time~/~min$'
+            layout.x_label = '$time~/~s$'
+            if x_axis_in_minutes:
+                layout.x_label = '$time~/~min$'
             layout.y_label = r'$Purity ~/~\%$'
             if start is not None:
                 start /= 60
@@ -787,23 +813,26 @@ class SolutionBulk(SolutionBase):
     @plotting.create_and_save_figure
     def plot(
             self,
-            start=None,
-            end=None,
-            components=None,
-            layout=None,
-            y_max=None,
-            ax=None,
+            start: float | None = None,
+            end: float | None = None,
+            components: list[str] | None = None,
+            layout: plotting.Layout | None = None,
+            y_max: float | None = None,
+            x_axis_in_minutes: bool = True,
+            ax: Axes | None = None,
             *args,
             **kwargs,
-            ):
+            ) -> Axes:
         """Plot the entire time_signal for each component.
 
         Parameters
         ----------
         start : float, optional
-            Start time for plotting. The default is 0.
+            Start time for plotting in seconds. If None is provided, the first data
+            point will be used as the start time. The default is None.
         end : float, optional
-            End time for plotting.
+            End time for plotting in seconds. If None is provided, the last data point
+            will be used as the end time. The default is None.
         components : list, optional.
             List of components to be plotted. If None, all components are plotted.
         layout : plotting.Layout
@@ -811,6 +840,8 @@ class SolutionBulk(SolutionBase):
         y_max : float, optional
             Maximum value of y axis.
             If None, value is automatically deferred from solution.
+        x_axis_in_minutes : bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
         ax : Axes
             Axes to plot on.
 
@@ -845,16 +876,20 @@ class SolutionBulk(SolutionBase):
             coordinates={'time': [start, end]}
         )
 
-        x = solution.time / 60
+        x = solution.time
+        if x_axis_in_minutes:
+            x = x / 60
+            if start is not None:
+                start = start / 60
+            if end is not None:
+                end = end / 60
 
         if layout is None:
             layout = plotting.Layout()
-            layout.x_label = '$time~/~min$'
+            layout.x_label = '$time~/~s$'
+            if x_axis_in_minutes:
+                layout.x_label = '$time~/~min$'
             layout.y_label = '$c~/~mM$'
-            if start is not None:
-                start /= 60
-            if end is not None:
-                end /= 60
             layout.x_lim = (start, end)
             if y_max is not None:
                 layout.y_lim = (None, y_max)
@@ -878,7 +913,7 @@ class SolutionBulk(SolutionBase):
         Parameters
         ----------
         t : float
-            Time for plotting
+            Time for plotting in seconds.
             If t == -1, the final solution is plotted.
         components : list, optional.
             List of components to be plotted. If None, all components are plotted.
@@ -923,7 +958,7 @@ class SolutionBulk(SolutionBase):
     @plotting.create_and_save_figure
     def plot_at_position(
             self,
-            z,
+            z: float,
             components=None,
             layout=None,
             ax=None,
@@ -963,11 +998,21 @@ class SolutionBulk(SolutionBase):
             coordinates={'axial_coordinates': [z, z]},
         )
 
+        x = self.time
+        if x_axis_in_minutes:
+            x = x / 60
+            if start is not None:
+                start = start / 60
+            if end is not None:
+                end = end / 60
+
         x = self.time / 60
 
         if layout is None:
             layout = plotting.Layout()
-            layout.x_label = '$time~/~min$'
+            layout.x_label = '$time~/~s$'
+            if x_axis_in_minutes:
+                layout.x_label = '$time~/~min$'
             layout.y_label = '$c~/~mM$'
 
         ax = _plot_solution_1D(ax, x, solution, layout, *args, **kwargs)
@@ -1212,23 +1257,26 @@ class SolutionSolid(SolutionBase):
     @plotting.create_and_save_figure
     def plot(
             self,
-            start=None,
-            end=None,
-            components=None,
-            layout=None,
-            y_max=None,
-            ax=None,
+            start: float | None = None,
+            end: float | None = None,
+            components: list[str] | None = None,
+            layout: plotting.Layout | None = None,
+            y_max: float | None = None,
+            x_axis_in_minutes: bool = True,
+            ax: Axes | None = None,
             *args,
             **kwargs,
-            ):
-        """Plot the entire time_signal for each component.
+            ) -> Axes:
+        """Plot the entire solid phase solution for each component.
 
         Parameters
         ----------
         start : float, optional
-            Start time for plotting. The default is 0.
+            Start time for plotting in seconds. If None is provided, the first data
+            point will be used as the start time. The default is None.
         end : float, optional
-            End time for plotting.
+            End time for plotting in seconds. If None is provided, the last data point
+            will be used as the end time. The default is None.
         components : list, optional.
             List of components to be plotted. If None, all components are plotted.
         layout : plotting.Layout
@@ -1236,6 +1284,8 @@ class SolutionSolid(SolutionBase):
         y_max : float, optional
             Maximum value of y axis.
             If None, value is automatically deferred from solution.
+        x_axis_in_minutes : bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
         ax : Axes
             Axes to plot on.
 
@@ -1268,16 +1318,20 @@ class SolutionSolid(SolutionBase):
             coordinates={'time': [start, end]}
         )
 
-        x = solution.time / 60
+        x = solution.time
+        if x_axis_in_minutes:
+            x = x / 60
+            if start is not None:
+                start = start / 60
+            if end is not None:
+                end = end / 60
 
         if layout is None:
             layout = plotting.Layout()
-            layout.x_label = '$time~/~min$'
+            layout.x_label = '$time~/~s$'
+            if x_axis_in_minutes:
+                layout.x_label = '$time~/~min$'
             layout.y_label = '$c~/~mM$'
-            if start is not None:
-                start /= 60
-            if end is not None:
-                end /= 60
             layout.x_lim = (start, end)
         if y_max is not None:
             layout.y_lim = (None, y_max)
@@ -1288,24 +1342,26 @@ class SolutionSolid(SolutionBase):
 
     def _plot_1D(
             self,
-            t,
-            components=None,
-            layout=None,
-            ax=None,
+            t: float,
+            components: list[str] | None = None,
+            layout: plotting.Layout | None = None,
+            ax: Axes | None = None,
             *args,
             **kwargs,
-            ):
+            ) -> Axes:
         """Plot bulk solution over space at given time.
 
         Parameters
         ----------
         t : float
-            Time for plotting
+            Time for plotting, in seconds.
             If t == -1, the final solution is plotted.
-        components : list, optional.
+        components : list, optional
             List of components to be plotted. If None, all components are plotted.
-        layout : plotting.Layout
-            Plot layout options.
+            The default is None.
+        layout : plotting.Layout, optional
+            Plot layout options. If None, a new instance is created.
+            The default is None.
         ax : Axes
             Axes to plot on.
 
@@ -1406,35 +1462,54 @@ class SolutionVolume(SolutionBase):
         return (self.nt, 1)
 
     @plotting.create_and_save_figure
-    def plot(self, start=None, end=None, ax=None, update_layout=True, **kwargs):
-        """Plot the whole time_signal for each component.
+    def plot(
+            self,
+            start: float | None = None,
+            end: float | None = None,
+            x_axis_in_minutes: bool = True,
+            ax: Axes | None = None,
+            update_layout: bool = True,
+            **kwargs
+            ) -> Axes:
+        """Plot the unit operation's volume over time.
 
         Parameters
         ----------
-        start : float
-            start time for plotting
-        end : float
-            end time for plotting
+        start : float, optional
+            Start time for plotting in seconds. If None is provided, the first data
+            point will be used as the start time. The default is None.
+        end : float, optional
+            End time for plotting in seconds. If None is provided, the last data point
+            will be used as the end time. The The default is None.
+        x_axis_in_minutes : bool, optional
+            If True, the x-axis will be plotted using minutes. The default is True.
         ax : Axes
             Axes to plot on.
+        update_layout : bool, optional
+            If True, update the figure's layout. The default is True.
 
         See Also
         --------
         CADETProcess.plot
         """
-        x = self.time / 60
+        x = self.time
+        if x_axis_in_minutes:
+            x = x / 60
+            if start is not None:
+                start = start / 60
+            if end is not None:
+                end = end / 60
+
         y = self.solution * 1000
 
         y_min = np.min(y)
         y_max = 1.1 * np.max(y)
 
         layout = plotting.Layout()
-        layout.x_label = '$time~/~min$'
+        layout.x_label = '$time~/~s$'
+        if x_axis_in_minutes:
+            layout.x_label = '$time~/~min$'
         layout.y_label = '$V~/~L$'
-        if start is not None:
-            start /= 60
-        if end is not None:
-            end /= 60
         layout.x_lim = (start, end)
         layout.y_lim = (y_min, y_max)
         ax.plot(x, y, **kwargs)

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -22,6 +22,7 @@ This module provides functionality for transforming data.
 from abc import ABC, abstractmethod, abstractproperty
 
 import numpy as np
+from matplotlib.axes import Axes
 import matplotlib.pyplot as plt
 
 from CADETProcess import plotting
@@ -239,7 +240,7 @@ class TransformBase(ABC):
 
         Parameters
         ----------
-        ax : matplotlib.axes.Axes
+        ax : Axes
             The axes object to plot on.
         use_log_scale : bool, optional
             If True, use a logarithmic scale for the x-axis.


### PR DESCRIPTION
Recently, the option to (not) plot the time axis using minutes was introduced.
This PR fixes some methods that were not properly implemented. Moreover, the name of the flag was changed from `use_minutes` to `x_axis_in_minutes` to make clear that only plotting is affected and not other parameter values (e.g. start and end times).

## Todo
- [x] Fix error (Error in type annotation)
- [x] Add flag to `plot_purity` (and check other plot methods again)