### PR TITLE
Add COBYQA optimizer

### DIFF
--- a/CADETProcess/optimization/__init__.py
+++ b/CADETProcess/optimization/__init__.py
@@ -36,6 +36,7 @@ Scipy
 
    TrustConstr
    COBYLA
+   COBYQA
    NelderMead
    SLSQP
 
@@ -101,7 +102,7 @@ from .results import *
 from .optimizationProblem import *
 from .parallelizationBackend import *
 from .optimizer import *
-from .scipyAdapter import COBYLA, TrustConstr, NelderMead, SLSQP
+from .scipyAdapter import COBYLA, COBYQA, TrustConstr, NelderMead, SLSQP
 from .pymooAdapter import NSGA2, U_NSGA3
 
 import importlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "pathos>=0.2.8",
     "psutil>=5.9.8",
     "pymoo>=0.6",
-    "scipy>=1.11",
+    "scipy>=1.14",
 ]
 
 [dependency-groups]

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from CADETProcess.optimization import (
     COBYLA,
+    COBYQA,
     SLSQP,
     U_NSGA3,
     NelderMead,
@@ -84,12 +85,12 @@ def set_non_default_parameters(optimizer, problem):
                 setattr(optimizer, pk, pv)
 
 
-class TrustConstr(TrustConstr):
+class COBYLA(COBYLA):
     x_tol = X_TOL
     cv_nonlincon_tol = CV_NONLINCON_TOL
 
 
-class COBYLA(COBYLA):
+class COBYQA(COBYQA):
     x_tol = X_TOL
     cv_nonlincon_tol = CV_NONLINCON_TOL
 
@@ -102,6 +103,11 @@ class NelderMead(NelderMead):
 class SLSQP(SLSQP):
     x_tol = X_TOL
     cv_lincon_tol = CV_LINCON_TOL
+
+
+class TrustConstr(TrustConstr):
+    x_tol = X_TOL
+    cv_nonlincon_tol = CV_NONLINCON_TOL
 
 
 class U_NSGA3(U_NSGA3):
@@ -163,9 +169,10 @@ def optimization_problem(request):
 
 
 params = [
-    TrustConstr,
     COBYLA,
+    COBYQA,
     SLSQP,
+    TrustConstr,
     NelderMead,
     U_NSGA3,
 ]


### PR DESCRIPTION
This PR adds the [`COBYQA`](https://www.cobyqa.com/stable/) optimizer which was recently added to SciPy, in v1.14.

## To do
- [x] Update parameters
- [x] Upstream issue: "ValueError: `x0` is infeasible with respect to some inequality constraint even though it is within bounds." (see [#155](https://github.com/cobyqa/cobyqa/issues/155))
- [x] Add switch for callback methods depending on selected method (see below)

## Open question
This PR also updates the callback function for scipy optimizers. I was hoping that this would include the current best point instead of simply the latest point. This would remove the need to determine the optimal points ourselves using the `ParetoFront` class. However, this is not how it's implemented in `COBYQA` (see [here](https://github.com/cobyqa/cobyqa/issues/157)).

Note, this interface is not supported by `COBYLA` and `SLSQP`, so these optimizers would have to be removed from **CADET-Process** when using the newer interface. Since `COBYQA` can replace `COBYLA`, I don't mind it going but `SLSQP` might be handy to keep around. So should we revert these changes (for now)?

**Edit:** Instead of removing `COBYLA` and `SLSQP`, provide both interfaces and switch depending on the selected method.