### PR TITLE
Support numpy v2

### DIFF
--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -2,7 +2,7 @@ import itertools
 import warnings
 
 import numpy as np
-from numpy import VisibleDeprecationWarning
+from numpy.exceptions import VisibleDeprecationWarning
 import scipy
 from matplotlib.axes import Axes
 


### PR DESCRIPTION
This PR serves to support numpy v2.0

Note, pymoo currently does not support numpy v2.0.0. Until this is resolved, we need to avoid the upgrade.
For further information, refer to https://github.com/anyoptimization/pymoo/issues/606.