### PR TITLE
Adapt to CADET-Python's new run interface

### DIFF
--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -337,7 +337,7 @@ class Cadet(SimulatorBase):
         if hasattr(cadet, "run_simulation"):
             return_information = cadet.run_simulation(timeout=self.timeout)
         else:
-            return_information = cadet.run_load()
+            return_information = cadet.run_load(timeout=self.timeout)
 
         return cadet
 

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -173,7 +173,7 @@ class Cadet(SimulatorBase):
         else:
             return_information = cadet.run_load()
 
-        os.remove(lwe_hdf5_path)
+        cadet.delete_file()
 
         if return_information.return_code != 0:
             raise CADETProcessError(return_information)
@@ -239,7 +239,9 @@ class Cadet(SimulatorBase):
 
         try:
             start = time.time()
-
+            # Check for CADET-Python > v1.1, which introduced the .run_simulation interface.
+            # If it's not present, assume CADET-Python <= 1.0.4 and use the old .run_load() interface
+            # This check can be removed at some point in the future.
             if hasattr(cadet, "run_simulation"):
                 return_information = cadet.run_simulation(timeout=self.timeout)
             else:

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -168,10 +168,13 @@ class Cadet(SimulatorBase):
 
         cadet.create_lwe(lwe_hdf5_path)
 
+        # Check for CADET-Python >= v1.1, which introduced the .run_simulation interface.
+        # If it's not present, assume CADET-Python <= 1.0.4 and use the old .run_load() interface
+        # This check can be removed at some point in the future.
         if hasattr(cadet, "run_simulation"):
             return_information = cadet.run_simulation(timeout=self.timeout)
         else:
-            return_information = cadet.run_load()
+            return_information = cadet.run_load(timeout=self.timeout)
 
         cadet.delete_file()
 
@@ -239,7 +242,8 @@ class Cadet(SimulatorBase):
 
         try:
             start = time.time()
-            # Check for CADET-Python > v1.1, which introduced the .run_simulation interface.
+
+            # Check for CADET-Python >= v1.1, which introduced the .run_simulation interface.
             # If it's not present, assume CADET-Python <= 1.0.4 and use the old .run_load() interface
             # This check can be removed at some point in the future.
             if hasattr(cadet, "run_simulation"):
@@ -326,6 +330,10 @@ class Cadet(SimulatorBase):
         cadet = self.get_new_cadet_instance()
         cadet.filename = file_path
         cadet.load()
+
+        # Check for CADET-Python >= v1.1, which introduced the .run_simulation interface.
+        # If it's not present, assume CADET-Python <= 1.0.4 and use the old .run_load() interface
+        # This check can be removed at some point in the future.
         if hasattr(cadet, "run_simulation"):
             return_information = cadet.run_simulation(timeout=self.timeout)
         else:

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -42,7 +42,11 @@ class Test_Adapter(unittest.TestCase):
         cwd = simulator.temp_dir
         sim = simulator.get_new_cadet_instance()
         sim.create_lwe(cwd / file_name)
-        sim.run()
+
+        if hasattr(sim, "run_simulation"):
+            return_information = sim.run_simulation()
+        else:
+            return_information = sim.run_load()
 
     @unittest.skipIf(found_cadet is False, "Skip if CADET is not installed.")
     def test_create_lwe(self):
@@ -52,7 +56,11 @@ class Test_Adapter(unittest.TestCase):
         cwd = simulator.temp_dir
         sim = simulator.get_new_cadet_instance()
         sim.create_lwe(cwd / file_name)
-        sim.run()
+
+        if hasattr(sim, "run_simulation"):
+            return_information = sim.run_simulation()
+        else:
+            return_information = sim.run_load()
 
     def tearDown(self):
         shutil.rmtree('./tmp', ignore_errors=True)

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -43,6 +43,9 @@ class Test_Adapter(unittest.TestCase):
         sim = simulator.get_new_cadet_instance()
         sim.create_lwe(cwd / file_name)
 
+        # Check for CADET-Python >= v1.1, which introduced the .run_simulation interface.
+        # If it's not present, assume CADET-Python <= 1.0.4 and use the old .run_load() interface
+        # This check can be removed at some point in the future.
         if hasattr(sim, "run_simulation"):
             return_information = sim.run_simulation()
         else:
@@ -57,6 +60,9 @@ class Test_Adapter(unittest.TestCase):
         sim = simulator.get_new_cadet_instance()
         sim.create_lwe(cwd / file_name)
 
+        # Check for CADET-Python >= v1.1, which introduced the .run_simulation interface.
+        # If it's not present, assume CADET-Python <= 1.0.4 and use the old .run_load() interface
+        # This check can be removed at some point in the future.
         if hasattr(sim, "run_simulation"):
             return_information = sim.run_simulation()
         else:

--- a/tests/test_parallelization_adapter.py
+++ b/tests/test_parallelization_adapter.py
@@ -111,7 +111,10 @@ class TestParallelEvaluation(unittest.TestCase):
             file_name = simulator.get_tempfile_name()
             cwd = simulator.temp_dir
             sim = simulator.create_lwe(cwd / file_name)
-            sim.run()
+            if hasattr(sim, "run_simulation"):
+                return_information = sim.run_simulation()
+            else:
+                return_information = sim.run_load()
 
             return True
 


### PR DESCRIPTION
This prepares for the new interface introduced in https://github.com/cadet/CADET-Python/pull/51 