### PR TITLE
Use last point fulfilling purity constraints for initial values

### DIFF
--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -55,9 +55,9 @@ class FractionationOptimizer():
         """
         if optimizer is None:
             optimizer = COBYLA()
-            optimizer.tol = 1e-3
+            optimizer.tol = 1e-4
             optimizer.catol = 5e-3
-            optimizer.rhobeg = 1e-4
+            optimizer.rhobeg = 1e-3
 
         self.optimizer = optimizer
         self.log_level = log_level

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -687,7 +687,7 @@ class Fractionator(EventHandler):
                     off_indices = np.where(diff[:, comp] == -1)
                     off_indices = off_indices[0]
                     for index, off_evt in enumerate(off_indices):
-                        time = chrom.time[int(off_evt)]
+                        time = chrom.time[int(off_evt) - 1]
                         event_name = \
                             'chrom_' + str(chrom_index) + \
                             '_comp_' + str(comp) + \


### PR DESCRIPTION
This PR updates the initial values routine of the Fractionator. Now, it starts the fraction at the first time point where the local purity exceeds the required purity and begins sending to waste starting from the last point where the purity is still above the required level (instead of the first point where it drops below). In practice, this change has minimal impact because we typically have enough data points to make the difference negligible. These are only initial values for the fractionation times, which are later optimized to ensure a cumulative required purity. However, the previous approach was slightly inconsistent, which was noted during testing.

Moreover, the default parameters for the COBYLA optimizer were updated since the initial step was much smaller than final tolerance. This now seems to produce more consistent results, as well as a better performance.