### PR TITLE
fixup! Make axial dispersion component dependent

### DIFF
--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -1279,8 +1279,8 @@ class MCT(UnitBaseClass):
         Length of column.
     channel_cross_section_areas : List of unsinged floats. Lenght depends on nchannel.
         Diameter of column.
-    axial_dispersion : List of unsigned floats. Length depends on n_comp.
-        Axial dispersion coefficient for each component.
+    axial_dispersion : List of unsigned floats. Length depends on n_comp and nchannel.
+        Axial dispersion coefficient for component and each component.
     flow_direction : Switch
         If 1: Forward flow.
         If -1: Backwards flow.
@@ -1298,7 +1298,7 @@ class MCT(UnitBaseClass):
 
     length = UnsignedFloat()
     channel_cross_section_areas = SizedList(size='nchannel')
-    axial_dispersion = SizedUnsignedList(size='n_comp')
+    axial_dispersion = SizedUnsignedList(size=('n_comp', 'nchannel'))
     flow_direction = Switch(valid=[-1, 1], default=1)
     nchannel = UnsignedInteger()
 

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -1218,7 +1218,10 @@ unit_parameters_map = {
         },
         'fixed': {
             'COL_DISPERSION_MULTIPLEX': 3,
-            'PAR_SURFDIFFUSION_MULTIPLEX': 0,
+            'FILM_DIFFUSION_MULTIPLEX': 3,
+            'PAR_DIFFUSION_MULTIPLEX': 3,
+            'PAR_SURFDIFFUSION_MULTIPLEX': 3,
+            'PORE_ACCESSIBILITY_MULTIPLEX': 3,
         },
     },
     'LumpedRateModelWithPores': {
@@ -1240,6 +1243,8 @@ unit_parameters_map = {
         },
         'fixed': {
             'COL_DISPERSION_MULTIPLEX': 3,
+            'FILM_DIFFUSION_MULTIPLEX': 3,
+            'PORE_ACCESSIBILITY_MULTIPLEX': 3,
         },
     },
     'LumpedRateModelWithoutPores': {

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -1217,6 +1217,7 @@ unit_parameters_map = {
             'VELOCITY': 'flow_direction',
         },
         'fixed': {
+            'COL_DISPERSION_MULTIPLEX': 3,
             'PAR_SURFDIFFUSION_MULTIPLEX': 0,
         },
     },
@@ -1237,6 +1238,9 @@ unit_parameters_map = {
             'CROSS_SECTION_AREA': 'cross_section_area',
             'VELOCITY': 'flow_direction',
         },
+        'fixed': {
+            'COL_DISPERSION_MULTIPLEX': 3,
+        },
     },
     'LumpedRateModelWithoutPores': {
         'name': 'LUMPED_RATE_MODEL_WITHOUT_PORES',
@@ -1249,6 +1253,9 @@ unit_parameters_map = {
             'TOTAL_POROSITY': 'total_porosity',
             'CROSS_SECTION_AREA': 'cross_section_area',
             'VELOCITY': 'flow_direction',
+        },
+        'fixed': {
+            'COL_DISPERSION_MULTIPLEX': 3,
         },
     },
     'TubularReactor': {
@@ -1263,6 +1270,7 @@ unit_parameters_map = {
         },
         'fixed': {
             'TOTAL_POROSITY': 1,
+            'COL_DISPERSION_MULTIPLEX': 3,
         },
     },
     'Cstr': {
@@ -1287,6 +1295,9 @@ unit_parameters_map = {
             'CHANNEL_CROSS_SECTION_AREAS': 'channel_cross_section_areas',
             'EXCHANGE_MATRIX': 'exchange_matrix',
             'VELOCITY': 'flow_direction',
+        },
+        'fixed': {
+            'COL_DISPERSION_MULTIPLEX': 7,
         },
     },
     'Inlet': {

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -317,7 +317,7 @@ class TestProcessWithLWE:
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.INIT_CP == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
-        assert unit_config.COL_DISPERSION == 5.75e-08
+        assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
         assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.COL_POROSITY == 0.37
@@ -343,7 +343,7 @@ class TestProcessWithLWE:
         assert unit_config.UNIT_TYPE == 'LUMPED_RATE_MODEL_WITHOUT_PORES'
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
-        assert unit_config.COL_DISPERSION == 5.75e-08
+        assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
         assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.TOTAL_POROSITY == 1
@@ -366,7 +366,7 @@ class TestProcessWithLWE:
         assert unit_config.UNIT_TYPE == 'LUMPED_RATE_MODEL_WITHOUT_PORES'
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
-        assert unit_config.COL_DISPERSION == 5.75e-08
+        assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
         assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.TOTAL_POROSITY == 0.8425
@@ -392,7 +392,7 @@ class TestProcessWithLWE:
         assert unit_config.INIT_Q == n_comp * [0]
         assert unit_config.INIT_CP == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
-        assert unit_config.COL_DISPERSION == 5.75e-08
+        assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
         assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.COL_POROSITY == 0.37
@@ -427,7 +427,7 @@ class TestProcessWithLWE:
                 [n_comp * [0.0], n_comp * [0.0], n_comp * [0.0]]
             ])
         )
-        assert unit_config.COL_DISPERSION == 5.75e-08
+        assert unit_config.COL_DISPERSION == n_comp * n_channel  * [5.75e-08]
         assert unit_config.NCHANNEL == 3
         assert unit_config.CHANNEL_CROSS_SECTION_AREAS == 3 * \
             [2 * np.pi * (0.01 ** 2)]

--- a/tests/test_unit_operation.py
+++ b/tests/test_unit_operation.py
@@ -33,6 +33,7 @@ film_diffusion_1 = 1e-6
 pore_diffusion_0 = 0
 pore_diffusion_1 = 1e-11
 
+nchannel = 3
 channel_cross_section_areas = [0.1, 0.1, 0.1]
 exchange_matrix = np.array([
     [[0.0], [0.01], [0.0]],
@@ -338,10 +339,10 @@ def test_polynomial_flow_rate(
         }
     }),
     ("mct", {
-        "nchannel": 3,
+        "nchannel": nchannel,
         "length": length,
         "channel_cross_section_areas": channel_cross_section_areas,
-        "axial_dispersion": [axial_dispersion],
+        "axial_dispersion": nchannel * [axial_dispersion],
         "exchange_matrix": exchange_matrix,
         "flow_direction": 1,
         "c": [[0, 0, 0]],


### PR DESCRIPTION
This PR explicitly sets the multiplex parameter for axial dispersion to avoid ambiguities.

Note, we should consider doing this for other section/component dependent parameters (e.g. film diffusion, pore diffusion etc.)