### PR TITLE
Call super().__init__() for Simulator

### DIFF
--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -91,7 +91,12 @@ class Cadet(SimulatorBase):
     use_dll = Bool(default=False)
     _force_constant_flow_rate = False
 
-    def __init__(self, install_path=None, temp_dir=None, *args, **kwargs):
+    def __init__(
+            self,
+            install_path=None,
+            temp_dir=None,
+            *args, **kwargs
+            ):
         super().__init__(*args, **kwargs)
 
         if install_path is None:

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -55,7 +55,9 @@ class SimulatorBase(Structure):
     n_cycles_max = UnsignedInteger(default=100)
     raise_exception_on_max_cycles = Bool(default=False)
 
-    def __init__(self, stationarity_evaluator=None):
+    def __init__(self, stationarity_evaluator=None, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
         self.logger = get_logger('Simulation')
 
         if stationarity_evaluator is None:


### PR DESCRIPTION
This allows passing additional options, e.g. `use_dll=True` in the constructor.