### PR TITLE
Add warning to simulator when setting n_cycles_max below n_cycles_min

### DIFF
--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -248,6 +248,13 @@ class SimulatorBase(Structure):
         if not process.check_config():
             raise CADETProcessError("Process is not configured correctly.")
 
+        if self.n_cycles_max < self.n_cycles_min:
+            effective_max_cycles = np.ceil(self.n_cycles_max / self.n_cycles_min) * self.n_cycles_min
+            self.logger.warning("n_cycles_max is set lower than n_cycles_min "
+                                f"({self.n_cycles_max} vs {self.n_cycles_min}). "
+                                f"This will cause simulations to run in batches of {self.n_cycles_min} cycles until "
+                                f"{effective_max_cycles} are reached.")
+
         if not self.evaluate_stationarity:
             results = self.simulate_n_cycles(
                 process, self.n_cycles, previous_results, **kwargs

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -249,11 +249,8 @@ class SimulatorBase(Structure):
             raise CADETProcessError("Process is not configured correctly.")
 
         if self.n_cycles_max < self.n_cycles_min:
-            effective_max_cycles = np.ceil(self.n_cycles_max / self.n_cycles_min) * self.n_cycles_min
-            self.logger.warning("n_cycles_max is set lower than n_cycles_min "
-                                f"({self.n_cycles_max} vs {self.n_cycles_min}). "
-                                f"This will cause simulations to run in batches of {self.n_cycles_min} cycles until "
-                                f"{effective_max_cycles} are reached.")
+            raise ValueError("n_cycles_max is set lower than n_cycles_min "
+                             f"({self.n_cycles_max} vs {self.n_cycles_min}). ")
 
         if not self.evaluate_stationarity:
             results = self.simulate_n_cycles(


### PR DESCRIPTION
A user on the forum was confused why n_cycles_max was not working as expected so I added this warning to clarify the behavior to future users.