### PR TITLE
Remove Height from Shape metric

### DIFF
--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -1,7 +1,6 @@
 from abc import abstractmethod
 import copy
 from functools import wraps
-from warnings import warn
 
 import numpy as np
 from scipy.integrate import simpson
@@ -27,14 +26,6 @@ __all__ = [
     'BreakthroughHeight', 'BreakthroughPosition',
     'FractionationSSE',
 ]
-
-
-def squishify(*args, **kwargs):
-    warn(
-        'This function is deprecated, use sigmoid_distance.',
-        DeprecationWarning, stacklevel=2
-    )
-    return sigmoid_distance(*args, **kwargs)
 
 
 def sigmoid_distance(measurement, target, normalization=1):

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -293,7 +293,6 @@ class TestShape(unittest.TestCase):
             use_derivative=False,
             components=['A'],
             normalize_metrics=False,
-            include_height=False,
         )
         metrics_expected = [0, 0]
         metrics = difference.evaluate(self.reference)
@@ -305,21 +304,8 @@ class TestShape(unittest.TestCase):
             use_derivative=False,
             components=['A'],
             normalize_metrics=False,
-            include_height=False,
         )
         metrics_expected = [5.5511151e-16, 10]
-        metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
-
-        # Compare with other Gauss Peak, include height
-        difference = Shape(
-            self.reference_switched,
-            use_derivative=False,
-            components=['A'],
-            normalize_metrics=False,
-            include_height=True,
-        )
-        metrics_expected = [5.5511151e-16, 10, 0]
         metrics = difference.evaluate(self.reference)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
@@ -329,7 +315,6 @@ class TestShape(unittest.TestCase):
             use_derivative=False,
             components=['A'],
             normalize_metrics=True,
-            include_height=False,
         )
         metrics_expected = [0, 4.6211716e-01]
         metrics = difference.evaluate(self.reference)
@@ -341,21 +326,8 @@ class TestShape(unittest.TestCase):
             use_derivative=True,
             components=['A'],
             normalize_metrics=False,
-            include_height=False,
         )
         metrics_expected = [0, 10, 0, ]
-        metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
-
-        # Compare with other Gauss Peak, include derivative and height
-        difference = Shape(
-            self.reference_switched,
-            use_derivative=True,
-            components=['A'],
-            normalize_metrics=False,
-            include_height=True,
-        )
-        metrics_expected = [0, 10, 0, 0, 0, 0]
         metrics = difference.evaluate(self.reference)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
@@ -365,7 +337,6 @@ class TestShape(unittest.TestCase):
             use_derivative=True,
             components=['A'],
             normalize_metrics=True,
-            include_height=False,
         )
         metrics_expected = [0, 4.6211716e-01, 0]
         metrics = difference.evaluate(self.reference)


### PR DESCRIPTION
After showing deprecation warnings for some time, This PR finally removes the Height from the Shape metric. Users can still manually specify Height as a separate metric.