### PR TITLE
Resolves: ImportError cannot import name FixedNoiseGP from `botorch.models.gp_regression`

### DIFF
--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -20,7 +20,7 @@ from ax.models.torch.botorch_modular.surrogate import Surrogate
 from ax.utils.common.result import Err, Ok
 from ax.service.utils.report_utils import exp_to_df
 from botorch.utils.sampling import manual_seed
-from botorch.models.gp_regression import FixedNoiseGP
+from botorch.models.gp_regression import SingleTaskGP
 from botorch.acquisition.analytic import (
     LogExpectedImprovement
 )
@@ -521,7 +521,7 @@ class BotorchModular(SingleObjectiveAxInterface):
     surrogate_model: Model class
     """
     acquisition_fn = Typed(ty=type, default=LogExpectedImprovement)
-    surrogate_model = Typed(ty=type, default=FixedNoiseGP)
+    surrogate_model = Typed(ty=type, default=SingleTaskGP)
 
     _specific_options = [
         'acquisition_fn', 'surrogate_model'
@@ -552,7 +552,7 @@ class NEHVI(MultiObjectiveAxInterface):
     supports_single_objective = False
 
     def __repr__(self):
-        smn = 'FixedNoiseGP'
+        smn = 'SingleTaskGP'
         afn = 'NEHVI'
 
         return f'{smn}+{afn}'
@@ -578,7 +578,7 @@ class qNParEGO(MultiObjectiveAxInterface):
     supports_single_objective = False
 
     def __repr__(self):
-        smn = 'FixedNoiseGP'
+        smn = 'SingleTaskGP'
         afn = 'qNParEGO'
 
         return f'{smn}+{afn}'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ testing = [
     "certifi", # tries to prevent certificate problems on windows
     "pytest",
     "pre-commit", # system tests run pre-commit
-    "ax-platform >=0.3.5,<0.4.3"
+    "ax-platform >=0.3.5"
 ]
 docs = [
     "myst-nb>=0.17.1",
@@ -56,7 +56,7 @@ docs = [
 ]
 
 ax = [
-    "ax-platform >=0.3.5,<0.4.3"
+    "ax-platform >=0.3.5"
 ]
 
 [project.urls]


### PR DESCRIPTION
FixedNoiseGP was deprecated for a while. The PR replaces `FixedNoiseGP` with `SingleTaskGP`. If ax tests pass, this should be ready to merge. SingleTaskGP has already been used in #98 