### PR TITLE
Add TypedList parameter

### DIFF
--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -8,7 +8,7 @@ from CADETProcess.dataStructure import frozen_attributes
 from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
     Bool, String,
-    RangedInteger, UnsignedInteger, UnsignedFloat, SizedList,
+    RangedInteger, UnsignedInteger, UnsignedFloat, SizedFloatList,
     SizedRangedIntegerList, SizedUnsignedIntegerList,
     SizedUnsignedList,
     DependentlyModulatedUnsignedList
@@ -451,7 +451,7 @@ class AntiLangmuir(BindingBaseClass):
     adsorption_rate = SizedUnsignedList(size='n_comp')
     desorption_rate = SizedUnsignedList(size='n_comp')
     capacity = SizedUnsignedList(size='n_comp')
-    antilangmuir = SizedList(size='n_comp')
+    antilangmuir = SizedFloatList(size='n_comp')
 
     _parameters = [
         'adsorption_rate',
@@ -527,7 +527,7 @@ class MobilePhaseModulator(BindingBaseClass):
     capacity = SizedUnsignedList(size='n_comp')
     ion_exchange_characteristic = SizedUnsignedList(size='n_comp')
     beta = ion_exchange_characteristic
-    hydrophobicity = SizedList(size='n_comp')
+    hydrophobicity = SizedFloatList(size='n_comp')
     gamma = hydrophobicity
     linear_threshold = UnsignedFloat(default=1e-8)
 
@@ -572,7 +572,7 @@ class ExtendedMobilePhaseModulator(BindingBaseClass):
     capacity = SizedUnsignedList(size='n_comp')
     ion_exchange_characteristic = SizedUnsignedList(size='n_comp')
     beta = ion_exchange_characteristic
-    hydrophobicity = SizedList(size='n_comp')
+    hydrophobicity = SizedFloatList(size='n_comp')
     gamma = hydrophobicity
     component_mode = SizedUnsignedIntegerList(size='n_comp', ub=2)
 
@@ -970,25 +970,25 @@ class GeneralizedIonExchange(BindingBaseClass):
 
     non_binding_component_indices = [1]
 
-    adsorption_rate = SizedList(size='n_comp')
-    adsorption_rate_linear = SizedList(size='n_comp')
-    adsorption_rate_quadratic = SizedList(size='n_comp', default=0)
-    adsorption_rate_cubic = SizedList(size='n_comp', default=0)
-    adsorption_rate_salt = SizedList(size='n_comp', default=0)
-    adsorption_rate_protein = SizedList(size='n_comp', default=0)
-    desorption_rate = SizedList(size='n_comp')
-    desorption_rate_linear = SizedList(size='n_comp', default=0)
-    desorption_rate_quadratic = SizedList(size='n_comp', default=0)
-    desorption_rate_cubic = SizedList(size='n_comp', default=0)
-    desorption_rate_salt = SizedList(size='n_comp', default=0)
-    desorption_rate_protein = SizedList(size='n_comp', default=0)
+    adsorption_rate = SizedFloatList(size='n_comp')
+    adsorption_rate_linear = SizedFloatList(size='n_comp')
+    adsorption_rate_quadratic = SizedFloatList(size='n_comp', default=0)
+    adsorption_rate_cubic = SizedFloatList(size='n_comp', default=0)
+    adsorption_rate_salt = SizedFloatList(size='n_comp', default=0)
+    adsorption_rate_protein = SizedFloatList(size='n_comp', default=0)
+    desorption_rate = SizedFloatList(size='n_comp')
+    desorption_rate_linear = SizedFloatList(size='n_comp', default=0)
+    desorption_rate_quadratic = SizedFloatList(size='n_comp', default=0)
+    desorption_rate_cubic = SizedFloatList(size='n_comp', default=0)
+    desorption_rate_salt = SizedFloatList(size='n_comp', default=0)
+    desorption_rate_protein = SizedFloatList(size='n_comp', default=0)
     characteristic_charge_breaks = DependentlyModulatedUnsignedList(
         size='n_comp', is_optional=True
     )
-    characteristic_charge = SizedList(size=('n_pieces', 'n_comp'),)
-    characteristic_charge_linear = SizedList(size=('n_pieces', 'n_comp'), default=0)
-    characteristic_charge_quadratic = SizedList(size=('n_pieces', 'n_comp'), default=0)
-    characteristic_charge_cubic = SizedList(size=('n_pieces', 'n_comp'), default=0)
+    characteristic_charge = SizedFloatList(size=('n_pieces', 'n_comp'),)
+    characteristic_charge_linear = SizedFloatList(size=('n_pieces', 'n_comp'), default=0)
+    characteristic_charge_quadratic = SizedFloatList(size=('n_pieces', 'n_comp'), default=0)
+    characteristic_charge_cubic = SizedFloatList(size=('n_pieces', 'n_comp'), default=0)
     steric_factor = SizedUnsignedList(size='n_comp')
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1)
@@ -1052,10 +1052,10 @@ class HICConstantWaterActivity(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedList(size='n_comp')
-    desorption_rate = SizedList(size='n_comp')
-    capacity = SizedList(size='n_comp')
-    hic_characteristic = SizedList(size='n_comp')
+    adsorption_rate = SizedFloatList(size='n_comp')
+    desorption_rate = SizedFloatList(size='n_comp')
+    capacity = SizedFloatList(size='n_comp')
+    hic_characteristic = SizedFloatList(size='n_comp')
 
     beta_0 = UnsignedFloat()
     beta_1 = UnsignedFloat()
@@ -1092,10 +1092,10 @@ class HICWaterOnHydrophobicSurfaces(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedList(size='n_comp')
-    desorption_rate = SizedList(size='n_comp')
-    capacity = SizedList(size='n_comp')
-    hic_characteristic = SizedList(size='n_comp')
+    adsorption_rate = SizedFloatList(size='n_comp')
+    desorption_rate = SizedFloatList(size='n_comp')
+    capacity = SizedFloatList(size='n_comp')
+    hic_characteristic = SizedFloatList(size='n_comp')
 
     beta_0 = UnsignedFloat()
     beta_1 = UnsignedFloat()
@@ -1165,18 +1165,18 @@ class MultiComponentColloidal(BindingBaseClass):
     kappa_factor = UnsignedFloat()
     kappa_constant = UnsignedFloat()
     coordination_number = UnsignedInteger()
-    logkeq_ph_exponent = SizedList(size='n_comp')
-    logkeq_power_exponent = SizedList(size='n_comp')
-    logkeq_power_factor = SizedList(size='n_comp')
-    logkeq_exponent_factor = SizedList(size='n_comp')
-    logkeq_exponent_multiplier = SizedList(size='n_comp')
-    bpp_ph_exponent = SizedList(size='n_comp')
-    bpp_power_exponent = SizedList(size='n_comp')
-    bpp_power_factor = SizedList(size='n_comp')
-    bpp_exponent_factor = SizedList(size='n_comp')
-    bpp_exponent_multiplier = SizedList(size='n_comp')
-    protein_radius = SizedList(size='n_comp')
-    kinetic_rate_constant = SizedList(size='n_comp')
+    logkeq_ph_exponent = SizedFloatList(size='n_comp')
+    logkeq_power_exponent = SizedFloatList(size='n_comp')
+    logkeq_power_factor = SizedFloatList(size='n_comp')
+    logkeq_exponent_factor = SizedFloatList(size='n_comp')
+    logkeq_exponent_multiplier = SizedFloatList(size='n_comp')
+    bpp_ph_exponent = SizedFloatList(size='n_comp')
+    bpp_power_exponent = SizedFloatList(size='n_comp')
+    bpp_power_factor = SizedFloatList(size='n_comp')
+    bpp_exponent_factor = SizedFloatList(size='n_comp')
+    bpp_exponent_multiplier = SizedFloatList(size='n_comp')
+    protein_radius = SizedFloatList(size='n_comp')
+    kinetic_rate_constant = SizedFloatList(size='n_comp')
     linear_threshold = UnsignedFloat(default=1e-8)
     use_ph = Bool(default=False)
 

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -10,7 +10,7 @@ from CADETProcess.dataStructure import (
     Aggregator, SizedAggregator, SizedClassDependentAggregator,
 )
 from CADETProcess.dataStructure import (
-    Bool, String, SizedList, SizedNdArray, UnsignedInteger, UnsignedFloat
+    Bool, String, SizedNdArray, UnsignedInteger, UnsignedFloat
 )
 
 from CADETProcess.dataStructure import deprecated_alias

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -12,7 +12,7 @@ from CADETProcess.dataStructure import (
     Constant, UnsignedFloat, UnsignedInteger,
     String, Switch,
     SizedUnsignedList,
-    Polynomial, NdPolynomial, SizedList, SizedNdArray
+    Polynomial, NdPolynomial, SizedFloatList, SizedNdArray
 )
 
 from .componentSystem import ComponentSystem
@@ -475,7 +475,7 @@ class TubularReactorBase(UnitBaseClass):
     diameter = UnsignedFloat()
     axial_dispersion = SizedUnsignedList(size='n_comp')
     flow_direction = Switch(valid=[-1, 1], default=1)
-    c = SizedList(size='n_comp', default=0)
+    c = SizedFloatList(size='n_comp', default=0)
 
     _initial_state = UnitBaseClass._initial_state + ['c']
     _parameters = ['length', 'diameter', 'axial_dispersion', 'flow_direction'] \
@@ -1167,7 +1167,7 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         SourceMixin._section_dependent_parameters + \
         ['flow_rate_filter']
 
-    c = SizedList(size='n_comp', default=0)
+    c = SizedFloatList(size='n_comp', default=0)
     _q = SizedUnsignedList(size='n_bound_states', default=0)
     init_liquid_volume = UnsignedFloat()
     const_solid_volume = UnsignedFloat(default=0)
@@ -1296,7 +1296,7 @@ class MCT(UnitBaseClass):
     discretization_schemes = (MCTDiscretizationFV)
 
     length = UnsignedFloat()
-    channel_cross_section_areas = SizedList(size='nchannel')
+    channel_cross_section_areas = SizedFloatList(size='nchannel')
     axial_dispersion = SizedUnsignedList(size=('n_comp', 'nchannel'))
     flow_direction = Switch(valid=[-1, 1], default=1)
     nchannel = UnsignedInteger()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -6,6 +6,7 @@ from CADETProcess.dataStructure import (
     Structure,
     Constant, Switch,
     Typed, Integer, Float, String, List,
+    IntegerList, FloatList,
     Callable,
     RangedFloat, UnsignedInteger,
     SizedList, SizedNdArray,
@@ -13,7 +14,7 @@ from CADETProcess.dataStructure import (
     Polynomial, NdPolynomial,
     Vector, Matrix,
     DependentlyModulatedUnsignedList,
-    Aggregator, SizedAggregator, SizedClassDependentAggregator,
+    Aggregator, SizedAggregator,
 )
 
 
@@ -209,6 +210,26 @@ class TestCallable(unittest.TestCase):
     def test_default(self):
         assert (callable(self.model.method_default))
         self.assertEqual(self.model.method_default(2), 2)
+
+
+class TestDtype(unittest.TestCase):
+    def setUp(self):
+        class Model(Structure):
+            integer_list_param = IntegerList()
+            float_list_param = FloatList()
+
+        self.model = Model()
+        self.model_other = Model()
+
+    def test_values(self):
+        self.model.integer_list_param = [1, 2]
+        self.assertEqual(self.model.integer_list_param, [1, 2])
+
+        with self.assertRaises(ValueError):
+            self.model.integer_list_param = [1, 'foo']
+
+        self.model.float_list_param = [1., 2]
+        self.assertEqual(self.model.float_list_param, [1., 2.])
 
 
 class TestRanged(unittest.TestCase):


### PR DESCRIPTION
This PR adds functionality to explicitly enforce the "type" of entries in a parameters list (similar to the `dtype` in numpy). This was added to avoid issues where a lazy instantiation of an array with `int` would later lead to not properly updating the arrays with float values (e.g. during optimization).

For more information, also refer to [this Forum Discussion](https://forum.cadet-web.de/t/issue-with-fitting-genetic-algorithm-isotherm-parameters/1181/12).