### PR TITLE
Fix Aggregator setter

### DIFF
--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -6,9 +6,29 @@ from .dataStructure import Aggregator
 class SizedAggregator(Aggregator):
     """Aggregator for sized parameters."""
 
+    def __init__(self, *args, transpose=False, **kwargs):
+        """
+        Initialize a SizedAggregator instance.
+
+        Parameters
+        ----------
+        *args : Any
+            Variable length argument list.
+        transpose : bool, options
+            If False, the parameter shape will be ((n_instances, ) + parameter_shape).
+            Else, it will be (parameter_shape + (n_instances, ))
+            The default is False.
+        **kwargs : Any
+            Arbitrary keyword arguments.
+        """
+        self.transpose = transpose
+
+        super().__init__(*args, **kwargs)
+
     def _parameter_shape(self, instance):
-        values = self._get_parameter_values_from_container(instance)
-        shapes = [np.array(el, ndmin=1).shape for el in values]
+        values = self._get_parameter_values_from_container(instance, transpose=False)
+
+        shapes = [el.shape for el in values]
 
         if len(set(shapes)) > 1:
             raise ValueError("Inconsistent parameter shapes.")
@@ -19,34 +39,86 @@ class SizedAggregator(Aggregator):
         return shapes[0]
 
     def _expected_shape(self, instance):
-        return (self._n_instances(instance), ) + self._parameter_shape(instance)
+        if self.transpose:
+            return self._parameter_shape(instance) + (self._n_instances(instance), )
+        else:
+            return (self._n_instances(instance), ) + self._parameter_shape(instance)
 
-    def _get_parameter_values_from_container(self, instance):
+    def _get_parameter_values_from_container(self, instance, transpose=False):
         value = super()._get_parameter_values_from_container(instance)
 
         if value is None or len(value) == 0:
             return
 
-        value = np.array(value, ndmin=2).T
+        value = np.array(value, ndmin=2)
+        if transpose and self.transpose:
+            value = value.T
+
         return value
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance, value, transpose=True, recursive=False):
+        value_array = np.array(value, ndmin=2)
+        if transpose and self.transpose:
+            value_array = value_array.T
+
+        value_shape = value_array.shape
         expected_shape = self._expected_shape(instance)
-        if value.shape != expected_shape:
+
+        if value_shape != expected_shape:
             raise ValueError(
-                f"Expected a array with shape {expected_shape}, got {value.shape}"
+                f"Expected a array with shape {expected_shape}, got {value_shape}"
             )
 
         if recursive:
             super()._check(instance, value, recursive)
 
-    def _prepare(self, instance, value, recursive=False):
-        value = np.array(value)
+    def _prepare(self, instance, value, transpose=False, recursive=False):
+        value = np.array(value, ndmin=2)
+
+        if transpose and self.transpose:
+            value = value.T
 
         if recursive:
             value = super()._prepare(instance, value, recursive)
 
         return value
+
+    def __get__(self, instance, cls):
+        """
+        Retrieve the descriptor value for the given instance.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to retrieve the descriptor value for.
+        cls : Type[Any], optional
+            Class to which the descriptor belongs. By default None.
+
+        Returns
+        -------
+        np.array
+            Descriptor values aggregated in a numpy array.
+        """
+        value = super().__get__(instance, cls)
+        if value is not None and value is not self:
+            if self.transpose:
+                value = value.T
+
+        return value
+
+    def __set__(self, instance, value):
+        """
+        Set the descriptor value for the given instance.
+
+        Parameters
+        ----------
+        instance : Any
+            Instance to set the descriptor value for.
+        value : Any
+            Value to set.
+        """
+        value = self._prepare(instance, value, transpose=True)
+        super().__set__(instance, value)
 
 
 class ClassDependentAggregator(Aggregator):

--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -2,6 +2,69 @@ import numpy as np
 
 from .dataStructure import Aggregator
 
+import numpy as np
+
+
+class NumpyProxyArray(np.ndarray):
+    """A numpy array that dynamically updates attributes of container elements."""
+
+    def __new__(cls, aggregator, instance):
+        values = aggregator._get_values_from_container(instance, transpose=True)
+
+        if values is None:
+            return
+
+        obj = values.view(cls)
+
+        obj.aggregator = aggregator
+        obj.instance = instance
+
+        return obj
+
+    def _get_values_from_aggregator(self):
+        """Refresh data from the underlying container."""
+        return self.aggregator._get_values_from_container(
+            self.instance, transpose=True, check=True
+        )
+
+    def __getitem__(self, index):
+        """Retrieve an item from the aggregated parameter array."""
+        return self._get_values_from_aggregator()[index]
+
+    def __setitem__(self, index, value):
+        """
+        Modify an individual element in the aggregated parameter list.
+        This ensures changes are propagated back to the objects.
+        """
+        current_value = self._get_values_from_aggregator()
+        current_value[index] = value
+        self.aggregator.__set__(self.instance, current_value)
+
+    def __array_finalize__(self, obj):
+        """Ensure attributes are copied when creating a new view or slice."""
+        if obj is None:
+            self.aggregator = None
+            self.instance = None
+            return
+
+        if not isinstance(obj, NumpyProxyArray):
+            return np.asarray(obj)
+
+        self.aggregator = getattr(obj, 'aggregator', None)
+        self.instance = getattr(obj, 'instance', None)
+
+    def __array_function__(self, func, types, *args, **kwargs):
+        """
+        Ensures that high-level NumPy functions (like np.dot, np.linalg.norm) return a
+        normal np.ndarray.
+        """
+        result = super().__array_function__(func, types, *args, **kwargs)
+        return np.asarray(result)
+
+    def __repr__(self):
+        """Return a fresh representation that reflects live data."""
+        return f"NumpyProxyArray({self._get_values_from_aggregator().__repr__()})"
+
 
 class SizedAggregator(Aggregator):
     """Aggregator for sized parameters."""
@@ -26,7 +89,7 @@ class SizedAggregator(Aggregator):
         super().__init__(*args, **kwargs)
 
     def _parameter_shape(self, instance):
-        values = self._get_parameter_values_from_container(instance, transpose=False)
+        values = self._get_values_from_container(instance, transpose=False)
 
         shapes = [el.shape for el in values]
 
@@ -44,13 +107,18 @@ class SizedAggregator(Aggregator):
         else:
             return (self._n_instances(instance), ) + self._parameter_shape(instance)
 
-    def _get_parameter_values_from_container(self, instance, transpose=False):
-        value = super()._get_parameter_values_from_container(instance)
+    def _get_values_from_container(self, instance, transpose=False, check=False):
+        value = super()._get_values_from_container(instance, check=False)
 
         if value is None or len(value) == 0:
             return
 
         value = np.array(value, ndmin=2)
+
+        if check:
+            value = self._prepare(instance, value, transpose=False, recursive=True)
+            self._check(instance, value, transpose=True, recursive=True)
+
         if transpose and self.transpose:
             value = value.T
 
@@ -92,19 +160,17 @@ class SizedAggregator(Aggregator):
         instance : Any
             Instance to retrieve the descriptor value for.
         cls : Type[Any], optional
-            Class to which the descriptor belongs. By default None.
+            Class to which the descriptor belongs.
 
         Returns
         -------
-        np.array
-            Descriptor values aggregated in a numpy array.
+        NumpyProxyArray
+            A numpy-like array that modifies the underlying objects when changed.
         """
-        value = super().__get__(instance, cls)
-        if value is not None and value is not self:
-            if self.transpose:
-                value = value.T
+        if instance is None:
+            return self
 
-        return value
+        return NumpyProxyArray(self, instance)
 
     def __set__(self, instance, value):
         """
@@ -142,7 +208,7 @@ class ClassDependentAggregator(Aggregator):
 
         super().__init__(*args, **kwargs)
 
-    def _get_parameter_values_from_container(self, instance):
+    def _get_values_from_container(self, instance, check=False):
         container = self._container_obj(instance)
 
         values = []
@@ -160,7 +226,12 @@ class ClassDependentAggregator(Aggregator):
         if len(values) == 0:
             return
 
+        if check:
+            values = self._prepare(instance, values, transpose=False, recursive=True)
+            self._check(instance, values, transpose=True, recursive=True)
+
         return values
+
 
 class SizedClassDependentAggregator(SizedAggregator, ClassDependentAggregator):
     pass

--- a/CADETProcess/dataStructure/dataStructure.py
+++ b/CADETProcess/dataStructure/dataStructure.py
@@ -232,7 +232,6 @@ class StructMeta(type):
     Descriptor : Class that represents the descriptors this metaclass operates on.
     Parameters : Base class for model parameters with e.g. type or bound constraints.
 
-
     Methods
     -------
     __prepare__(name, bases) -> OrderedDict

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -1180,7 +1180,6 @@ class SizedNdArray(NdArray, Sized):
         ValueError
             If the value cannot be cast to a NumPy array with the expected shape.
         """
-        # if not isinstance(value, self.ty):
         if isinstance(value, (int, float)):
             try:
                 expected_size = self.get_expected_size(instance)
@@ -1615,6 +1614,7 @@ class Polynomial(NdPolynomial):
 
 
 # %% Modulated Parameters
+
 class DependentlyModulated(Sized):
     """
     Mixin for checking parameter shapes based on other instance attributes.

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -545,8 +545,11 @@ class Float(Typed):
             Float equivalent if value is an integer or numpy number;
             otherwise, the original value.
         """
-        if isinstance(value, (int, np.number)):
-            value = float(value)
+        try:
+            value = float(np.array(value).squeeze())
+        except ValueError:
+            raise TypeError("Cannot cast value to float.")
+
         return value
 
 
@@ -1182,7 +1185,7 @@ class SizedNdArray(NdArray, Sized):
         ValueError
             If the value cannot be cast to a NumPy array with the expected shape.
         """
-        if isinstance(value, (int, float)):
+        if np.array(value).squeeze().ndim == 0:
             try:
                 expected_size = self.get_expected_size(instance)
             except ValueError:
@@ -1192,9 +1195,10 @@ class SizedNdArray(NdArray, Sized):
                 value = value * np.ones(expected_size)
         else:
             try:
-                self.check_size(instance, np.array(value))
+                value_array = np.array(value)
             except ValueError:
-                raise ValueError("Cannot cast value from given value.")
+                raise TypeError("Cannot cast value from given value.")
+            self.check_size(instance, value_array)
 
         if recursive:
             value = super()._prepare(instance, value, recursive)

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -1025,11 +1025,13 @@ class Sized(ParameterBase):
         ValueError
             If the value's size does not match the expected size.
         """
-        if np.array(value).size == 1:
-            return
-
         size = self.get_size(value)
-        expected_size = self.get_expected_size(instance)
+        try:
+            expected_size = self.get_expected_size(instance)
+        except ValueError:
+            if np.array(value).squeeze().ndim == 0:
+                return
+            raise
 
         if size != expected_size:
             raise ValueError(f"Expected size {expected_size}")

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -50,7 +50,7 @@ class Reaction(Structure):
         The equilibrium constant for the reaction.
     """
     is_kinetic = Bool(default=True)
-    stoich = SizedNdArray(size='n_comp', default=0)
+    stoich = SizedNdArray(size='n_comp')
     k_fwd = UnsignedFloat()
     k_bwd = UnsignedFloat()
     k_fwd_min = UnsignedFloat(default=100)
@@ -492,9 +492,9 @@ class MassActionLaw(BulkReactionBase):
 
     k_fwd = Aggregator('k_fwd', 'reactions')
     k_bwd = Aggregator('k_bwd', 'reactions')
-    stoich = SizedAggregator('stoich', 'reactions')
-    exponents_fwd = SizedAggregator('exponents_fwd', 'reactions')
-    exponents_bwd = SizedAggregator('exponents_bwd', 'reactions')
+    stoich = SizedAggregator('stoich', 'reactions', transpose=True)
+    exponents_fwd = SizedAggregator('exponents_fwd', 'reactions', transpose=True)
+    exponents_bwd = SizedAggregator('exponents_bwd', 'reactions', transpose=True)
 
     _parameters = ['stoich', 'exponents_fwd', 'exponents_bwd', 'k_fwd', 'k_bwd']
 
@@ -545,38 +545,50 @@ class MassActionLawParticle(ParticleReactionBase):
         mapping={
             CrossPhaseReaction: 'stoich_liquid',
             None: 'stoich'
-        }
+        },
+        transpose=True,
     )
     k_fwd_liquid = Aggregator('k_fwd', 'liquid_reactions')
     k_bwd_liquid = Aggregator('k_bwd', 'liquid_reactions')
-    exponents_fwd_liquid = SizedAggregator('exponents_fwd', 'liquid_reactions')
-    exponents_bwd_liquid = SizedAggregator('exponents_bwd', 'liquid_reactions')
+    exponents_fwd_liquid = SizedAggregator(
+        'exponents_fwd', 'liquid_reactions', transpose=True
+    )
+    exponents_bwd_liquid = SizedAggregator(
+        'exponents_bwd', 'liquid_reactions', transpose=True
+    )
 
     stoich_solid = SizedClassDependentAggregator(
         'stoich_solid', 'solid_reactions',
         mapping={
             CrossPhaseReaction: 'stoich_solid',
             None: 'stoich'
-        }
+        },
+        transpose=True
     )
     k_fwd_solid = Aggregator('k_fwd', 'solid_reactions')
     k_bwd_solid = Aggregator('k_bwd', 'solid_reactions')
-    exponents_fwd_solid = SizedAggregator('exponents_fwd', 'solid_reactions')
-    exponents_bwd_solid = SizedAggregator('exponents_bwd', 'solid_reactions')
+    exponents_fwd_solid = SizedAggregator(
+        'exponents_fwd', 'solid_reactions', transpose=True
+    )
+    exponents_bwd_solid = SizedAggregator(
+        'exponents_bwd', 'solid_reactions', transpose=True
+    )
 
     exponents_fwd_liquid_modsolid = SizedClassDependentAggregator(
         'exponents_fwd_liquid_modsolid', 'liquid_reactions',
         mapping={
             CrossPhaseReaction: 'exponents_fwd_liquid_modsolid',
             None: None
-        }
+        },
+        transpose=True,
     )
     exponents_bwd_liquid_modsolid = SizedClassDependentAggregator(
         'exponents_bwd_liquid_modsolid', 'liquid_reactions',
         mapping={
             CrossPhaseReaction: 'exponents_bwd_liquid_modsolid',
             None: None
-        }
+        },
+        transpose=True,
     )
 
     exponents_fwd_solid_modliquid = SizedClassDependentAggregator(
@@ -584,14 +596,16 @@ class MassActionLawParticle(ParticleReactionBase):
         mapping={
             CrossPhaseReaction: 'exponents_fwd_solid_modliquid',
             None: None
-        }
+        },
+        transpose=True,
     )
     exponents_bwd_solid_modliquid = SizedClassDependentAggregator(
         'exponents_bwd_solid_modliquid', 'solid_reactions',
         mapping={
             CrossPhaseReaction: 'exponents_bwd_solid_modliquid',
             None: None
-        }
+        },
+        transpose=True,
     )
 
     _parameters = [

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -104,10 +104,6 @@ class Reaction(Structure):
         self.component_system = component_system
         super().__init__()
 
-        self.stoich = np.zeros((self.n_comp,))
-        for i, c in zip(indices, coefficients):
-            self.stoich[i] = c
-
         self.is_kinetic = is_kinetic
         if not is_kinetic:
             k_fwd, k_bwd = scale_to_rapid_equilibrium(k_fwd, k_fwd_min)

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -503,10 +503,12 @@ class MassActionLaw(BulkReactionBase):
         super().__init__(*args, **kwargs)
 
     @wraps(Reaction.__init__)
-    def add_reaction(self, *args, **kwargs):
+    def add_reaction(self, *args, **kwargs) -> Reaction:
         """Add reaction to ReactionSystem."""
         r = Reaction(self.component_system, *args, **kwargs)
         self._reactions.append(r)
+
+        return r
 
     @property
     def reactions(self):


### PR DESCRIPTION
Fixes #215 

Added methods to indicate whether the internal data should be transposed (i.e., have shape `(n_containers, *parameter_shape))`. While this resolves the immediate issue, I had to overwrite the `__set__` method of the Aggregator base class, which feels less than ideal. I'll revisit this implementation to explore alternative approaches, but it should work for now.

Additionally, I noticed there are currently no tests for any aggregated parameters. This is unexpected, as I was fairly certain I had written some. Maybe they got lost somewhere...

ToDos:
- [x] Stoich coeffs in reactions should be sized
- [x] Check if the wrong code snippet is commented out in `SizedAggregator.__set__`
- [x] Check length of container vs value in `Aggregator.__set__`
- [x] Check consistency of transpose=True vs False in `SizedAggregator`
- [x] Add tests