### PR TITLE
Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,8 +64,8 @@ homepage = "https://github.com/fau-advanced-separations/CADET-Process"
 documentation = "https://cadet-process.readthedocs.io"
 "Bug Tracker" = "https://github.com/fau-advanced-separations/CADET-Process/issues"
 
-[tool.setuptools]
-packages = ["CADETProcess"]
+[tool.setuptools.packages]
+find = {}
 
 [tool.setuptools.dynamic]
 version = { attr = "CADETProcess.__version__" }


### PR DESCRIPTION
When migrating to `pyproject.toml`, we had forgotten to remove the `setup.cfg` file (see #165). Now that we finally did delete it, [users in the Forum reported](https://forum.cadet-web.de/t/dev-branch-pip-install-not-working/1119) that subpackages were not installed properly. This PR aims to fix this.

