### PR TITLE
Add linear threshold parameter for mobile phase modulator 

### DIFF
--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -518,6 +518,8 @@ class MobilePhaseModulator(BindingBaseClass):
     hydrophobicity : list of unsigned floats.
         Parameters describing the hydrophobicity (HIC).
         Length depends on `n_comp`.
+    linear_threshold : UnsignedFloat
+        Concentration of c0 at which to switch to linear model approximation.
     """
 
     adsorption_rate = SizedUnsignedList(size='n_comp')
@@ -527,6 +529,7 @@ class MobilePhaseModulator(BindingBaseClass):
     beta = ion_exchange_characteristic
     hydrophobicity = SizedUnsignedList(size='n_comp')
     gamma = hydrophobicity
+    linear_threshold = UnsignedFloat(default=1e-8)
 
     _parameters = [
         'adsorption_rate',
@@ -534,6 +537,7 @@ class MobilePhaseModulator(BindingBaseClass):
         'capacity',
         'ion_exchange_characteristic',
         'hydrophobicity',
+        'linear_threshold',
     ]
 
 

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -1453,7 +1453,8 @@ adsorption_parameters_map = {
             'MPM_KD': 'desorption_rate',
             'MPM_QMAX': 'capacity',
             'MPM_BETA': 'ion_exchange_characteristic',
-            'MPM_GAMMA': 'hydrophobicity'
+            'MPM_GAMMA': 'hydrophobicity',
+            'MPM_LINEAR_THRESHOLD': 'linear_threshold',
         },
     },
     'ExtendedMobilePhaseModulator': {

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -4,7 +4,7 @@ import numpy
 
 from CADETProcess.processModel import ComponentSystem, binding, BindingBaseClass
 from CADETProcess.processModel import (
-    Langmuir, BiLangmuir, MultistateStericMassAction, StericMassAction
+    Langmuir, BiLangmuir, MultistateStericMassAction, StericMassAction, MobilePhaseModulator
 )
 from CADETProcess.simulator.cadetAdapter import adsorption_parameters_map
 
@@ -50,6 +50,16 @@ class Test_Binding(unittest.TestCase):
         binding_model.reference_liquid_phase_conc = 200
         binding_model.reference_solid_phase_conc = 100
         self.sma = binding_model
+
+        binding_model = MobilePhaseModulator(component_system, name='test')
+
+        binding_model.adsorption_rate = [0.02, 0.03]
+        binding_model.desorption_rate = [1, 1]
+        binding_model.capacity = [100, 100]
+        binding_model.ion_exchange_characteristic = [1.4, 1.7]
+        binding_model.hydrophobicity = [1.4, 1.7]
+        binding_model.linear_threshold = 1e-8
+        self.mobile_phase_modulator = binding_model
 
     def test_sma_reference_concentration_transformations(self):
         adsorption_rate = numpy.array(self.sma.adsorption_rate)


### PR DESCRIPTION
Following the merge of https://github.com/cadet/CADET-Core/pull/261 this PR adds the linearization threshold parameter.