### PR TITLE
Add ShapeFront difference metric

### DIFF
--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -199,7 +199,7 @@ class Comparator(Structure):
         except KeyError:
             raise CADETProcessError("Could not find solution path")
 
-        return solution
+        return copy.deepcopy(solution)
 
     def evaluate(self, simulation_results):
         """Evaluate all metrics for a given simulation and return the results as a list.

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -314,10 +314,6 @@ class Comparator(Structure):
 
         for ax, metric in zip(axs, self.metrics):
             solution = self.extract_solution(simulation_results, metric)
-            if metric.normalize:
-                solution.normalize()
-            if metric.smooth:
-                solution.smooth_data()
             solution_sliced = metric.slice_and_transform(solution)
 
             y_max = 1.1 * max(

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -218,8 +218,8 @@ class DifferenceBase(MetricBase):
 
         return wrapper
 
-    def resamples_smoothes_and_normalizes_solution(func):
-        """Decorator to automatically smooth and normalize solution."""
+    def resamples_normalizes_and_smoothes_solution(func):
+        """Decorator to automatically resample, normalize, and smooth solution."""
         @wraps(func)
         def wrapper(self, solution, *args, **kwargs):
             solution = copy.deepcopy(solution)
@@ -265,7 +265,7 @@ class DifferenceBase(MetricBase):
         """
         return
 
-    @resamples_smoothes_and_normalizes_solution
+    @resamples_normalizes_and_smoothes_solution
     @slices_solution
     @transforms_solution
     @checks_dimensions
@@ -288,7 +288,7 @@ class DifferenceBase(MetricBase):
 
     __call__ = evaluate
 
-    @resamples_smoothes_and_normalizes_solution
+    @resamples_normalizes_and_smoothes_solution
     @slices_solution
     @transforms_solution
     def slice_and_transform(self, solution):

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -171,12 +171,13 @@ class DifferenceBase(MetricBase):
             )
 
         self._reference = copy.deepcopy(reference)
-        if self.resample and not self._reference.is_resampled:
-            self._reference.resample()
-        if self.normalize and not self._reference.is_normalized:
-            self._reference.normalize()
-        if self.smooth and not self._reference.is_smoothed:
-            self._reference.smooth_data()
+        if self.resample:
+            reference = reference.resample()
+        if self.normalize:
+            reference = reference.normalize()
+        if self.smooth:
+            reference = reference.smooth_data()
+
         reference = slice_solution(
             self._reference,
             self.components,
@@ -224,15 +225,15 @@ class DifferenceBase(MetricBase):
         def wrapper(self, solution, *args, **kwargs):
             solution = copy.deepcopy(solution)
             if self.resample:
-                solution.resample(
-                    self._reference.time[0],
-                    self._reference.time[-1],
-                    len(self._reference.time),
+                solution = solution.resample(
+                    self.reference.time[0],
+                    self.reference.time[-1],
+                    len(self.reference.time),
                 )
-            if self.normalize and not solution.is_normalized:
-                solution.normalize()
-            if self.smooth and not solution.is_smoothed:
-                solution.smooth_data()
+            if self.normalize:
+                solution = solution.normalize()
+            if self.smooth:
+                solution = solution.smooth_data()
 
             value = func(self, solution, *args, **kwargs)
             return value
@@ -746,8 +747,6 @@ class PeakPosition(DifferenceBase):
                 for i in range(self.reference.n_comp)
             ]
 
-        # if normalization_factor is None:
-        #     normalization_factor = self.reference.time[-1]/10
         self.normalization_factor = normalization_factor
 
     @property

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -18,15 +18,15 @@ from .peaks import find_peaks, find_breakthroughs
 
 
 __all__ = [
-    'DifferenceBase',
-    'calculate_sse', 'calculate_rmse',
-    'SSE', 'RMSE', 'NRMSE',
-    'Norm', 'L1', 'L2',
-    'AbsoluteArea', 'RelativeArea',
-    'Shape', 'ShapeFront',
-    'PeakHeight', 'PeakPosition',
-    'BreakthroughHeight', 'BreakthroughPosition',
-    'FractionationSSE',
+    "DifferenceBase",
+    "calculate_sse", "calculate_rmse",
+    "SSE", "RMSE", "NRMSE",
+    "Norm", "L1", "L2",
+    "AbsoluteArea", "RelativeArea",
+    "Shape", "ShapeFront",
+    "PeakHeight", "PeakPosition",
+    "BreakthroughHeight", "BreakthroughPosition",
+    "FractionationSSE",
 ]
 
 
@@ -187,7 +187,7 @@ class DifferenceBase(MetricBase):
             self.components,
             self.use_total_concentration,
             self.use_total_concentration_components,
-            coordinates={'time': (self.start, self.end)}
+            coordinates={"time": (self.start, self.end)}
         )
 
         self._reference = reference
@@ -214,7 +214,7 @@ class DifferenceBase(MetricBase):
                     self.components,
                     self.use_total_concentration,
                     self.use_total_concentration_components,
-                    coordinates={'time': (self.start, self.end)}
+                    coordinates={"time": (self.start, self.end)}
                 )
 
             value = func(self, solution, *args, **kwargs)
@@ -545,9 +545,9 @@ class Shape(DifferenceBase):
 
     @property
     def labels(self):
-        labels = ['Pearson Correleation', 'Time offset']
+        labels = ["Pearson Correleation", "Time offset"]
         if self.use_derivative:
-            labels += ['Pearson Correlation Derivative']
+            labels += ["Pearson Correlation Derivative"]
         return labels
 
     def _evaluate(self, solution):

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -619,15 +619,22 @@ class ShapeFront(Shape):
             *args,
             min_percent: Optional[float] = 0.02,
             max_percent: Optional[float] = 0.98,
+            use_max_slope: Optional[bool] = False,
             **kwargs
-            ):
+            ) -> None:
         """
         Initialize ShapeFront metric.
 
         Parameters
         ----------
-        *args :
+        *args
             Positional arguments for Shape.
+        min_percent : Optional[float], default=0.02
+            The minimum percentage value for the metric.
+        max_percent : Optional[float], default=0.98
+            The maximum percentage value for the metric.
+        use_max_slope : Optional[bool], default=False
+            If True, use the maximum slope in calculations.
         **kwargs : dict
             Keyword arguments for Shape.
         """
@@ -635,10 +642,12 @@ class ShapeFront(Shape):
 
         self.min_percent = min_percent
         self.max_percent = max_percent
+        self.use_max_slope = use_max_slope
 
         self.reference_front, idx_min, idx_max = slice_solution_front(
             self.reference,
             self.min_percent, self.max_percent,
+            use_max_slope=use_max_slope,
             return_indices=True
         )
 
@@ -668,6 +677,7 @@ class ShapeFront(Shape):
         solution_front, idx_min, idx_max = slice_solution_front(
             solution,
             self.min_percent, self.max_percent,
+            use_max_slope=self.use_max_slope,
             return_indices=True,
         )
 

--- a/CADETProcess/comparison/peaks.py
+++ b/CADETProcess/comparison/peaks.py
@@ -1,3 +1,5 @@
+import copy
+
 import numpy as np
 import scipy.signal
 
@@ -24,13 +26,13 @@ def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
         Regardless of normalization, the actual peak height is returned.
 
     """
-    peaks = []
-    if normalize and not solution.is_normalized:
-        normalized = True
-        solution.normalize()
-    else:
-        normalized = False
+    solution_original = solution
+    solution = copy.deepcopy(solution)
 
+    if normalize:
+        solution = solution.normalize()
+
+    peaks = []
     for i in range(solution.component_system.n_comp):
         sol = solution.solution[:, i].copy()
 
@@ -41,15 +43,9 @@ def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
         if len(peak_indices) == 0:
             peak_indices = [np.argmax(sol)]
         time = solution.time[peak_indices]
-        peak_heights = solution.solution[peak_indices, i]
-
-        if normalized:
-            peak_heights = solution.transform.untransform(peak_heights)
+        peak_heights = solution_original.solution[peak_indices, i]
 
         peaks.append([(t, h) for t, h in zip(time, peak_heights)])
-
-    if normalized:
-        solution.denormalize()
 
     return peaks
 
@@ -75,13 +71,13 @@ def find_breakthroughs(solution, normalize=True, threshold=0.95):
         Regardless of normalization, the actual breakthroug height is returned.
 
     """
-    breakthrough = []
-    if normalize and not solution.is_normalized:
-        normalized = True
-        solution.normalize()
-    else:
-        normalized = False
+    solution_original = solution
+    solution = copy.deepcopy(solution)
 
+    if normalize:
+        solution = solution.normalize()
+
+    breakthrough = []
     for i in range(solution.component_system.n_comp):
         sol = solution.solution[:, i].copy()
 
@@ -89,14 +85,8 @@ def find_breakthroughs(solution, normalize=True, threshold=0.95):
         if len(breakthrough_indices) == 0:
             breakthrough_indices = [np.argmax(sol)]
         time = solution.time[breakthrough_indices]
-        breakthrough_height = solution.solution[breakthrough_indices, i]
-
-        if solution.is_normalized:
-            breakthrough_height = solution.transform.untransform(breakthrough_height)
+        breakthrough_height = solution_original.solution[breakthrough_indices, i]
 
         breakthrough.append((time, breakthrough_height))
-
-    if normalized:
-        solution.denormalize()
 
     return breakthrough

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -148,39 +148,39 @@ class SimulationResults(Structure):
                     ports = ports_cycles
                     for port, cycles in ports.items():
                         solution[unit][sol][port] = copy.deepcopy(cycles[0])
-                        solution_complete = cycles[0].solution_original
+                        solution_complete = cycles[0].solution
                         if solution_complete.ndim > 1:
                             for i in range(1, self.n_cycles):
                                 solution_complete = np.vstack((
-                                    solution_complete, cycles[i].solution_original[1:]
+                                    solution_complete, cycles[i].solution[1:]
                                 ))
                         else:
                             for i in range(1, self.n_cycles):
                                 solution_complete = np.hstack((
-                                    solution_complete, cycles[i].solution_original[1:]
+                                    solution_complete, cycles[i].solution[1:]
                                 ))
 
-                        solution[unit][sol][port].time_original = time_complete
-                        solution[unit][sol][port].solution_original = solution_complete
-                        solution[unit][sol][port].reset()
+                        solution[unit][sol][port].time = time_complete
+                        solution[unit][sol][port].solution = solution_complete
+                        solution[unit][sol][port].update_solution()
                 else:
                     cycles = ports_cycles
                     solution[unit][sol] = copy.deepcopy(cycles[0])
-                    solution_complete = cycles[0].solution_original
+                    solution_complete = cycles[0].solution
                     if solution_complete.ndim > 1:
                         for i in range(1, self.n_cycles):
                             solution_complete = np.vstack((
-                                solution_complete, cycles[i].solution_original[1:]
+                                solution_complete, cycles[i].solution[1:]
                             ))
                     else:
                         for i in range(1, self.n_cycles):
                             solution_complete = np.hstack((
-                                solution_complete, cycles[i].solution_original[1:]
+                                solution_complete, cycles[i].solution[1:]
                             ))
 
-                    solution[unit][sol].time_original = time_complete
-                    solution[unit][sol].solution_original = solution_complete
-                    solution[unit][sol].reset()
+                    solution[unit][sol].time = time_complete
+                    solution[unit][sol].solution = solution_complete
+                    solution[unit][sol].update_solution()
 
         self._solution = solution
 
@@ -205,26 +205,26 @@ class SimulationResults(Structure):
                         for port, cycles in ports.items():
                             sensitivity[sens_name][unit][flow][port] = copy.deepcopy(
                                 cycles[0])
-                            sensitivity_complete = cycles[0].solution_original
+                            sensitivity_complete = cycles[0].solution
                             for i in range(1, self.n_cycles):
                                 sensitivity_complete = np.vstack((
-                                    sensitivity_complete, cycles[i].solution_original[1:]
+                                    sensitivity_complete, cycles[i].solution[1:]
                                 ))
-                            sensitivity[sens_name][unit][flow][port].time_original = time_complete
-                            sensitivity[sens_name][unit][flow][port].solution_original = sensitivity_complete
-                            sensitivity[sens_name][unit][flow][port].reset()
+                            sensitivity[sens_name][unit][flow][port].time = time_complete
+                            sensitivity[sens_name][unit][flow][port].solution = sensitivity_complete
+                            sensitivity[sens_name][unit][flow][port].update_solution()
 
                     else:
                         cycles = ports_cycles
                         sensitivity[sens_name][unit][flow] = copy.deepcopy(cycles[0])
-                        sensitivity_complete = cycles[0].solution_original
+                        sensitivity_complete = cycles[0].solution
                         for i in range(1, self.n_cycles):
                             sensitivity_complete = np.vstack((
-                                sensitivity_complete, cycles[i].solution_original[1:]
+                                sensitivity_complete, cycles[i].solution[1:]
                             ))
-                        sensitivity[sens_name][unit][flow].time_original = time_complete
-                        sensitivity[sens_name][unit][flow].solution_original = sensitivity_complete
-                        sensitivity[sens_name][unit][flow].reset()
+                        sensitivity[sens_name][unit][flow].time = time_complete
+                        sensitivity[sens_name][unit][flow].solution = sensitivity_complete
+                        sensitivity[sens_name][unit][flow].update_solution()
 
         self._sensitivity = sensitivity
 
@@ -247,7 +247,7 @@ class SimulationResults(Structure):
     @property
     def time_cycle(self):
         """np.array: Solution times vector"""
-        return self.solution_cycles[self._first_unit][self._first_solution][0].time_original
+        return self.solution_cycles[self._first_unit][self._first_solution][0].time
 
     @property
     def time_complete(self):

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -1824,6 +1824,7 @@ def slice_solution_front(
         solution_original: SolutionIO,
         min_percent: Optional[float] = 0.02,
         max_percent: Optional[float] = 0.98,
+        use_max_slope: Optional[bool] = False,
         return_indices: Optional[bool] = False,
         ) -> SolutionIO | tuple[SolutionIO, int, int]:
     """
@@ -1853,17 +1854,22 @@ def slice_solution_front(
     # Initialize new sequence with zeros
     solution.solution[:] = 0
 
+    # Determine whether to use derivative array
+    solution_array = solution_original.solution
+    if use_max_slope:
+        solution_array = solution_original.derivative.solution
+
     # Determine the max value and its index
-    max_value = np.max(solution_original.solution)
-    max_index = np.argmax(solution_original.solution)
+    max_value = np.max(solution_array)
+    max_index = np.argmax(solution_array)
 
     # Determine the min and max percent values
     select_min = min_percent * max_value
     select_max = max_percent * max_value
 
     # Find the indices for slicing using logical indexing
-    idx_min = np.where(solution_original.solution[:max_index] <= select_min)[0][-1]
-    idx_max = np.where(solution_original.solution[:max_index] >= select_max)[0][0]
+    idx_min = np.where(solution_array[:max_index] <= select_min)[0][-1]
+    idx_max = np.where(solution_array[:max_index] >= select_max)[0][0]
 
     # Slice the sequence
     solution.solution[idx_min:idx_max + 1] = solution_original.solution[idx_min:idx_max + 1]

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -223,13 +223,11 @@ class SolutionIO(SolutionBase):
 
     def __init__(self, name, component_system, time, solution, flow_rate):
 
-        super().__init__(name, component_system, time, solution)
-
         if not isinstance(flow_rate, TimeLine):
             flow_rate = TimeLine.from_profile(time, flow_rate)
         self.flow_rate = flow_rate
 
-        self.reset()
+        super().__init__(name, component_system, time, solution)
 
     @property
     def derivative(self):
@@ -787,16 +785,11 @@ class SolutionBulk(SolutionBase):
             time, solution,
             axial_coordinates=None, radial_coordinates=None
             ):
-        self.name = name
-        self.component_system_original = component_system
-        self.time_original = time
 
         self.axial_coordinates = axial_coordinates
         self.radial_coordinates = radial_coordinates
 
-        self.solution_original = solution
-
-        self.reset()
+        super().__init__(name, component_system, time, solution)
 
     @property
     def ncol(self):

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -37,7 +37,7 @@ from scipy import integrate
 
 from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    String, UnsignedInteger, UnsignedFloat, Vector, SizedNdArray
+    Typed, String, UnsignedInteger, UnsignedFloat, Vector, SizedNdArray
 )
 
 from CADETProcess.processModel import ComponentSystem
@@ -89,6 +89,7 @@ class SolutionBase(Structure):
 
     name = String()
     time = Vector()
+    component_system = Typed(ty=ComponentSystem)
     solution = SizedNdArray(size='solution_shape')
     c_min = UnsignedFloat(default=1e-6)
 
@@ -115,17 +116,6 @@ class SolutionBase(Structure):
     def update_transform(self):
         """Update the transforms."""
         pass
-
-    @property
-    def component_system(self):
-        """ComponentSystem: ComponentSystem of the Solution object."""
-        return self._component_system
-
-    @component_system.setter
-    def component_system(self, component_system):
-        if not isinstance(component_system, ComponentSystem):
-            raise TypeError('Expected ComponentSystem')
-        self._component_system = component_system
 
     @property
     def n_comp(self):

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -351,6 +351,92 @@ class TestShape(unittest.TestCase):
             metrics = difference.evaluate(self.reference)
 
 
+from CADETProcess.comparison import ShapeFront
+class TestShapeFront(unittest.TestCase):
+
+    def setUp(self):
+        # 2 Components, gaussian peaks, constant flow
+        component_system = ComponentSystem(1)
+        self.reference_single = ReferenceIO(
+            'simple', time, solution_2_gaussian[:, [0]],
+            component_system=component_system
+        )
+
+        self.reference = ReferenceIO(
+            'simple', time, solution_2_gaussian,
+            component_system=comp_2
+        )
+
+        self.reference_switched = ReferenceIO(
+            'simple', time, solution_2_gaussian_switched,
+            component_system=comp_2
+        )
+
+    def test_metric(self):
+        # Compare with itself
+        difference = ShapeFront(
+            self.reference,
+            use_derivative=False,
+            components=['A'],
+            normalize_metrics=False,
+        )
+        metrics_expected = [0, 0]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
+        # Compare with other Gauss Peak
+        difference = ShapeFront(
+            self.reference_switched,
+            use_derivative=False,
+            components=['A'],
+            normalize_metrics=False,
+        )
+        metrics_expected = [0, 10]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
+        # Compare with other Gauss Peak, normalize_metrics
+        difference = ShapeFront(
+            self.reference_switched,
+            use_derivative=False,
+            components=['A'],
+            normalize_metrics=True,
+        )
+        metrics_expected = [0, 4.6211716e-01]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
+        # Compare with other Gauss Peak, include derivative
+        difference = ShapeFront(
+            self.reference_switched,
+            use_derivative=True,
+            components=['A'],
+            normalize_metrics=False,
+        )
+        metrics_expected = [0, 10, 0]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
+        # Compare with other Gauss Peak, include derivative, normalize metrics
+        difference = ShapeFront(
+            self.reference_switched,
+            use_derivative=True,
+            components=['A'],
+            normalize_metrics=True,
+        )
+        metrics_expected = [0, 4.6211716e-01, 0]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
+        # Multi-component, currently not implemented
+        with self.assertRaises(CADETProcessError):
+            difference = ShapeFront(self.reference, use_derivative=False)
+            metrics_expected = [0, 0]
+        with self.assertRaises(CADETProcessError):
+            difference = ShapeFront(self.reference_single)
+            metrics = difference.evaluate(self.reference)
+
+
 from CADETProcess.fractionation import Fraction
 from CADETProcess.reference import FractionationReference
 from CADETProcess.comparison import FractionationSSE

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -428,6 +428,29 @@ class TestShapeFront(unittest.TestCase):
         metrics = difference.evaluate(self.reference)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
+        # Use maximum slope
+        difference = ShapeFront(
+            self.reference,
+            use_derivative=False,
+            use_max_slope=True,
+            components=['A'],
+            normalize_metrics=False,
+        )
+        metrics_expected = [0, 0]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
+        difference = ShapeFront(
+            self.reference_switched,
+            use_derivative=False,
+            use_max_slope=True,
+            components=['A'],
+            normalize_metrics=False,
+        )
+        metrics_expected = [0, 10]
+        metrics = difference.evaluate(self.reference)
+        np.testing.assert_almost_equal(metrics, metrics_expected)
+
         # Multi-component, currently not implemented
         with self.assertRaises(CADETProcessError):
             difference = ShapeFront(self.reference, use_derivative=False)

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -181,7 +181,7 @@ class TestPeakHeight(unittest.TestCase):
             self.reference,
             normalize_metrics=False
         )
-        metrics_expected = [0.0531923, 0.0531923]
+        metrics_expected = [0.0531923, 0.0]
         metrics = difference.evaluate(self.reference_different_height)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
@@ -189,7 +189,7 @@ class TestPeakHeight(unittest.TestCase):
             self.reference,
             normalize_metrics=True
         )
-        metrics_expected = [0.3215127, 0.3215127]
+        metrics_expected = [0.3215127, 0.0]
         metrics = difference.evaluate(self.reference_different_height)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
@@ -327,7 +327,7 @@ class TestShape(unittest.TestCase):
             components=['A'],
             normalize_metrics=False,
         )
-        metrics_expected = [0, 10, 0, ]
+        metrics_expected = [0, 10, 0]
         metrics = difference.evaluate(self.reference)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 


### PR DESCRIPTION
This PR adds another difference metric originally implemented in CADET-Match. It is similar (no pun intended) to the Shape metric. However, it only accounts for the front of the peak which is useful for components which have a tendency for tailing, such as Blue Dextran.