### PR TITLE
Fix loading of multi-cycle solutions

### DIFF
--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -693,17 +693,17 @@ class Cadet(SimulatorBase):
                                 )
                             )
 
-                    if 'solution_volume' in unit_solution.keys():
-                        sol_volume = unit_solution.solution_volume[start:end, :]
-                        solution[unit.name]['volume'].append(
-                            SolutionVolume(
-                                unit.name,
-                                unit.component_system,
-                                time,
-                                sol_volume
+                        if 'solution_volume' in unit_solution.keys():
+                            sol_volume = unit_solution.solution_volume[start:end, :]
+                            solution[unit.name]['volume'].append(
+                                SolutionVolume(
+                                    unit.name,
+                                    unit.component_system,
+                                    time,
+                                    sol_volume
+                                )
                             )
-                        )
-                    start = end - 1
+                        start = end - 1
 
             solution = Dict(solution)
 


### PR DESCRIPTION
This PR fixes a bug that occurs when loading the results of multi-cycle simulations where only the first cycle gets loaded for all cycles.

The cause was a block of code that was not indented enough. The for loop iterates over all cycles. The codeblock in question contained the code to bump the start-coordinate, so that the next cycle would be loaded on the next iteration of the for loop.

simplified example before:
```python
start = 0
for cycle in cycles:
    end = start + len(time)
    if 'solution_x' in unit_solution.keys():
        load_solution_x(start, end)
    if 'solution_y' in unit_solution.keys():
        load_solution_y(start, end)
if 'solution_z' in unit_solution.keys():
    load_solution_z(start, end)
start = end - 1
```

example as it is now:

```python
start = 0
for cycle in cycles:
    end = start + len(time)
    if 'solution_x' in unit_solution.keys():
        load_solution_x(start, end)
    if 'solution_y' in unit_solution.keys():
        load_solution_y(start, end)
    if 'solution_z' in unit_solution.keys():
        load_solution_z(start, end)
    start = end - 1
```