### PR TITLE
Optimizer improvement v2

### DIFF
--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -25,6 +25,7 @@ from botorch.acquisition.analytic import (
     LogExpectedImprovement
 )
 
+from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import UnsignedInteger, Typed, Float
 from CADETProcess.optimization.optimizationProblem import OptimizationProblem
 from CADETProcess.optimization import OptimizerBase
@@ -424,6 +425,14 @@ class AxInterface(OptimizerBase):
 
         n_iter = self.results.n_gen
         n_evals = self.results.n_evals
+
+        global_stopping_message = None
+
+        if n_evals >= self.n_max_evals:
+            raise CADETProcessError(
+                f"Initial number of evaluations exceeds `n_max_evals` "
+                f"({self.n_max_evals})."
+            )
 
         with manual_seed(seed=self.seed):
             while not (n_evals >= self.n_max_evals or n_iter >= self.n_max_iter):

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -110,6 +110,7 @@ class CADETProcessRunner(Runner):
         F = obj_fun(
             X,
             untransform=True,
+            get_dependent_values=True,
             ensure_minimization=True,
             parallelization_backend=self.parallelization_backend
         )
@@ -123,6 +124,7 @@ class CADETProcessRunner(Runner):
             CV = nonlincon_cv_fun(
                 X,
                 untransform=True,
+                get_dependent_values=True,
                 parallelization_backend=self.parallelization_backend
             )
 
@@ -314,7 +316,7 @@ class AxInterface(OptimizerBase):
             G = G_data["mean"].values.reshape((op.n_nonlinear_constraints, n_ind)).T
 
             nonlincon_cv_fun = op.evaluate_nonlinear_constraints_violation
-            CV = nonlincon_cv_fun(X, untransform=True)
+            CV = nonlincon_cv_fun(X, untransform=True, get_dependent_values=True)
         else:
             G = None
             CV = None

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -331,7 +331,7 @@ class AxInterface(OptimizerBase):
             X_transformed=X,
             F_minimized=F,
             G=G,
-            CV=CV,
+            CV_nonlincon=CV,
             current_generation=self.ax_experiment.num_trials,
             X_opt_transformed=None,
         )

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -131,30 +131,30 @@ class OptimizationProblem(Structure):
     def untransforms(func):
         """Untransform population or individual before calling function."""
         @wraps(func)
-        def wrapper(self, x, *args, untransform=False, **kwargs):
+        def wrapper_untransforms(self, x, *args, untransform=False, **kwargs):
             x = np.array(x, ndmin=1)
             if untransform:
                 x = self.untransform(x)
 
             return func(self, x, *args, **kwargs)
 
-        return wrapper
+        return wrapper_untransforms
 
     def gets_dependent_values(func):
         """Get dependent values of individual before calling function."""
         @wraps(func)
-        def wrapper(self, x, *args, get_dependent_values=False, **kwargs):
+        def wrapper_gets_dependent_values(self, x, *args, get_dependent_values=False, **kwargs):
             if get_dependent_values:
                 x = self.get_dependent_values(x)
 
             return func(self, x, *args, **kwargs)
 
-        return wrapper
+        return wrapper_gets_dependent_values
 
     def ensures2d(func):
         """Ensure X array is an ndarray with ndmin=2."""
         @wraps(func)
-        def wrapper(
+        def wrapper_ensures2d(
                 self,
                 X: npt.ArrayLike,
                 *args, **kwargs
@@ -174,13 +174,13 @@ class OptimizationProblem(Structure):
             else:
                 return Y_2d
 
-        return wrapper
+        return wrapper_ensures2d
 
     def ensures_minimization(scores):
         """Convert maximization problems to minimization problems."""
         def wrap(func):
             @wraps(func)
-            def wrapper(self, *args, ensure_minimization=False, **kwargs):
+            def wrapper_ensures_minimization(self, *args, ensure_minimization=False, **kwargs):
                 s = func(self, *args, **kwargs)
 
                 if ensure_minimization:
@@ -188,7 +188,7 @@ class OptimizationProblem(Structure):
 
                 return s
 
-            return wrapper
+            return wrapper_ensures_minimization
         return wrap
 
     def transform_maximization(self, s, scores):

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -152,7 +152,7 @@ class OptimizationProblem(Structure):
         return wrapper
 
     def ensures2d(func):
-        """Decorate function to ensure X array is an ndarray with ndmin=2."""
+        """Ensure X array is an ndarray with ndmin=2."""
         @wraps(func)
         def wrapper(
                 self,
@@ -654,6 +654,7 @@ class OptimizationProblem(Structure):
         return independent_values
 
     @untransforms
+    @gets_dependent_values
     def set_variables(self, x, evaluation_objects=-1):
         """Set the values from the x-vector to the EvaluationObjects.
 
@@ -685,9 +686,7 @@ class OptimizationProblem(Structure):
         evaluate
 
         """
-        values = self.get_dependent_values(x)
-
-        for variable, value in zip(self.variables, values):
+        for variable, value in zip(self.variables, x):
             variable.set_value(value)
 
     def _evaluate_population(
@@ -789,7 +788,6 @@ class OptimizationProblem(Structure):
 
         return results
 
-    @untransforms
     def _evaluate(self, x, func, force=False):
         """Iterate over all evaluation objects and evaluate at x.
 
@@ -797,6 +795,7 @@ class OptimizationProblem(Structure):
         ----------
         x : array_like
             Value of the optimization variables in untransformed space.
+            Must include all variables, including the dependent variables.
         func : Evaluator or Objective, or Nonlinear Constraint, or Callback
             Evaluation function.
         force : bool
@@ -1070,6 +1069,7 @@ class OptimizationProblem(Structure):
 
     @ensures2d
     @untransforms
+    @gets_dependent_values
     @ensures_minimization(scores='objectives')
     def evaluate_objectives(
             self,
@@ -1118,6 +1118,7 @@ class OptimizationProblem(Structure):
         self.evaluate_objectives(*args, *kwargs)
 
     @untransforms
+    @gets_dependent_values
     def objective_jacobian(self, x, ensure_minimization=False, dx=1e-3):
         """Compute jacobian of objective functions using finite differences.
 
@@ -1305,6 +1306,7 @@ class OptimizationProblem(Structure):
 
     @ensures2d
     @untransforms
+    @gets_dependent_values
     def evaluate_nonlinear_constraints(
             self,
             X: npt.ArrayLike,
@@ -1354,6 +1356,7 @@ class OptimizationProblem(Structure):
 
     @ensures2d
     @untransforms
+    @gets_dependent_values
     def evaluate_nonlinear_constraints_violation(
             self,
             X: npt.ArrayLike,
@@ -1416,6 +1419,7 @@ class OptimizationProblem(Structure):
         self.evaluate_nonlinear_constraints_violation(*args, *kwargs)
 
     @untransforms
+    @gets_dependent_values
     def check_nonlinear_constraints(self, x):
         """Check if all nonlinear constraints are met.
 
@@ -1438,6 +1442,7 @@ class OptimizationProblem(Structure):
         return True
 
     @untransforms
+    @gets_dependent_values
     def nonlinear_constraint_jacobian(self, x, dx=1e-3):
         """Compute jacobian of the nonlinear constraints at point x.
 
@@ -1634,7 +1639,7 @@ class OptimizationProblem(Structure):
                 callback._current_iteration = current_iteration
 
                 try:
-                    self._evaluate(ind.x_transformed, callback, force, untransform=True)
+                    self._evaluate(ind.x, callback, force)
                 except CADETProcessError as e:
                     self.logger.warning(
                         f'Evaluation of {callback} failed at {ind.x} with Error "{e}".'
@@ -1760,6 +1765,7 @@ class OptimizationProblem(Structure):
 
     @ensures2d
     @untransforms
+    @gets_dependent_values
     @ensures_minimization(scores='meta_scores')
     def evaluate_meta_scores(
             self,
@@ -2606,7 +2612,7 @@ class OptimizationProblem(Structure):
         Parameters
         ----------
         x_independent : np.ndarray
-            Value of the independent optimization variables in untransformed space.
+            Independent optimization variables in untransformed space.
 
         Returns
         -------
@@ -2630,7 +2636,7 @@ class OptimizationProblem(Structure):
         Parameters
         ----------
         X_transformed : npt.ArrayLike
-            Optimization variables in transformed parameter space.
+            Independent optimization variables in transformed parameter space.
 
         Returns
         -------

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -40,10 +40,10 @@ class PymooInterface(OptimizerBase):
     n_max_gen = UnsignedInteger()
     n_skip = UnsignedInteger(default=0)
 
-    x_tol = xtol            # Alias for uniform interface
-    f_tol = ftol            # Alias for uniform interface
-    cv_tol = cvtol          # Alias for uniform interface
-    n_max_iter = n_max_gen  # Alias for uniform interface
+    x_tol = xtol                # Alias for uniform interface
+    f_tol = ftol                # Alias for uniform interface
+    cv_nonlincon_tol = cvtol    # Alias for uniform interface
+    n_max_iter = n_max_gen      # Alias for uniform interface
 
     _specific_options = [
         'seed', 'pop_size', 'xtol', 'ftol', 'cvtol', 'n_max_gen', 'n_skip'
@@ -111,7 +111,7 @@ class PymooInterface(OptimizerBase):
             ref_dirs=ref_dirs,
             pop_size=pop_size,
             sampling=pop,
-            repair=RepairIndividuals(optimization_problem),
+            repair=RepairIndividuals(self, optimization_problem),
         )
 
         n_max_gen = self.get_max_number_of_generations(optimization_problem)
@@ -266,7 +266,8 @@ class PymooProblem(Problem):
 
 
 class RepairIndividuals(Repair):
-    def __init__(self, optimization_problem, *args, **kwargs):
+    def __init__(self, optimizer, optimization_problem, *args, **kwargs):
+        self.optimizer = optimizer
         self.optimization_problem = optimization_problem
         super().__init__(*args, **kwargs)
 
@@ -278,6 +279,9 @@ class RepairIndividuals(Repair):
                     ind,
                     untransform=True,
                     get_dependent_values=True,
+                    cv_bounds_tol=self.optimizer.cv_bounds_tol,
+                    cv_lincon_tol=self.optimizer.cv_lincon_tol,
+                    cv_lineqcon_tol=self.optimizer.cv_lineqcon_tol,
                     check_nonlinear_constraints=False,
                     ):
                 if X_new is None:

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -240,6 +240,7 @@ class PymooProblem(Problem):
             F = opt.evaluate_objectives(
                 X,
                 untransform=True,
+                get_dependent_values=True,
                 ensure_minimization=True,
                 parallelization_backend=self.parallelization_backend,
             )
@@ -249,11 +250,13 @@ class PymooProblem(Problem):
             G = opt.evaluate_nonlinear_constraints(
                 X,
                 untransform=True,
+                get_dependent_values=True,
                 parallelization_backend=self.parallelization_backend,
             )
             CV = opt.evaluate_nonlinear_constraints_violation(
                 X,
                 untransform=True,
+                get_dependent_values=True,
                 parallelization_backend=self.parallelization_backend,
             )
             out["G"] = np.array(CV)

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -68,8 +68,11 @@ class OptimizationResults(Structure):
     system_information = Dictionary()
 
     def __init__(
-            self, optimization_problem, optimizer,
-            similarity_tol=0, cv_tol=1e-6):
+            self,
+            optimization_problem,
+            optimizer,
+            similarity_tol: float = 0,
+            ):
         self.optimization_problem = optimization_problem
         self.optimizer = optimizer
 
@@ -78,7 +81,6 @@ class OptimizationResults(Structure):
         self._population_all = Population()
         self._populations = []
         self._similarity_tol = similarity_tol
-        self._cv_tol = cv_tol
         self._pareto_fronts = []
 
         if optimization_problem.n_multi_criteria_decision_functions > 0:
@@ -182,7 +184,7 @@ class OptimizationResults(Structure):
             New pareto front. If None, update existing front with latest population.
         """
         pareto_front = ParetoFront(
-            similarity_tol=self._similarity_tol, cv_tol=self._cv_tol
+            similarity_tol=self._similarity_tol
         )
 
         if pareto_new is not None:
@@ -229,6 +231,21 @@ class OptimizationResults(Structure):
         return self.meta_front.x_transformed
 
     @property
+    def cv_bounds(self) -> np.ndarray:
+        """np.array: Bound constraint violation of optimal points."""
+        return self.meta_front.cv_bounds
+
+    @property
+    def cv_lincon(self) -> np.ndarray:
+        """np.array: Linear constraint violation of optimal points."""
+        return self.meta_front.cv_lincon
+
+    @property
+    def cv_lineqcon(self) -> np.ndarray:
+        """np.array: Linear equality constraint violation of optimal points."""
+        return self.meta_front.cv_lineqcon
+
+    @property
     def f(self) -> np.ndarray:
         """np.array: Objective function values of optimal points."""
         return self.meta_front.f
@@ -239,9 +256,9 @@ class OptimizationResults(Structure):
         return self.meta_front.g
 
     @property
-    def cv(self):
-        """np.array: Optimal nonlinear constraint violations."""
-        return self.meta_front.cv
+    def cv_nonlincon(self) -> np.ndarray:
+        """np.array: Nonlinear constraint violation values of optimal points."""
+        return self.meta_front.cv_nonlincon
 
     @property
     def m(self) -> np.ndarray:
@@ -304,28 +321,28 @@ class OptimizationResults(Structure):
             return np.array([pop.g_avg for pop in self.meta_fronts])
 
     @property
-    def cv_min_history(self):
+    def cv_nonlincon_min_history(self) -> np.ndarray:
         """np.array: Minimum nonlinear constraint violation values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.cv_min for pop in self.meta_fronts])
+            return np.array([pop.cv_nonlincon_min for pop in self.meta_fronts])
 
     @property
-    def cv_max_history(self):
+    def cv_nonlincon_max_history(self) -> np.ndarray:
         """np.array: Maximum nonlinear constraint violation values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.cv_max for pop in self.meta_fronts])
+            return np.array([pop.cv_nonlincon_max for pop in self.meta_fronts])
 
     @property
-    def cv_avg_history(self):
+    def cv_nonlincon_avg_history(self) -> np.ndarray:
         """np.array: Average nonlinear constraint violation values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.cv_avg for pop in self.meta_fronts])
+            return np.array([pop.cv_nonlincon_avg for pop in self.meta_fronts])
 
     @property
     def m_best_history(self) -> np.ndarray:

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -79,7 +79,7 @@ class SciPyInterface(OptimizerBase):
 
         def objective_function(x):
             return optimization_problem.evaluate_objectives(
-                x, untransform=True, ensure_minimization=True,
+                x, untransform=True, get_dependent_values=True, ensure_minimization=True,
             )[0]
 
         def callback_function(x, state=None):
@@ -99,13 +99,14 @@ class SciPyInterface(OptimizerBase):
             f = optimization_problem.evaluate_objectives(
                 x,
                 untransform=True,
+                get_dependent_values=True,
                 ensure_minimization=True,
             )
             g = optimization_problem.evaluate_nonlinear_constraints(
-                x, untransform=True
+                x, untransform=True, get_dependent_values=True,
             )
             cv = optimization_problem.evaluate_nonlinear_constraints_violation(
-                x, untransform=True
+                x, untransform=True, get_dependent_values=True,
             )
 
             self.run_post_processing(x, f, g, cv, self.n_evals)
@@ -275,7 +276,9 @@ class SciPyInterface(OptimizerBase):
             in the main loop.
             """
             constr = optimize.NonlinearConstraint(
-                lambda x: opt.evaluate_nonlinear_constraints_violation(x, untransform=True)[i],
+                lambda x: opt.evaluate_nonlinear_constraints_violation(
+                    x, untransform=True, get_dependent_values=True,
+                )[i],
                 lb=-np.inf, ub=0,
                 finite_diff_rel_step=self.finite_diff_rel_step,
                 keep_feasible=True

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -398,7 +398,7 @@ class TrustConstr(SciPyInterface):
     disp = Bool(default=False)
 
     x_tol = xtol            # Alias for uniform interface
-    cv_tol = gtol           # Alias for uniform interface
+    cv_nonlincon_tol = gtol # Alias for uniform interface
     n_max_evals = maxiter   # Alias for uniform interface
     n_max_iter = maxiter    # Alias for uniform interface
 
@@ -449,10 +449,10 @@ class COBYLA(SciPyInterface):
     disp = Bool(default=False)
     catol = UnsignedFloat(default=0.0002)
 
-    x_tol = tol             # Alias for uniform interface
-    cv_tol = catol          # Alias for uniform interface
-    n_max_evals = maxiter   # Alias for uniform interface
-    n_max_iter = maxiter    # Alias for uniform interface
+    x_tol = tol                 # Alias for uniform interface
+    cv_nonlincon_tol = catol    # Alias for uniform interface
+    n_max_evals = maxiter       # Alias for uniform interface
+    n_max_iter = maxiter        # Alias for uniform interface
 
     _specific_options = ['rhobeg', 'tol', 'maxiter', 'disp', 'catol']
 

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -21,7 +21,7 @@ def setup_individual(n_vars=2, n_obj=1, n_nonlin=0, n_meta=0, rng=None):
     else:
         m = None
 
-    return Individual(x, f, g, m)
+    return Individual(x, f=f, g=g, m=m)
 
 
 class TestHashArray(unittest.TestCase):
@@ -75,7 +75,7 @@ class TestIndividual(unittest.TestCase):
         f = [-1]
         g = [2]
         m = [1]
-        self.individual_constr_meta = Individual(x, f, g, cv=g, m=m)
+        self.individual_constr_meta = Individual(x, f, g, cv_nonlincon=g, m=m)
 
     def test_dimensions(self):
         dimensions_expected = (2, 1, 0, 0)
@@ -145,7 +145,7 @@ class TestIndividual(unittest.TestCase):
 
         # Missing: Test for labels.
         # self.assertEqual(data['objective_labels'], self.individual_1.objective_labels)
-        # self.assertEqual(data['contraint_labels'], self.individual_1.contraint_labels)
+        # self.assertEqual(data['nonlinear_constraint_labels'], self.individual_1.nonlinear_constraint_labels)
         # self.assertEqual(data['meta_score_labels'], elf.individual_1.meta_score_labels)
 
     def test_from_dict(self):
@@ -170,7 +170,7 @@ class TestIndividual(unittest.TestCase):
             test_individual.objective_labels, self.individual_1.objective_labels
         )
         self.assertEqual(
-            test_individual.contraint_labels, self.individual_1.contraint_labels
+            test_individual.nonlinear_constraint_labels, self.individual_1.nonlinear_constraint_labels
         )
         self.assertEqual(
             test_individual.meta_score_labels, self.individual_1.meta_score_labels

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -43,7 +43,11 @@ MOO_TEST_KWARGS = {
 
 F_TOL = 0.001
 X_TOL = 0.001
-CV_TOL = 0.0001
+
+CV_BOUNDS_TOL = 1e-9
+CV_LINCON_TOL = 1e-6
+CV_LINEQCON_TOL = 1e-9
+CV_NONLINCON_TOL = 0.0001
 
 EXCLUDE_COMBINATIONS = [
     (
@@ -78,12 +82,12 @@ def set_non_default_parameters(optimizer, problem):
 
 class TrustConstr(TrustConstr):
     x_tol = X_TOL
-    cv_tol = CV_TOL
+    cv_nonlincon_tol = CV_NONLINCON_TOL
 
 
 class COBYLA(COBYLA):
     x_tol = X_TOL
-    cv_tol = CV_TOL
+    cv_nonlincon_tol = CV_NONLINCON_TOL
 
 
 class NelderMead(NelderMead):
@@ -93,17 +97,19 @@ class NelderMead(NelderMead):
 
 class SLSQP(SLSQP):
     x_tol = X_TOL
+    cv_lincon_tol = CV_LINCON_TOL
 
 
 class U_NSGA3(U_NSGA3):
     f_tol = F_TOL
     x_tol = X_TOL
-    cv_tol = CV_TOL
+    cv_nonlincon_tol = CV_NONLINCON_TOL
     pop_size = 100
     n_max_gen = 20  # before used 100 generations --> this did not improve the fit
 
 
 class GPEI(GPEI):
+    cv_lincon_tol = CV_LINCON_TOL
     n_init_evals = 40
     early_stopping_improvement_bar = 1e-4
     early_stopping_improvement_window = 10
@@ -111,6 +117,7 @@ class GPEI(GPEI):
 
 
 class NEHVI(NEHVI):
+    cv_lincon_tol = CV_LINCON_TOL
     n_init_evals = 50
     early_stopping_improvement_bar = 1e-4
     early_stopping_improvement_window = 10
@@ -118,6 +125,7 @@ class NEHVI(NEHVI):
 
 
 class qNParEGO(qNParEGO):
+    cv_lincon_tol = CV_LINCON_TOL
     n_init_evals = 50
     early_stopping_improvement_bar = 1e-4
     early_stopping_improvement_window = 10

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -28,39 +28,39 @@ class TestPopulation(unittest.TestCase):
     def setUp(self):
         x = [1, 2]
         f = [-1]
-        self.individual_1 = Individual(x, f)
+        self.individual_1 = Individual(x, f=f)
 
         x = [2, 3]
         f = [-2]
-        self.individual_2 = Individual(x, f)
+        self.individual_2 = Individual(x, f=f)
 
         x = [1.001, 2]
         f = [-1.001]
-        self.individual_similar = Individual(x, f)
+        self.individual_similar = Individual(x, f=f)
 
         x = [1, 2]
         f = [-1, -2]
-        self.individual_multi_1 = Individual(x, f)
+        self.individual_multi_1 = Individual(x, f=f)
 
         x = [1.001, 2]
         f = [-1.001, -2]
-        self.individual_multi_2 = Individual(x, f)
+        self.individual_multi_2 = Individual(x, f=f)
 
         x = [1, 2]
         f = [-1]
         g = [3]
-        self.individual_constr_1 = Individual(x, f, g)
+        self.individual_constr_1 = Individual(x, f=f, g=g)
 
         x = [2, 3]
         f = [-2]
         g = [0]
-        self.individual_constr_2 = Individual(x, f, g)
+        self.individual_constr_2 = Individual(x, f=f, g=g)
 
         x = [2, 3]
         f = [-2, -2]
         g = [0]
         m = [-4]
-        self.individual_multi_meta_1 = Individual(x, f, m=m)
+        self.individual_multi_meta_1 = Individual(x, f=f, m=m)
 
         self.population = Population()
         self.population.add_individual(self.individual_1)
@@ -138,7 +138,7 @@ class TestPopulation(unittest.TestCase):
                 self.individual_1, ignore_duplicate=False
             )
 
-        new_individual = Individual([9, 10], [3], [-1])
+        new_individual = Individual([9, 10], f=[3], g=[-1])
         with self.assertRaises(CADETProcessError):
             self.population.add_individual(new_individual)
 


### PR DESCRIPTION
This PR includes a couple of improvements to the optimization module and is a continuation of #152

## General improvements
- [x] Consider bound and linear constraint violations in feasibility
- [x] `Individual.cv` does not work if any of the bounds are `None` (breaks `np.concatenate`).
- [ ] Add tests for dependent variables

## Open questions
- [x] `cv_tol` was renamed to `cv_nonlincontol` which is more explicit, especially for reporting results in the `Individual` (since we also want to report the violations of other constraints). However, `cv_tol` is also a parameter for the `OptimizerBase`. Here, it's not always clear to me for what the `cv_tol` is used (I presume it's also mostly just for nonlinear constraints but I'll have to investigate this). Also, does this sacrifice a breaking change? Generally, I would encourage not using `x_tol`, `f_tol` or `cv_(nonlincon)tol` but rather setting the parameters as described in the corresponding optimizer implementation (e.g. `gtol` in `TrustConstr`).