### PR TITLE
Updates test_cadet_adapter to new CADET-Core (+ minor bug fix)

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,27 @@
+{
+  "title": "CADET-Process",
+  "upload_type": "software",
+  "creators": [
+
+    {
+      "name": "Schmölder, Johannes",
+      "orcid": "0000-0003-0446-7209",
+      "affiliation": "Forschungszentrum Jülich"
+    },
+    {
+      "name": "Jäpel, Ronald",
+      "orcid": "0000-0002-4912-5176",
+      "affiliation": "Forschungszentrum Jülich"
+    }
+  ],
+  "license": "GPL-3.0",
+  "keywords": [
+   "modeling","simulation", "biotechnology", "process", "chromatography", "CADET", "general rate model", "C++"
+  ],
+  "version": "0.9.1",
+  "access_right": "open",
+  "communities": [
+    { "identifier": "open-source" }
+  ],
+  "doi": "10.5281/zenodo.14202878"
+}

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -504,7 +504,7 @@ class Cadet(SimulatorBase):
                             )
 
                         if 'solution_volume' in unit_solution.keys():
-                            sol_volume = unit_solution.solution_volume[start:end, :]
+                            sol_volume = unit_solution.solution_volume[start:end]
                             solution[unit.name]['volume'].append(
                                 SolutionVolume(
                                     unit.name,

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -801,11 +801,7 @@ class SolutionBulk(SolutionBase):
         self.component_system_original = component_system
         self.time_original = time
 
-        if axial_coordinates is not None and len(axial_coordinates) == 1:
-            axial_coordinates = None
-
         self.axial_coordinates = axial_coordinates
-
         self.radial_coordinates = radial_coordinates
 
         self.solution_original = solution
@@ -1074,21 +1070,8 @@ class SolutionParticle(SolutionBase):
             particle_coordinates=None
             ):
 
-        if axial_coordinates is not None and len(axial_coordinates) == 1:
-            axial_coordinates = None
-
         self.axial_coordinates = axial_coordinates
-        # Account for dimension reduction in case of only one cell (e.g. LRMP)
-
-        if radial_coordinates is not None and len(radial_coordinates) == 1:
-            radial_coordinates = None
-
         self.radial_coordinates = radial_coordinates
-        # Account for dimension reduction in case of only one cell (e.g. CSTR)
-
-        if particle_coordinates is not None and len(particle_coordinates) == 1:
-            particle_coordinates = None
-
         self.particle_coordinates = particle_coordinates
 
         super().__init__(name, component_system, time, solution)
@@ -1109,6 +1092,7 @@ class SolutionParticle(SolutionBase):
 
     @property
     def npar(self):
+        """int: Number of particle discretization points."""
         if self.particle_coordinates is None:
             return
         return len(self.particle_coordinates)
@@ -1250,16 +1234,8 @@ class SolutionSolid(SolutionBase):
 
         self.bound_states = bound_states
 
-        if axial_coordinates is not None and len(axial_coordinates) == 1:
-            axial_coordinates = None
         self.axial_coordinates = axial_coordinates
-        # Account for dimension reduction in case of only one cell (e.g. LRMP)
-        if radial_coordinates is not None and len(radial_coordinates) == 1:
-            radial_coordinates = None
         self.radial_coordinates = radial_coordinates
-        # Account for dimension reduction in case of only one cell (e.g. CSTR)
-        if particle_coordinates is not None and len(particle_coordinates) == 1:
-            particle_coordinates = None
         self.particle_coordinates = particle_coordinates
 
         super().__init__(name, component_system, time, solution)
@@ -1286,6 +1262,7 @@ class SolutionSolid(SolutionBase):
 
     @property
     def npar(self):
+        """int: Number of particle discretization points."""
         if self.particle_coordinates is None:
             return
         return len(self.particle_coordinates)

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -1472,7 +1472,7 @@ class SolutionVolume(SolutionBase):
     @property
     def solution_shape(self):
         """tuple: (Expected) shape of the solution"""
-        return (self.nt, 1)
+        return (self.nt, )
 
     @plotting.create_and_save_figure
     def plot(

--- a/CITATION.bib
+++ b/CITATION.bib
@@ -1,0 +1,13 @@
+% As an open-source project, CADET-Process relies on the support and recognition from users and researchers to thrive.
+% Therefore, we kindly ask that any publications or projects leveraging the capabilities of CADET-Process acknowledge its creators and their contributions by citing an adequate selection of our publications.
+
+@Article{Schmoelder2020,
+  author  = {Schmölder, Johannes and Kaspereit, Malte},
+  title   = {A {{Modular Framework}} for the {{Modelling}} and {{Optimization}} of {{Advanced Chromatographic Processes}}},
+  doi     = {10.3390/pr8010065},
+  number  = {1},
+  pages   = {65},
+  volume  = {8},
+  journal = {Processes},
+  year    = {2020},
+}

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -2,6 +2,6 @@ name: cadet-process-docs
 channels:
   - conda-forge
 dependencies:
-  - python=3.11
-  - cadet>=4.4.0
+  - python=3.12
+  - cadet>=5.0.2
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,6 @@ name: cadet-process
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10.*
-  - cadet
+  - python>=3.12.*
+  - cadet>5.0.2
   - pip

--- a/tests/create_LWE.py
+++ b/tests/create_LWE.py
@@ -156,7 +156,7 @@ def configure_general_rate_model(component_system: ComponentSystem, **kwargs) ->
 
     configure_solution_recorder(grm, **kwargs)
     configure_discretization(grm, **kwargs)
-    configure_particles(grm, **kwargs)
+    configure_particles(grm)
     configure_steric_mass_action(grm, component_system, **kwargs)
     configure_film_diffusion(grm, component_system.n_comp)
     configure_flow_direction(grm, **kwargs)
@@ -253,7 +253,7 @@ def configure_lumped_rate_model_with_pores(component_system: ComponentSystem, **
 
     configure_solution_recorder(lrmp, **kwargs)
     configure_discretization(lrmp, **kwargs)
-    configure_particles(lrmp, **kwargs)
+    configure_particles(lrmp)
     configure_steric_mass_action(lrmp, component_system, **kwargs)
     configure_film_diffusion(lrmp, component_system.n_comp)
     configure_flow_direction(lrmp, **kwargs)

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -633,4 +633,4 @@ class TestResultsWithLWE:
 
 
 if __name__ == "__main__":
-    unittest.main()
+    pytest.main([__file__])

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -63,23 +63,12 @@ class Test_Adapter(unittest.TestCase):
         shutil.rmtree('./tmp', ignore_errors=True)
 
 
-# TODO: Update when MCT is included in CADET-Python
-# Include path to latest CADET-Core version here to test the MCT
-cadet_install_path = None
-process_simulator = Cadet(install_path=cadet_install_path)
-cadet_version, branch_name = process_simulator.get_cadet_version()
+unit_types = [
+    'Cstr', 'GeneralRateModel', 'TubularReactor',
+    'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores', 'MCT'
+]
 
-if cadet_version < '5.0.0' and branch_name == 'GITDIR-NOTFOUND branch':
-    unit_types = [
-        'Cstr', 'GeneralRateModel', 'TubularReactor',
-        'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores'
-    ]
-else:
-    unit_types = [
-        'Cstr', 'GeneralRateModel', 'TubularReactor',
-        'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores', 'MCT'
-    ]
-
+install_path = "/home/jo/code/CADET-Core/install/interface/bin/cadet-cli"
 
 def run_simulation(
         process: Process,
@@ -107,17 +96,6 @@ def run_simulation(
     """
     try:
         process_simulator = Cadet(install_path)
-
-        cadet_version, branch_name = process_simulator.get_cadet_version()
-        if cadet_version < '5.0.0' and branch_name == 'GITDIR-NOTFOUND branch':
-            warnings.warn(
-                f"Your current CADET-Core version ({cadet_version}) does not "
-                "support all unit operations of this CADET-Process version. "
-                "Please update to the latest CADET-Core version from "
-                "https://github.com/cadet/CADET-Core for full compatibility.",
-                UserWarning
-            )
-
         simulation_results = process_simulator.simulate(process)
 
         if not simulation_results.exit_flag == 0:
@@ -269,8 +247,8 @@ class TestProcessWithLWE:
         assert unit_config.UNIT_TYPE == 'CSTR'
         assert unit_config.INIT_Q == n_comp * [0]
         assert unit_config.INIT_C == n_comp * [0]
-        assert unit_config.INIT_VOLUME == 0.001
-        assert unit_config.POROSITY == 0.8425
+        assert unit_config.INIT_LIQUID_VOLUME == 0.0008425
+        assert unit_config.CONST_SOLID_VOLUME == 0.00015749999999999998
         assert unit_config.FLOWRATE_FILTER == 0.0
         assert unit_config.nbound == [1, 1, 1, 1]
 

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -62,13 +62,19 @@ class Test_Adapter(unittest.TestCase):
     def tearDown(self):
         shutil.rmtree('./tmp', ignore_errors=True)
 
+process_simulator = Cadet()
+cadet_version, branch_name = process_simulator.get_cadet_version()
 
-unit_types = [
-    'Cstr', 'GeneralRateModel', 'TubularReactor',
-    'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores', 'MCT'
-]
-
-install_path = "/home/jo/code/CADET-Core/install/interface/bin/cadet-cli"
+if cadet_version < '5.0.0' and branch_name == 'GITDIR-NOTFOUND branch':
+    unit_types = [
+        'Cstr', 'GeneralRateModel', 'TubularReactor',
+        'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores'
+    ]
+else:
+    unit_types = [
+        'Cstr', 'GeneralRateModel', 'TubularReactor',
+        'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores', 'MCT'
+    ]
 
 def run_simulation(
         process: Process,
@@ -81,8 +87,6 @@ def run_simulation(
     ----------
     process : Process
         The process to simulate.
-    install_path : str, optional
-        The path to the CADET installation.
 
     Returns
     -------
@@ -126,9 +130,8 @@ def simulation_results(request: pytest.FixtureRequest):
     """
     unit_type = request.param
     process = create_lwe(unit_type)
-    simulation_results = run_simulation(process, install_path)
+    simulation_results = run_simulation(process)
     return simulation_results
-
 
 @pytest.mark.parametrize("process", unit_types, indirect=True)
 class TestProcessWithLWE:
@@ -147,7 +150,7 @@ class TestProcessWithLWE:
         dict
             The configuration of the process.
         """
-        process_simulator = Cadet(install_path)
+        process_simulator = Cadet()
         process_config = process_simulator.get_process_config(process).input
         return process_config
 


### PR DESCRIPTION
This PR updates test_cadet_adapter to use the new CSTR parameters. Also, the placeholder to insert a CADET-Core install path was removed, as the MCT is released now. I also fixed a bug in `create_lwe` that caused the `**kwargs` passing not to work properly.