### PR TITLE
Adapt to new CSTR interface

### DIFF
--- a/CADETProcess/equilibria/initial_conditions.py
+++ b/CADETProcess/equilibria/initial_conditions.py
@@ -52,8 +52,8 @@ def simulate_solid_equilibria(
 
     if unit_model == 'cstr':
         unit = Cstr(component_system, 'cstr')
-        unit.porosity = 0.5
-        unit.V = 1e-6
+        unit.init_liquid_volume = 5e-7
+        unit.const_solid_volume = 5e-7
 
         Q = 1e-6
         cycle_time = np.round(1000*unit.volume/Q)

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -708,7 +708,7 @@ class Process(EventHandler):
         for cstr in self.flow_sheet.cstrs:
             if cstr.flow_rate is None:
                 continue
-            V_0 = cstr.V
+            V_0 = cstr.init_liquid_volume
             unit_index = self.flow_sheet.get_unit_index(cstr)
             for port in self.flow_sheet.units[unit_index].ports:
                 V_in = self.flow_rate_timelines[cstr.name].total_in[port].integral()

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -1111,6 +1111,10 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         Initial volume of the reactor.
     porosity : UnsignedFloat between 0 and 1.
         Total porosity of the Cstr.
+    initial_liquid_volume : UnsignedFloat above 0.
+        Initial liquid volume of the reactor.
+    const_solid_volume : UnsignedFloat above or equal 0.
+        Initial and constant solid volume of the reactor.
     flow_rate_filter: float
         Flow rate of pure liquid without components to reduce volume.
     solution_recorder : CSTRRecorder
@@ -1126,9 +1130,8 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
     supports_bulk_reaction = True
     supports_particle_reaction = False
 
-    porosity = UnsignedFloat(ub=1, default=1)
     flow_rate_filter = UnsignedFloat(default=0)
-    _parameters = ['porosity', 'flow_rate_filter']
+    _parameters = ['const_solid_volume', 'flow_rate_filter']
 
     _section_dependent_parameters = \
         UnitBaseClass._section_dependent_parameters + \
@@ -1137,8 +1140,10 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
 
     c = SizedList(size='n_comp', default=0)
     _q = SizedUnsignedList(size='n_bound_states', default=0)
-    V = UnsignedFloat()
-    _initial_state = ['c', 'q', 'V']
+    init_liquid_volume = UnsignedFloat()
+    const_solid_volume = UnsignedFloat()
+    _V = UnsignedFloat()
+    _initial_state = ['c', 'q', 'init_liquid_volume']
     _parameters = _parameters + _initial_state
 
     def __init__(self, *args, **kwargs):
@@ -1157,19 +1162,50 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         return required_parameters
 
     @property
+    def porosity(self):
+        if self.const_solid_volume is None or self.init_liquid_volume is None:
+            return None
+        return self.init_liquid_volume / (self.init_liquid_volume + self.const_solid_volume)
+
+    @porosity.setter
+    def porosity(self, porosity):
+        warnings.warn(
+            "Field POROSITY is only supported for backwards compatibility, but the implementation of the CSTR has "
+            "changed, please refer to the documentation. The POROSITY will be used to compute the "
+            "constant solid volume from the total volume V."
+        )
+        if self.V is None:
+            raise RuntimeError("Please set the volume first before setting a porosity.")
+        self.const_solid_volume = self.V * (1 - porosity)
+        self.init_liquid_volume = self.V * porosity
+
+    @property
+    def V(self):
+        return self._V
+
+    @V.setter
+    def V(self, V):
+        warnings.warn(
+            "The field V is only supported for backwards compatibility. Please set initial_liquid_volume and "
+            "const_solid_volume"
+        )
+        self.init_liquid_volume = V
+        self._V = V
+
+    @property
     def volume(self):
         """float: Alias for volume."""
-        return self.V
+        return self.const_solid_volume + self.init_liquid_volume
 
     @property
     def volume_liquid(self):
         """float: Volume of the liquid phase."""
-        return self.porosity * self.V
+        return self.init_liquid_volume
 
     @property
     def volume_solid(self):
         """float: Volume of the solid phase."""
-        return (1 - self.porosity) * self.V
+        return self.const_solid_volume
 
     def calculate_interstitial_rt(self, flow_rate):
         """Calculate mean residence time of a (non adsorbing) volume element.

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -1266,11 +1266,11 @@ unit_parameters_map = {
         'name': 'CSTR',
         'parameters': {
             'NCOMP': 'n_comp',
-            'INIT_VOLUME': 'V',
             'INIT_C': 'c',
             'INIT_Q': 'q',
-            'POROSITY': 'porosity',
             'FLOWRATE_FILTER': 'flow_rate_filter',
+            'CONST_SOLID_VOLUME': 'const_solid_volume',
+            'INIT_LIQUID_VOLUME': 'init_liquid_volume',
         },
     },
     'MCT': {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
 ]
 dependencies = [
     "addict==2.3",
-    "cadet-python>=0.14,<1.0.0",
+    "cadet-python>=1.0",
     "corner>=2.2.1",
     "diskcache>=5.4.0",
     "hopsy>=1.4.0",

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -42,20 +42,19 @@ class Test_Adapter(unittest.TestCase):
     @unittest.skipIf(found_cadet is False, "Skip if CADET is not installed.")
     def test_install_path(self):
         simulator = Cadet()
-        self.assertEqual(cli_path, simulator.cadet_cli_path)
+        self.assertEqual(cli_path, simulator.get_new_cadet_instance().cadet_cli_path)
 
-        with self.assertWarns(UserWarning):
-            simulator.install_path = cli_path
-        self.assertEqual(cli_path, simulator.cadet_cli_path)
+        simulator.install_path = cli_path
+        self.assertEqual(cli_path, simulator.get_new_cadet_instance().cadet_cli_path)
 
         simulator.install_path = cli_path.parent.parent
-        self.assertEqual(cli_path, simulator.cadet_cli_path)
+        self.assertEqual(cli_path, simulator.get_new_cadet_instance().cadet_cli_path)
 
         simulator = Cadet(install_path)
-        self.assertEqual(cli_path, simulator.cadet_cli_path)
+        self.assertEqual(cli_path, simulator.get_new_cadet_instance().cadet_cli_path)
 
         with self.assertRaises(FileNotFoundError):
-            simulator = Cadet('foo/bar')
+            simulator = Cadet('foo/bar').get_new_cadet_instance()
 
     @unittest.skipIf(found_cadet is False, "Skip if CADET is not installed.")
     def test_check_cadet(self):
@@ -65,7 +64,8 @@ class Test_Adapter(unittest.TestCase):
 
         file_name = simulator.get_tempfile_name()
         cwd = simulator.temp_dir
-        sim = simulator.create_lwe(cwd / file_name)
+        sim = simulator.get_new_cadet_instance()
+        sim.create_lwe(cwd / file_name)
         sim.run()
 
     @unittest.skipIf(found_cadet is False, "Skip if CADET is not installed.")
@@ -74,7 +74,8 @@ class Test_Adapter(unittest.TestCase):
 
         file_name = simulator.get_tempfile_name()
         cwd = simulator.temp_dir
-        sim = simulator.create_lwe(cwd / file_name)
+        sim = simulator.get_new_cadet_instance()
+        sim.create_lwe(cwd / file_name)
         sim.run()
 
     def tearDown(self):

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -212,7 +212,7 @@ class TestAdsorptionEquilibrium(unittest.TestCase):
         buffer = [1, 1]
         eq = equilibria.simulate_solid_equilibria(self.sma, buffer)
         eq_expected = [10/3, 2*10/3]
-        np.testing.assert_almost_equal(eq, eq_expected)
+        np.testing.assert_almost_equal(eq, eq_expected, decimal=4)
 
 
 if __name__ == '__main__':

--- a/tests/test_unit_operation.py
+++ b/tests/test_unit_operation.py
@@ -25,6 +25,8 @@ volume = cross_section_area * length
 bed_porosity = 0.3
 particle_porosity = 0.6
 total_porosity = bed_porosity + (1 - bed_porosity) * particle_porosity
+const_solid_volume = volume * (1 - total_porosity)
+init_liquid_volume = volume * total_porosity
 
 axial_dispersion = 4.7e-7
 
@@ -53,8 +55,11 @@ class Test_Unit_Operation(unittest.TestCase):
     def create_cstr(self):
         cstr = Cstr(self.component_system, name='test')
 
-        cstr.porosity = total_porosity
-        cstr.V = volume
+        # cstr.V = volume
+        # cstr.porosity = total_porosity
+
+        cstr.const_solid_volume = const_solid_volume
+        cstr.init_liquid_volume = init_liquid_volume
 
         cstr.flow_rate = 1
 
@@ -217,11 +222,11 @@ class Test_Unit_Operation(unittest.TestCase):
         cstr = self.create_cstr()
         parameters_expected = {
                 'flow_rate': np.array([1, 0, 0, 0]),
-                'porosity': total_porosity,
+                'init_liquid_volume': init_liquid_volume,
                 'flow_rate_filter': 0,
                 'c': [0, 0],
                 'q': [],
-                'V': volume,
+                'const_solid_volume': const_solid_volume,
         }
 
         np.testing.assert_equal(parameters_expected, cstr.parameters)
@@ -241,7 +246,7 @@ class Test_Unit_Operation(unittest.TestCase):
             poly_parameters, cstr.polynomial_parameters
         )
 
-        self.assertEqual(cstr.required_parameters, ['V'])
+        self.assertEqual(cstr.required_parameters, ['const_solid_volume', 'init_liquid_volume'])
 
 
     def test_MCT(self):


### PR DESCRIPTION
The new CSTR unit in CADET v5.0.0 deprecates setting volume and porosity in favor of setting init_liquid_volume and const_solid_volume. This PR adapts CADET-Process to this change. The new parameters have been added to the CSTR UO with backwards-compatibility functions to calculate the new parameters from the old parameters combined with deprecation warnings.