### PR TITLE
Add ruff linter+formater for unified coding style

### DIFF
--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,0 +1,16 @@
+name: Ruff
+on:
+  push:
+    branches:
+      - master
+      - dev
+  pull_request:
+jobs:
+  ruff:
+    runs-on: ubuntu-latest
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/ruff-action@v3
+        with:
+          args: check --output-format=github

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,3 +22,12 @@ repos:
             examples/[^/]+/index.py
         )$
     args: [--sync]
+# ruff
+repos:
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  # Ruff version.
+  rev: v0.11.13
+  hooks:
+    # Run the linter.
+    - id: ruff-check
+      args: [ --fix ]

--- a/CADETProcess/CADETProcessError.py
+++ b/CADETProcess/CADETProcessError.py
@@ -12,7 +12,7 @@ Exceptions in **CADET-Process**.
 
     CADETProcessError
 
-"""
+"""  # noqa
 
 
 class CADETProcessError(Exception):

--- a/CADETProcess/__init__.py
+++ b/CADETProcess/__init__.py
@@ -8,6 +8,7 @@ for other solvers.
 
 See https://cadet-process.readthedocs.io for complete documentation.
 """
+
 # Version information
 name = "CADET-Process"
 __version__ = "0.10.0"

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -1,21 +1,19 @@
 import copy
 import functools
 import importlib
-from typing import Optional, NoReturn
+from typing import NoReturn, Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
-import matplotlib.pyplot as plt
-from matplotlib.figure import Figure
 from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
-from CADETProcess import CADETProcessError
-from CADETProcess import plotting, SimulationResults
-from CADETProcess.dataStructure import Structure, String
-from CADETProcess.dataStructure import get_nested_value
-from CADETProcess.solution import SolutionBase
+from CADETProcess import CADETProcessError, SimulationResults, plotting
 from CADETProcess.comparison import DifferenceBase
+from CADETProcess.dataStructure import String, Structure, get_nested_value
 from CADETProcess.numerics import round_to_significant_digits
+from CADETProcess.solution import SolutionBase
 
 
 class Comparator(Structure):
@@ -37,9 +35,9 @@ class Comparator(Structure):
     name = String()
 
     def __init__(
-            self,
-            name: Optional[str] = None,
-            ) -> NoReturn:
+        self,
+        name: Optional[str] = None,
+    ) -> NoReturn:
         """
         Initialize a new Comparator instance.
 
@@ -54,11 +52,11 @@ class Comparator(Structure):
         self.solution_paths = {}
 
     def add_reference(
-            self,
-            reference: SolutionBase,
-            update: Optional[bool] = False,
-            smooth: Optional[bool] = False,
-            ) -> NoReturn:
+        self,
+        reference: SolutionBase,
+        update: Optional[bool] = False,
+        smooth: Optional[bool] = False,
+    ) -> NoReturn:
         """
         Add reference to the Comparator.
 
@@ -123,14 +121,10 @@ class Comparator(Structure):
             except AttributeError:
                 metric_labels = [f"{metric}"]
                 if metric.n_metrics > 1:
-                    metric_labels = [
-                        f"{metric}_{i}" for i in range(metric.n_metrics)
-                    ]
+                    metric_labels = [f"{metric}_{i}" for i in range(metric.n_metrics)]
 
             if len(metric_labels) != metric.n_metrics:
-                raise CADETProcessError(
-                    f"Must return {metric.n_labels} labels."
-                )
+                raise CADETProcessError(f"Must return {metric.n_labels} labels.")
 
             labels += metric_labels
 
@@ -138,12 +132,13 @@ class Comparator(Structure):
 
     @functools.wraps(DifferenceBase.__init__)
     def add_difference_metric(
-            self,
-            difference_metric: str,
-            reference: str | SolutionBase,
-            solution_path: str,
-            *args, **kwargs,
-            ) -> DifferenceBase:
+        self,
+        difference_metric: str,
+        reference: str | SolutionBase,
+        solution_path: str,
+        *args,
+        **kwargs,
+    ) -> DifferenceBase:
         """
         Add a difference metric to the Comparator.
 
@@ -170,9 +165,7 @@ class Comparator(Structure):
             If the difference metric or reference is unknown.
         """
         try:
-            module = importlib.import_module(
-                "CADETProcess.comparison.difference"
-            )
+            module = importlib.import_module("CADETProcess.comparison.difference")
             cls_ = getattr(module, difference_metric)
         except KeyError:
             raise CADETProcessError("Unknown Metric Type.")
@@ -194,10 +187,8 @@ class Comparator(Structure):
         return metric
 
     def extract_solution(
-            self,
-            simulation_results: SimulationResults,
-            metric: DifferenceBase
-            ) -> SolutionBase:
+        self, simulation_results: SimulationResults, metric: DifferenceBase
+    ) -> SolutionBase:
         """
         Extract the solution for a given metric from the SimulationResults object.
 
@@ -255,9 +246,9 @@ class Comparator(Structure):
     __call__ = evaluate
 
     def setup_comparison_figure(
-            self,
-            plot_individual: Optional[bool] = False,
-            ) -> tuple[list[Figure], npt.NDArray[Axes]]:
+        self,
+        plot_individual: Optional[bool] = False,
+    ) -> tuple[list[Figure], npt.NDArray[Axes]]:
         """
         Set up a figure for comparing simulation results.
 
@@ -279,8 +270,7 @@ class Comparator(Structure):
             return (None, None)
 
         comparison_fig_all, comparison_axs_all = plotting.setup_figure(
-            n_rows=self.n_difference_metrics,
-            squeeze=False
+            n_rows=self.n_difference_metrics, squeeze=False
         )
 
         plt.close(comparison_fig_all)
@@ -294,8 +284,9 @@ class Comparator(Structure):
             comparison_axs_ind.append(axs)
             plt.close(fig)
 
-        comparison_axs_ind = \
-            np.array(comparison_axs_ind).reshape(comparison_axs_all.shape)
+        comparison_axs_ind = np.array(comparison_axs_ind).reshape(
+            comparison_axs_all.shape
+        )
 
         if plot_individual:
             return comparison_fig_ind, comparison_axs_ind
@@ -303,15 +294,15 @@ class Comparator(Structure):
             return comparison_fig_all, comparison_axs_all
 
     def plot_comparison(
-            self,
-            simulation_results: SimulationResults,
-            axs: Optional[Axes | list[Axes]] = None,
-            figs: Optional[Figure | list[Figure]] = None,
-            file_name: Optional[str] = None,
-            show: Optional[bool] = True,
-            plot_individual: Optional[bool] = False,
-            x_axis_in_minutes: Optional[bool] = True,
-            ) -> tuple[list[Figure], npt.NDArray[plt.Axes]]:
+        self,
+        simulation_results: SimulationResults,
+        axs: Optional[Axes | list[Axes]] = None,
+        figs: Optional[Figure | list[Figure]] = None,
+        file_name: Optional[str] = None,
+        show: Optional[bool] = True,
+        plot_individual: Optional[bool] = False,
+        x_axis_in_minutes: Optional[bool] = True,
+    ) -> tuple[list[Figure], npt.NDArray[plt.Axes]]:
         """
         Plot the comparison of the simulation results with the reference data.
 

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -1,7 +1,7 @@
 import copy
 import functools
 import importlib
-from typing import Any, Iterator, NoReturn, Optional
+from typing import Any, Iterator, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -37,7 +37,7 @@ class Comparator(Structure):
     def __init__(
         self,
         name: Optional[str] = None,
-    ) -> NoReturn:
+    ) -> None:
         """
         Initialize a new Comparator instance.
 
@@ -56,7 +56,7 @@ class Comparator(Structure):
         reference: SolutionBase,
         update: Optional[bool] = False,
         smooth: Optional[bool] = False,
-    ) -> NoReturn:
+    ) -> None:
         """
         Add reference to the Comparator.
 
@@ -136,8 +136,8 @@ class Comparator(Structure):
         difference_metric: str,
         reference: str | SolutionBase,
         solution_path: str,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> DifferenceBase:
         """
         Add a difference metric to the Comparator.
@@ -187,7 +187,9 @@ class Comparator(Structure):
         return metric
 
     def extract_solution(
-        self, simulation_results: SimulationResults, metric: DifferenceBase
+        self,
+        simulation_results: SimulationResults,
+        metric: DifferenceBase
     ) -> SolutionBase:
         """
         Extract the solution for a given metric from the SimulationResults object.
@@ -401,7 +403,7 @@ class Comparator(Structure):
 
         return figs, axs
 
-    def __iter__(self) -> Iterator[Any]:
+    def __iter__(self) -> Iterator[list[DifferenceBase]]:
         """Yield metrics from the instance."""
         yield from self.metrics
 

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -1,7 +1,7 @@
 import copy
 import functools
 import importlib
-from typing import NoReturn, Optional
+from typing import Any, Iterator, NoReturn, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -401,10 +401,12 @@ class Comparator(Structure):
 
         return figs, axs
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Any]:
+        """Yield metrics from the instance."""
         yield from self.metrics
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: Name of the Comparator."""
         if self.name is not None:
             return self.name
         else:

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -39,7 +39,8 @@ __all__ = [
 
 
 def sigmoid_distance(measurement, target, normalization=1):
-    """Calculate the distance between two values using a sigmoid function.
+    """
+    Calculate the distance between two values using a sigmoid function.
 
     The distance is defined as the sigmoid transformation of the difference between the
     measurement and target values, normalized by a user-specified factor.
@@ -116,7 +117,8 @@ class DifferenceBase(MetricBase):
         smooth=False,
         normalize=False,
     ):
-        """Initialize an instance of DifferenceBase.
+        """
+        Initialize an instance of DifferenceBase.
 
         Parameters
         ----------
@@ -143,7 +145,6 @@ class DifferenceBase(MetricBase):
             If True, smooth data. The default is False.
         normalize : bool, optional
             If True, normalize data. The default is False.
-
         """
         self.components = components
         self.use_total_concentration = use_total_concentration
@@ -201,10 +202,10 @@ class DifferenceBase(MetricBase):
         self._reference = reference
 
     def checks_dimensions(func):
-        """Decorator to automatically check reference and solution dimensions."""
-
+        """Wrap method automatically check reference and solution dimensions."""
         @wraps(func)
         def wrapper(self, solution, *args, **kwargs):
+            """Automatically check reference and solution dimensions before further processing."""
             if solution.solution.shape != self.reference.solution.shape:
                 raise CADETProcessError("Simulation shape does not match experiment")
             value = func(self, solution, *args, **kwargs)
@@ -213,10 +214,10 @@ class DifferenceBase(MetricBase):
         return wrapper
 
     def slices_solution(func):
-        """Decorator to automatically slice solution."""
-
+        """Wrap method to automatically slice solution."""
         @wraps(func)
         def wrapper(self, solution, slice=True, *args, **kwargs):
+            """Automatically slice solution before further processing."""
             if slice:
                 solution = slice_solution(
                     solution,
@@ -233,10 +234,10 @@ class DifferenceBase(MetricBase):
         return wrapper
 
     def resamples_normalizes_and_smoothes_solution(func):
-        """Decorator to automatically resample, normalize, and smooth solution."""
-
+        """Wrap metho to automatically resample, normalize, and smooth solution."""
         @wraps(func)
         def wrapper(self, solution, *args, **kwargs):
+            """Automatically resample, normalize, and smooth solution before further processing."""
             solution = copy.deepcopy(solution)
             if self.resample:
                 solution = solution.resample(
@@ -255,10 +256,10 @@ class DifferenceBase(MetricBase):
         return wrapper
 
     def transforms_solution(func):
-        """Decorator to automatically transform solution data."""
-
+        """Wrap method s.t. solution is automatically transformed."""
         @wraps(func)
         def wrapper(self, solution, *args, **kwargs):
+            """Automatically transforme solution data before further processing."""
             if self.transform is not None:
                 solution = copy.deepcopy(solution)
 
@@ -274,7 +275,8 @@ class DifferenceBase(MetricBase):
 
     @abstractmethod
     def _evaluate(self):
-        """Abstract method to compute the difference metric.
+        """
+        Abstract method to compute the difference metric.
 
         Returns
         -------
@@ -288,7 +290,8 @@ class DifferenceBase(MetricBase):
     @transforms_solution
     @checks_dimensions
     def evaluate(self, solution):
-        """Compute the difference between the reference solution and the input solution.
+        """
+        Compute the difference between the reference solution and the input solution.
 
         Parameters
         ----------
@@ -299,7 +302,6 @@ class DifferenceBase(MetricBase):
         -------
         np.ndarray
             The difference between the two solutions.
-
         """
         metric = self._evaluate(solution)
         return metric
@@ -310,7 +312,8 @@ class DifferenceBase(MetricBase):
     @slices_solution
     @transforms_solution
     def slice_and_transform(self, solution):
-        """Slice the solution and applies the transform callable (if defined).
+        """
+        Slice the solution and applies the transform callable (if defined).
 
         Parameters
         ----------
@@ -326,7 +329,8 @@ class DifferenceBase(MetricBase):
 
 
 def calculate_sse(simulation, reference):
-    """Calculate the sum of squared errors (SSE) between simulation and reference.
+    """
+    Calculate the sum of squared errors (SSE) between simulation and reference.
 
     Parameters
     ----------
@@ -355,7 +359,8 @@ class SSE(DifferenceBase):
 
 
 def calculate_rmse(simulation, reference):
-    """Calculate the root mean squared error (RMSE) between simulation and reference.
+    """
+    Calculate the root mean squared error (RMSE) between simulation and reference.
 
     Parameters
     ----------
@@ -396,7 +401,8 @@ class NRMSE(DifferenceBase):
 
 
 class Norm(DifferenceBase):
-    """Norm difference metric.
+    """
+    Norm difference metric.
 
     Attributes
     ----------
@@ -434,13 +440,13 @@ class AbsoluteArea(DifferenceBase):
     _valid_references = (SolutionIO, ReferenceIO)
 
     def _evaluate(self, solution):
-        """np.array: Absolute difference in area compared to reference.
+        """
+        np.array: Absolute difference in area compared to reference.
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         area_ref = simpson(self.reference.solution, self.reference.time, axis=0)
         area_sol = simpson(solution.solution, solution.time, axis=0)
@@ -454,13 +460,13 @@ class RelativeArea(DifferenceBase):
     _valid_references = (SolutionIO, ReferenceIO)
 
     def _evaluate(self, solution):
-        """np.array: Relative difference in area compared to reference.
+        """
+        np.array: Relative difference in area compared to reference.
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         area_ref = simpson(self.reference.solution, x=self.reference.time, axis=0)
         area_new = simpson(solution.solution, x=solution.time, axis=0)
@@ -469,7 +475,8 @@ class RelativeArea(DifferenceBase):
 
 
 class Shape(DifferenceBase):
-    """Shape similarity difference metric.
+    """
+    Shape similarity difference metric.
 
     The similarity is calculated using the Pearson correlation between the reference
     and solution profiles, as well as the time offset between their peak positions, and
@@ -492,7 +499,6 @@ class Shape(DifferenceBase):
     Notes
     -----
     Currently, this class only works for single-component systems with one peak.
-
     """
 
     _valid_references = (SolutionIO, ReferenceIO)
@@ -506,7 +512,8 @@ class Shape(DifferenceBase):
         normalization_factor=None,
         **kwargs,
     ):
-        """Initialize Shape metric.
+        """
+        Initialize Shape metric.
 
         Parameters
         ----------
@@ -524,7 +531,6 @@ class Shape(DifferenceBase):
             Default is None, which sets it to 1/10 of the simulation time.
         **kwargs : dict
             Keyword arguments passed to the base class constructor.
-
         """
         super().__init__(*args, **kwargs)
 
@@ -546,7 +552,8 @@ class Shape(DifferenceBase):
         self.normalization_factor = normalization_factor
 
     @property
-    def n_metrics(self):
+    def n_metrics(self) -> int:
+        """int: Number of metrics."""
         n_metrics = 2
 
         if self.use_derivative:
@@ -556,6 +563,7 @@ class Shape(DifferenceBase):
 
     @property
     def labels(self):
+        """list[str]: List of difference metric names."""
         labels = ["Pearson Correleation", "Time offset"]
         if self.use_derivative:
             labels += ["Pearson Correlation Derivative"]
@@ -738,7 +746,8 @@ class ShapeFront(Shape):
 
 
 class PeakHeight(DifferenceBase):
-    """Absolute difference in peak height difference metric.
+    """
+    Absolute difference in peak height difference metric.
 
     Attributes
     ----------
@@ -763,7 +772,8 @@ class PeakHeight(DifferenceBase):
         normalization_factor=None,
         **kwargs,
     ):
-        """Initialize the PeakHeight object.
+        """
+        Initialize the PeakHeight object.
 
         Parameters
         ----------
@@ -780,7 +790,6 @@ class PeakHeight(DifferenceBase):
             The default is None.
         **kwargs : dict
             Keyword arguments passed to the base class constructor.
-
         """
         super().__init__(*args, **kwargs)
 
@@ -801,17 +810,18 @@ class PeakHeight(DifferenceBase):
         self.normalization_factor = normalization_factor
 
     @property
-    def n_metrics(self):
+    def n_metrics(self) -> int:
+        """int: Number of metrics."""
         return sum([len(peak) for peak in self.reference_peaks])
 
     def _evaluate(self, solution):
-        """np.array: Difference in peak height (concentration).
+        """
+        np.array: Difference in peak height (concentration).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         solution_peaks = find_peaks(solution, find_minima=self.find_minima)
 
@@ -836,7 +846,8 @@ class PeakHeight(DifferenceBase):
 
 
 class PeakPosition(DifferenceBase):
-    """Absolute difference in peak peak position difference metric.
+    """
+    Absolute difference in peak peak position difference metric.
 
     Attributes
     ----------
@@ -854,7 +865,8 @@ class PeakPosition(DifferenceBase):
     def __init__(
         self, *args, normalize_metrics=True, normalization_factor=None, **kwargs
     ):
-        """Initialize PeakPosition object.
+        """
+        Initialize PeakPosition object.
 
         Parameters
         ----------
@@ -869,7 +881,6 @@ class PeakPosition(DifferenceBase):
             None.
         **kwargs : dict
             Keyword arguments passed to the base class constructor.
-
         """
         super().__init__(*args, **kwargs)
 
@@ -890,17 +901,18 @@ class PeakPosition(DifferenceBase):
         self.normalization_factor = normalization_factor
 
     @property
-    def n_metrics(self):
+    def n_metrics(self) -> int:
+        """int: Number of metrics."""
         return sum([len(peak) for peak in self.reference_peaks])
 
     def _evaluate(self, solution):
-        """np.array: Difference in peak position (time).
+        """
+        np.array: Difference in peak position (time).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         solution_peaks = find_peaks(solution)
 
@@ -925,7 +937,8 @@ class PeakPosition(DifferenceBase):
 
 
 class BreakthroughHeight(DifferenceBase):
-    """Absolute difference in breakthrough curve height difference metric.
+    """
+    Absolute difference in breakthrough curve height difference metric.
 
     Attributes
     ----------
@@ -933,14 +946,14 @@ class BreakthroughHeight(DifferenceBase):
         Whether to normalize the difference scores based on a sigmoid function.
     reference_bt : list of tuple
         List of breakthrough curves in the reference solution.
-
     """
 
     _valid_references = (SolutionIO, ReferenceIO)
 
     @wraps(DifferenceBase.__init__)
     def __init__(self, *args, normalize_metrics=True, **kwargs):
-        """Initialize BreakthroughHeight metric.
+        """
+        Initialize BreakthroughHeight metric.
 
         Parameters
         ----------
@@ -958,17 +971,18 @@ class BreakthroughHeight(DifferenceBase):
         self.reference_bt = find_breakthroughs(self.reference)
 
     @property
-    def n_metrics(self):
+    def n_metrics(self) -> int:
+        """int: Number of metrics."""
         return len(self.reference_bt)
 
     def _evaluate(self, solution):
-        """np.array: Difference in breakthrough height (concentration).
+        """
+        np.array: Difference in breakthrough height (concentration).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         solution_bt = find_breakthroughs(solution)
 
@@ -1008,7 +1022,6 @@ class BreakthroughPosition(DifferenceBase):
             the reference breakthrough.
         **kwargs : dict
             Keyword arguments passed to the base class constructor.
-
         """
         super().__init__(*args, **kwargs)
 
@@ -1025,17 +1038,18 @@ class BreakthroughPosition(DifferenceBase):
         self.normalization_factor = normalization_factor
 
     @property
-    def n_metrics(self):
+    def n_metrics(self) -> int:
+        """int: Number of metrics."""
         return len(self.reference_bt)
 
     def _evaluate(self, solution):
-        """np.array: Difference in breakthrough position (time).
+        """
+        np.array: Difference in breakthrough position (time).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         solution_bt = find_breakthroughs(solution)
 
@@ -1075,7 +1089,6 @@ class FractionationSSE(DifferenceBase):
             the reference breakthrough.
         **kwargs : dict
             Keyword arguments passed to the base class constructor.
-
         """
         super().__init__(*args, resample=False, only_transforms_array=False, **kwargs)
 
@@ -1085,6 +1098,7 @@ class FractionationSSE(DifferenceBase):
             )
 
         def transform(solution):
+            """Transform solution."""
             solution = copy.deepcopy(solution)
             solution_fractions = [
                 solution.create_fraction(frac.start, frac.end)
@@ -1103,13 +1117,13 @@ class FractionationSSE(DifferenceBase):
         self.transform = transform
 
     def _evaluate(self, solution):
-        """np.array: Difference in breakthrough position (time).
+        """
+        np.array: Difference in breakthrough position (time).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
-
         """
         sse = calculate_sse(solution.solution, self.reference.solution)
 

--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import copy
 from abc import abstractmethod
 from functools import wraps
-from typing import Optional
+from typing import Any, Callable, Optional, Union
 
 import numpy as np
 from scipy.integrate import simpson
@@ -10,8 +12,13 @@ from scipy.special import expit
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import UnsignedInteger
 from CADETProcess.metric import MetricBase
-from CADETProcess.reference import FractionationReference, ReferenceIO
-from CADETProcess.solution import SolutionIO, slice_solution, slice_solution_front
+from CADETProcess.reference import FractionationReference, ReferenceBase, ReferenceIO
+from CADETProcess.solution import (
+    SolutionBase,
+    SolutionIO,
+    slice_solution,
+    slice_solution_front,
+)
 
 from .peaks import find_breakthroughs, find_peaks
 from .shape import pearson, pearson_offset
@@ -38,7 +45,11 @@ __all__ = [
 ]
 
 
-def sigmoid_distance(measurement, target, normalization=1):
+def sigmoid_distance(
+    measurement: Union[float, np.ndarray],
+    target: Union[float, np.ndarray],
+    normalization: float = 1
+) -> float | np.ndarray:
     """
     Calculate the distance between two values using a sigmoid function.
 
@@ -101,22 +112,22 @@ class DifferenceBase(MetricBase):
         If True, normalize data. The default is False.
     """
 
-    _valid_references = ()
+    _valid_references: tuple[type] = ()
 
     def __init__(
         self,
-        reference,
-        components=None,
-        use_total_concentration=False,
-        use_total_concentration_components=True,
-        start=None,
-        end=None,
-        transform=None,
-        only_transforms_array=True,
-        resample=True,
-        smooth=False,
-        normalize=False,
-    ):
+        reference: ReferenceBase,
+        components: Optional[dict[str, list]] = None,
+        use_total_concentration: bool = False,
+        use_total_concentration_components: bool = True,
+        start: Optional[float] = None,
+        end: Optional[float] = None,
+        transform: Optional[Callable] = None,
+        only_transforms_array: bool = True,
+        resample: bool = True,
+        smooth: bool = False,
+        normalize: bool = False
+    ) -> None:
         """
         Initialize an instance of DifferenceBase.
 
@@ -159,22 +170,22 @@ class DifferenceBase(MetricBase):
         self.reference = reference
 
     @property
-    def n_metrics(self):
+    def n_metrics(self) -> int:
         """int: Number of metrics."""
         return self.reference.solution.shape[-1]
 
     @property
-    def bad_metrics(self):
+    def bad_metrics(self) -> list:
         """list: Worst case values for each metric."""
         return self.n_metrics * [np.inf]
 
     @property
-    def reference(self):
+    def reference(self) -> SolutionBase:
         """SolutionBase: The reference solution."""
         return self._reference
 
     @reference.setter
-    def reference(self, reference):
+    def reference(self, reference: SolutionBase) -> None:
         if not isinstance(reference, self._valid_references):
             raise TypeError(
                 f"Invalid reference type: {type(reference)}. "
@@ -201,10 +212,15 @@ class DifferenceBase(MetricBase):
 
         self._reference = reference
 
-    def checks_dimensions(func):
+    def checks_dimensions(func: Callable) -> Callable:
         """Wrap method automatically check reference and solution dimensions."""
         @wraps(func)
-        def wrapper(self, solution, *args, **kwargs):
+        def wrapper(
+            self: 'DifferenceBase',
+            solution: SolutionBase,
+            *args: Any,
+            **kwargs: Any
+        ) -> Any:
             """Automatically check reference and solution dimensions before further processing."""
             if solution.solution.shape != self.reference.solution.shape:
                 raise CADETProcessError("Simulation shape does not match experiment")
@@ -213,10 +229,16 @@ class DifferenceBase(MetricBase):
 
         return wrapper
 
-    def slices_solution(func):
+    def slices_solution(func: Callable) -> Callable:
         """Wrap method to automatically slice solution."""
         @wraps(func)
-        def wrapper(self, solution, slice=True, *args, **kwargs):
+        def wrapper(
+            self: 'DifferenceBase',
+            solution: SolutionBase,
+            slice: bool = True,
+            *args: Any,
+            **kwargs: Any
+        ) -> Any:
             """Automatically slice solution before further processing."""
             if slice:
                 solution = slice_solution(
@@ -233,10 +255,15 @@ class DifferenceBase(MetricBase):
 
         return wrapper
 
-    def resamples_normalizes_and_smoothes_solution(func):
-        """Wrap metho to automatically resample, normalize, and smooth solution."""
+    def resamples_normalizes_and_smoothes_solution(func: Callable) -> Callable:
+        """Wrap method to automatically resample, normalize, and smooth solution."""
         @wraps(func)
-        def wrapper(self, solution, *args, **kwargs):
+        def wrapper(
+            self: 'DifferenceBase',
+            solution: SolutionBase,
+            *args: Any,
+            **kwargs: Any
+        ) -> Any:
             """Automatically resample, normalize, and smooth solution before further processing."""
             solution = copy.deepcopy(solution)
             if self.resample:
@@ -255,10 +282,15 @@ class DifferenceBase(MetricBase):
 
         return wrapper
 
-    def transforms_solution(func):
+    def transforms_solution(func: Callable) -> Callable:
         """Wrap method s.t. solution is automatically transformed."""
         @wraps(func)
-        def wrapper(self, solution, *args, **kwargs):
+        def wrapper(
+            self: DifferenceBase,
+            solution: SolutionBase,
+            *args: Any,
+            **kwargs: Any,
+        ) -> Any:
             """Automatically transforme solution data before further processing."""
             if self.transform is not None:
                 solution = copy.deepcopy(solution)
@@ -274,7 +306,7 @@ class DifferenceBase(MetricBase):
         return wrapper
 
     @abstractmethod
-    def _evaluate(self):
+    def _evaluate(self) -> np.ndarray:
         """
         Abstract method to compute the difference metric.
 
@@ -289,7 +321,7 @@ class DifferenceBase(MetricBase):
     @slices_solution
     @transforms_solution
     @checks_dimensions
-    def evaluate(self, solution):
+    def evaluate(self, solution: SolutionBase) -> np.ndarray:
         """
         Compute the difference between the reference solution and the input solution.
 
@@ -311,7 +343,7 @@ class DifferenceBase(MetricBase):
     @resamples_normalizes_and_smoothes_solution
     @slices_solution
     @transforms_solution
-    def slice_and_transform(self, solution):
+    def slice_and_transform(self, solution: SolutionBase) -> SolutionBase:
         """
         Slice the solution and applies the transform callable (if defined).
 
@@ -328,7 +360,7 @@ class DifferenceBase(MetricBase):
         return solution
 
 
-def calculate_sse(simulation, reference):
+def calculate_sse(simulation: np.ndarray, reference: np.ndarray) -> np.ndarray:
     """
     Calculate the sum of squared errors (SSE) between simulation and reference.
 
@@ -352,13 +384,13 @@ class SSE(DifferenceBase):
 
     _valid_references = (ReferenceIO, SolutionIO)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionBase) -> np.ndarray:
         sse = calculate_sse(solution.solution, self.reference.solution)
 
         return sse
 
 
-def calculate_rmse(simulation, reference):
+def calculate_rmse(simulation: np.ndarray, reference: np.ndarray) -> np.ndarray:
     """
     Calculate the root mean squared error (RMSE) between simulation and reference.
 
@@ -382,7 +414,7 @@ class RMSE(DifferenceBase):
 
     _valid_references = (SolutionIO, ReferenceIO)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionBase) -> np.ndarray:
         rmse = calculate_rmse(solution.solution, self.reference.solution)
 
         return rmse
@@ -393,7 +425,7 @@ class NRMSE(DifferenceBase):
 
     _valid_references = (SolutionIO, ReferenceIO)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionBase) -> np.ndarray:
         rmse = calculate_rmse(solution.solution, self.reference.solution)
         nrmse = rmse / np.max(self.reference.solution, axis=0)
 
@@ -414,7 +446,7 @@ class Norm(DifferenceBase):
 
     order = UnsignedInteger()
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionBase) -> float:
         norm = np.linalg.norm(
             (solution.solution - self.reference.solution), ord=self.order
         )
@@ -439,9 +471,9 @@ class AbsoluteArea(DifferenceBase):
 
     _valid_references = (SolutionIO, ReferenceIO)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionBase) -> Union[float, np.ndarray]:
         """
-        np.array: Absolute difference in area compared to reference.
+        np.ndarray: Absolute difference in area compared to reference.
 
         Parameters
         ----------
@@ -459,14 +491,19 @@ class RelativeArea(DifferenceBase):
 
     _valid_references = (SolutionIO, ReferenceIO)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionBase) -> Union[np.ndarray, float]:
         """
-        np.array: Relative difference in area compared to reference.
+        Calculate relative difference in area compared to reference.
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
+
+        Returns
+        -------
+        np.ndarray
+            The relative difference in area comared to reference.
         """
         area_ref = simpson(self.reference.solution, x=self.reference.time, axis=0)
         area_new = simpson(solution.solution, x=solution.time, axis=0)
@@ -506,12 +543,12 @@ class Shape(DifferenceBase):
     @wraps(DifferenceBase.__init__)
     def __init__(
         self,
-        *args,
-        use_derivative=True,
-        normalize_metrics=True,
-        normalization_factor=None,
-        **kwargs,
-    ):
+        *args: Any,
+        use_derivative: bool = True,
+        normalize_metrics: bool = True,
+        normalization_factor: Optional[float] = None,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize Shape metric.
 
@@ -562,14 +599,14 @@ class Shape(DifferenceBase):
         return n_metrics
 
     @property
-    def labels(self):
+    def labels(self) -> list:
         """list[str]: List of difference metric names."""
         labels = ["Pearson Correleation", "Time offset"]
         if self.use_derivative:
             labels += ["Pearson Correlation Derivative"]
         return labels
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
         Evaluate the Shape similarity using Pearson correlation.
 
@@ -580,7 +617,7 @@ class Shape(DifferenceBase):
 
         Returns
         -------
-        np.array
+        np.ndarray
             Array of similarity metrics.
         """
         corr, offset_original = pearson(
@@ -636,11 +673,11 @@ class ShapeFront(Shape):
 
     def __init__(
         self,
-        *args,
+        *args: Any,
         min_percent: Optional[float] = 0.02,
         max_percent: Optional[float] = 0.98,
         use_max_slope: Optional[bool] = False,
-        **kwargs,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize ShapeFront metric.
@@ -680,7 +717,7 @@ class ShapeFront(Shape):
             )
             self.reference_der_front.update_solution()
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
         Evaluate the ShapeFront similarity using Pearson correlation.
 
@@ -691,7 +728,7 @@ class ShapeFront(Shape):
 
         Returns
         -------
-        np.array
+        np.ndarray
             Array of similarity metrics.
         """
         times = solution.time
@@ -766,12 +803,12 @@ class PeakHeight(DifferenceBase):
     @wraps(DifferenceBase.__init__)
     def __init__(
         self,
-        *args,
-        find_minima=False,
-        normalize_metrics=True,
-        normalization_factor=None,
-        **kwargs,
-    ):
+        *args: Any,
+        find_minima: bool = False,
+        normalize_metrics: bool = True,
+        normalization_factor: Optional[float] = None,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize the PeakHeight object.
 
@@ -814,14 +851,19 @@ class PeakHeight(DifferenceBase):
         """int: Number of metrics."""
         return sum([len(peak) for peak in self.reference_peaks])
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
-        np.array: Difference in peak height (concentration).
+        Calculate difference in peak height (concentration).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
+
+        Returns
+        -------
+        np.ndarray
+            Array of difference in peak height (concentration).
         """
         solution_peaks = find_peaks(solution, find_minima=self.find_minima)
 
@@ -863,8 +905,12 @@ class PeakPosition(DifferenceBase):
 
     @wraps(DifferenceBase.__init__)
     def __init__(
-        self, *args, normalize_metrics=True, normalization_factor=None, **kwargs
-    ):
+        self,
+        *args: Any,
+        normalize_metrics: bool = True,
+        normalization_factor: Optional[float] = None,
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize PeakPosition object.
 
@@ -905,14 +951,19 @@ class PeakPosition(DifferenceBase):
         """int: Number of metrics."""
         return sum([len(peak) for peak in self.reference_peaks])
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
-        np.array: Difference in peak position (time).
+        Calculate difference in peak position (time).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
+
+        Returns
+        -------
+        np.ndarray
+            The difference in peak position.
         """
         solution_peaks = find_peaks(solution)
 
@@ -951,7 +1002,7 @@ class BreakthroughHeight(DifferenceBase):
     _valid_references = (SolutionIO, ReferenceIO)
 
     @wraps(DifferenceBase.__init__)
-    def __init__(self, *args, normalize_metrics=True, **kwargs):
+    def __init__(self, *args: Any, normalize_metrics: bool = True, **kwargs: Any) -> None:
         """
         Initialize BreakthroughHeight metric.
 
@@ -975,14 +1026,19 @@ class BreakthroughHeight(DifferenceBase):
         """int: Number of metrics."""
         return len(self.reference_bt)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
-        np.array: Difference in breakthrough height (concentration).
+        Calculate difference in breakthrough height (concentration).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
+
+        Returns
+        -------
+        np.ndarray:
+            The difference in breakthrough height.
         """
         solution_bt = find_breakthroughs(solution)
 
@@ -1004,8 +1060,12 @@ class BreakthroughPosition(DifferenceBase):
 
     @wraps(DifferenceBase.__init__)
     def __init__(
-        self, *args, normalize_metrics=True, normalization_factor=None, **kwargs
-    ):
+        self,
+        *args: Any,
+        normalize_metrics: bool = True,
+        normalization_factor: Optional[float] = None,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize the BreakthroughPosition object.
 
@@ -1042,14 +1102,19 @@ class BreakthroughPosition(DifferenceBase):
         """int: Number of metrics."""
         return len(self.reference_bt)
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
-        np.array: Difference in breakthrough position (time).
+        Calculate difference in breakthrough position (time).
 
         Parameters
         ----------
         solution : SolutionIO
             Concentration profile of simulation.
+
+        Returns
+        -------
+        np.ndarray:
+            The difference in breakthrough position.
         """
         solution_bt = find_breakthroughs(solution)
 
@@ -1071,8 +1136,12 @@ class FractionationSSE(DifferenceBase):
 
     @wraps(DifferenceBase.__init__)
     def __init__(
-        self, *args, normalize_metrics=True, normalization_factor=None, **kwargs
-    ):
+        self,
+        *args: Any,
+        normalize_metrics: bool = True,
+        normalization_factor: Optional[float] = None,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize the FractionationSSE object.
 
@@ -1097,7 +1166,7 @@ class FractionationSSE(DifferenceBase):
                 "FractionationSSE can only work with FractionationReference"
             )
 
-        def transform(solution):
+        def transform(solution: SolutionIO) -> SolutionIO:
             """Transform solution."""
             solution = copy.deepcopy(solution)
             solution_fractions = [
@@ -1116,14 +1185,19 @@ class FractionationSSE(DifferenceBase):
 
         self.transform = transform
 
-    def _evaluate(self, solution):
+    def _evaluate(self, solution: SolutionIO) -> np.ndarray:
         """
-        np.array: Difference in breakthrough position (time).
+        Calculate the sum of squared errors between the solution and a reference solution.
 
         Parameters
         ----------
         solution : SolutionIO
-            Concentration profile of simulation.
+            An object containing the concentration profile of the simulation to be evaluated.
+
+        Returns
+        -------
+        np.ndarray
+            The sum of squared errors (SSE) between the solution and the reference solution.
         """
         sse = calculate_sse(solution.solution, self.reference.solution)
 

--- a/CADETProcess/comparison/peaks.py
+++ b/CADETProcess/comparison/peaks.py
@@ -3,8 +3,15 @@ import copy
 import numpy as np
 import scipy.signal
 
+from CADETProcess.solution import SolutionIO
 
-def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
+
+def find_peaks(
+    solution: SolutionIO,
+    normalize: bool = True,
+    prominence: float = 0.5,
+    find_minima: bool = False
+) -> list[list[tuple[float, float]]]:
     """
     Find peaks in solution.
 
@@ -50,7 +57,11 @@ def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
     return peaks
 
 
-def find_breakthroughs(solution, normalize=True, threshold=0.95):
+def find_breakthroughs(
+    solution: SolutionIO,
+    normalize: bool = True,
+    threshold: float = 0.95
+) -> list[(float, float)]:
     """
     Find breakthroughs in solution.
 

--- a/CADETProcess/comparison/peaks.py
+++ b/CADETProcess/comparison/peaks.py
@@ -81,7 +81,7 @@ def find_breakthroughs(solution, normalize=True, threshold=0.95):
     for i in range(solution.component_system.n_comp):
         sol = solution.solution[:, i].copy()
 
-        breakthrough_indices = np.where(sol > threshold*np.max(sol))[0][0]
+        breakthrough_indices = np.where(sol > threshold * np.max(sol))[0][0]
         if len(breakthrough_indices) == 0:
             breakthrough_indices = [np.argmax(sol)]
         time = solution.time[breakthrough_indices]

--- a/CADETProcess/comparison/peaks.py
+++ b/CADETProcess/comparison/peaks.py
@@ -5,7 +5,8 @@ import scipy.signal
 
 
 def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
-    """Find peaks in solution.
+    """
+    Find peaks in solution.
 
     Parameters
     ----------
@@ -24,7 +25,6 @@ def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
     peaks : list
         List with list of (time, height) for each peak for every component.
         Regardless of normalization, the actual peak height is returned.
-
     """
     solution_original = solution
     solution = copy.deepcopy(solution)
@@ -51,7 +51,8 @@ def find_peaks(solution, normalize=True, prominence=0.5, find_minima=False):
 
 
 def find_breakthroughs(solution, normalize=True, threshold=0.95):
-    """Find breakthroughs in solution.
+    """
+    Find breakthroughs in solution.
 
     Parameters
     ----------
@@ -69,7 +70,6 @@ def find_breakthroughs(solution, normalize=True, threshold=0.95):
     breakthrough : list
         List with (time, height) for breakthrough of every component.
         Regardless of normalization, the actual breakthroug height is returned.
-
     """
     solution_original = solution
     solution = copy.deepcopy(solution)

--- a/CADETProcess/comparison/shape.py
+++ b/CADETProcess/comparison/shape.py
@@ -2,36 +2,42 @@ import warnings
 
 import numba
 import numpy as np
+import numpy.typing as npt
 import scipy
+from scipy.interpolate import PchipInterpolator
 
 from CADETProcess import CADETProcessError
 
 
-def linear_coeff(x1, y1, x2, y2):
+def linear_coeff(x1: float, y1: float, x2: float, y2: float) -> tuple[float, float]:
     """Return paramters that fit y = a*x+b."""
     a = (y2 - y1) / (x2 - x1)
     b = y2 - a * x2
     return a, b
 
 
-def exponential_coeff(x1, y1, x2, y2):
+def exponential_coeff(x1: float, y1: float, x2: float, y2: float) -> tuple[float, float]:
     """Return paramaters that fit y = b*exp(m*x)."""
     b = (np.log(y2) - np.log(y1)) / (x2 - x1)
     a = y1 * np.exp(-b * x1)
     return a, b
 
 
-def exponential(x, a, b):
+def exponential(x: float, a: float, b: float) -> float:
     """Evaluate exponential function."""
     return a * np.exp(b * x)
 
 
-def linear(x, a, b):
+def linear(x: float, a: float, b: float) -> float:
     """Evaluate linear function."""
     return a * x + b
 
 
-def find_opt_poly(x, y, index):
+def find_opt_poly(
+    x: np.ndarray,
+    y: np.ndarray,
+    index: int
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """
     Find optimal overlap between x (offset) and y (pearson).
 
@@ -64,7 +70,7 @@ def find_opt_poly(x, y, index):
     return root, x, y
 
 
-def pear_corr(cr):
+def pear_corr(cr: float) -> float:
     """Flip pearson correlation s.t. 0 is best and 1 is worst."""
     # handle the case where a nan is returned
     if np.isnan(cr):
@@ -76,7 +82,7 @@ def pear_corr(cr):
 
 
 @numba.njit(fastmath=True)
-def pearsonr_mat(x, Y, times):
+def pearsonr_mat(x: np.ndarray, Y: np.ndarray, times: np.ndarray) -> np.ndarray:
     """
     High performance implementation of the pearson correlation.
 
@@ -107,7 +113,12 @@ def pearsonr_mat(x, Y, times):
     return r
 
 
-def pearson_offset(time, reference_spline, simulation_spline, offset):
+def pearson_offset(
+    time: npt.ArrayLike,
+    reference_spline: PchipInterpolator,
+    simulation_spline: PchipInterpolator,
+    offset: float
+) -> float:
     """Calculate single pearson correlation at offset."""
     simulation_data_offset = simulation_spline(time - offset)
     reference_data = reference_spline(time)
@@ -124,7 +135,12 @@ def pearson_offset(time, reference_spline, simulation_spline, offset):
     return score_local
 
 
-def eval_offsets(time, reference_spline, simulation_spline, offsets):
+def eval_offsets(
+    time: float,
+    reference_spline: PchipInterpolator,
+    simulation_spline: PchipInterpolator,
+    offsets: np.ndarray
+) -> np.ndarray:
     """Calculate pearson correlation for each offset."""
     rol_mat = np.zeros([len(offsets), len(time)])
 
@@ -137,8 +153,14 @@ def eval_offsets(time, reference_spline, simulation_spline, offsets):
 
 
 def pearson(
-    time, reference_spline, simulation_spline, size=20, nest=50, bounds=2, tol=1e-13
-):
+    time: np.ndarray,
+    reference_spline: PchipInterpolator,
+    simulation_spline: PchipInterpolator,
+    size: int = 20,
+    nest: int = 50,
+    bounds: int = 2,
+    tol: float = 1e-13
+) -> tuple[float, float]:
     """
     Find highest correlation between reference and simulation.
 
@@ -148,11 +170,11 @@ def pearson(
 
     Parameters
     ----------
-    time: np.array
+    time: np.ndarray
         Time points.
-    reference_spline : np.array
+    reference_spline : PchipInterpolator
         Reference data points.
-    simulation_spline : np.array
+    simulation_spline : PchipInterpolator
         Simulation Data points.
     size : int, optional
         Number of points to be generated between upper and lower bounds.

--- a/CADETProcess/comparison/shape.py
+++ b/CADETProcess/comparison/shape.py
@@ -1,7 +1,7 @@
 import warnings
 
-import numpy as np
 import numba
+import numpy as np
 import scipy
 
 from CADETProcess import CADETProcessError
@@ -99,7 +99,7 @@ def pearsonr_mat(x, Y, times):
             for j in range(x.shape[0]):
                 min_fun += min(x[j], Y[i, j])
 
-            r[i] = min(max(r_num/denominator, -1.0), 1.0) * min_fun
+            r[i] = min(max(r_num / denominator, -1.0), 1.0) * min_fun
     return r
 
 
@@ -133,8 +133,8 @@ def eval_offsets(time, reference_spline, simulation_spline, offsets):
 
 
 def pearson(
-        time, reference_spline, simulation_spline,
-        size=20, nest=50, bounds=2, tol=1e-13):
+    time, reference_spline, simulation_spline, size=20, nest=50, bounds=2, tol=1e-13
+):
     """Find highest correlation between reference and simulation.
 
     The two signals are shifted in time to find the time offset which
@@ -173,19 +173,19 @@ def pearson(
         if i == 0:
             lb = -time[-1]
             ub = time[-1]
-            local_size = min(100+1, int((ub - lb) * 2+1))
+            local_size = min(100 + 1, int((ub - lb) * 2 + 1))
         else:
             idx_max = np.argmax(pearson)
 
             try:
-                lb = offsets[idx_max - bounds]
+                lb = offsets[idx_max - bounds]  # noqa: F821
             except IndexError:
-                lb = offsets[0]
+                lb = offsets[0]  # noqa: F821
 
             try:
-                ub = offsets[idx_max + bounds]
+                ub = offsets[idx_max + bounds]  # noqa: F821
             except IndexError:
-                ub = offsets[-1]
+                ub = offsets[-1]  # noqa: F821
             local_size = size
 
         if ub - lb < tol:
@@ -193,9 +193,7 @@ def pearson(
 
         offsets = np.linspace(lb, ub, local_size)
 
-        pearson = eval_offsets(
-            time, reference_spline, simulation_spline, offsets
-        )
+        pearson = eval_offsets(time, reference_spline, simulation_spline, offsets)
 
         idx_max = np.argmax(pearson)
 
@@ -234,8 +232,6 @@ def pearson(
     dt, time_found, goal_found = find_opt_poly(offsets, pearson, idx)
 
     # calculate pearson correlation at the new time
-    score_local = pearson_offset(
-        time, reference_spline, simulation_spline, dt
-    )
+    score_local = pearson_offset(time, reference_spline, simulation_spline, dt)
 
     return score_local, dt

--- a/CADETProcess/comparison/shape.py
+++ b/CADETProcess/comparison/shape.py
@@ -8,31 +8,33 @@ from CADETProcess import CADETProcessError
 
 
 def linear_coeff(x1, y1, x2, y2):
-    "Return paramters that fit y = a*x+b"
+    """Return paramters that fit y = a*x+b."""
     a = (y2 - y1) / (x2 - x1)
     b = y2 - a * x2
     return a, b
 
 
 def exponential_coeff(x1, y1, x2, y2):
-    "Return paramaters that fit y = b*exp(m*x)"
+    """Return paramaters that fit y = b*exp(m*x)."""
     b = (np.log(y2) - np.log(y1)) / (x2 - x1)
     a = y1 * np.exp(-b * x1)
     return a, b
 
 
 def exponential(x, a, b):
-    "Evaluate exponential function."
+    """Evaluate exponential function."""
     return a * np.exp(b * x)
 
 
 def linear(x, a, b):
-    "Evaluate linear function."
+    """Evaluate linear function."""
     return a * x + b
 
 
 def find_opt_poly(x, y, index):
-    """Find optimal overlap between x (offset) and y (pearson).
+    """
+    Find optimal overlap between x (offset) and y (pearson).
+
     Given a curve, find highest point.
     """
     if index == 0:
@@ -63,7 +65,7 @@ def find_opt_poly(x, y, index):
 
 
 def pear_corr(cr):
-    "Flip pearson correlation s.t. 0 is best and 1 is worst."
+    """Flip pearson correlation s.t. 0 is best and 1 is worst."""
     # handle the case where a nan is returned
     if np.isnan(cr):
         return 1.0
@@ -75,9 +77,11 @@ def pear_corr(cr):
 
 @numba.njit(fastmath=True)
 def pearsonr_mat(x, Y, times):
-    """High performance implementation of the pearson correlation.
-    This is to simultaneously evaluate the pearson correlation between a
-    vector and a matrix. Scipy can only evaluate vector/vector.
+    """
+    High performance implementation of the pearson correlation.
+
+    This is to simultaneously evaluate the pearson correlation between a vector and a
+    matrix. Scipy can only evaluate vector/vector.
     """
     r = np.zeros(Y.shape[0])
     xm = x - x.mean()
@@ -121,7 +125,7 @@ def pearson_offset(time, reference_spline, simulation_spline, offset):
 
 
 def eval_offsets(time, reference_spline, simulation_spline, offsets):
-    "Calculate pearson correlation for each offset."
+    """Calculate pearson correlation for each offset."""
     rol_mat = np.zeros([len(offsets), len(time)])
 
     for idx, offset in enumerate(offsets):
@@ -135,7 +139,8 @@ def eval_offsets(time, reference_spline, simulation_spline, offsets):
 def pearson(
     time, reference_spline, simulation_spline, size=20, nest=50, bounds=2, tol=1e-13
 ):
-    """Find highest correlation between reference and simulation.
+    """
+    Find highest correlation between reference and simulation.
 
     The two signals are shifted in time to find the time offset which
     corresponds to highest correlation. To ensure deterministic results, a
@@ -166,9 +171,7 @@ def pearson(
         pearson correlation (inverted).
     dt : float
         time offset.
-
     """
-
     for i in range(nest + 1):
         if i == 0:
             lb = -time[-1]

--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -2,8 +2,6 @@ import numpy as np
 
 from .dataStructure import Aggregator
 
-import numpy as np
-
 
 class NumpyProxyArray(np.ndarray):
     """A numpy array that dynamically updates attributes of container elements."""
@@ -50,8 +48,8 @@ class NumpyProxyArray(np.ndarray):
         if not isinstance(obj, NumpyProxyArray):
             return np.asarray(obj)
 
-        self.aggregator = getattr(obj, 'aggregator', None)
-        self.instance = getattr(obj, 'instance', None)
+        self.aggregator = getattr(obj, "aggregator", None)
+        self.instance = getattr(obj, "instance", None)
 
     def __array_function__(self, func, types, *args, **kwargs):
         """
@@ -103,9 +101,9 @@ class SizedAggregator(Aggregator):
 
     def _expected_shape(self, instance):
         if self.transpose:
-            return self._parameter_shape(instance) + (self._n_instances(instance), )
+            return self._parameter_shape(instance) + (self._n_instances(instance),)
         else:
-            return (self._n_instances(instance), ) + self._parameter_shape(instance)
+            return (self._n_instances(instance),) + self._parameter_shape(instance)
 
     def _get_values_from_container(self, instance, transpose=False, check=False):
         value = super()._get_values_from_container(instance, check=False)

--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+from typing import Any, Optional
+
 import numpy as np
 
 from .dataStructure import Aggregator
@@ -6,7 +10,22 @@ from .dataStructure import Aggregator
 class NumpyProxyArray(np.ndarray):
     """A numpy array that dynamically updates attributes of container elements."""
 
-    def __new__(cls, aggregator, instance):
+    def __new__(cls, aggregator: Aggregator, instance: Any) -> Optional[NumpyProxyArray]:
+        """
+        Create a new NumpyProxyArray instance using data from an aggregator.
+
+        Parameters
+        ----------
+        aggregator : Aggregator
+            The aggregator from which to obtain values.
+        instance : Any
+            The instance associated with the values.
+
+        Returns
+        -------
+        Optional[NumpyProxyArray]
+            A new instance of the class if values are available, otherwise None.
+        """
         values = aggregator._get_values_from_container(instance, transpose=True)
 
         if values is None:
@@ -32,6 +51,7 @@ class NumpyProxyArray(np.ndarray):
     def __setitem__(self, index, value):
         """
         Modify an individual element in the aggregated parameter list.
+
         This ensures changes are propagated back to the objects.
         """
         current_value = self._get_values_from_aggregator()
@@ -52,10 +72,7 @@ class NumpyProxyArray(np.ndarray):
         self.instance = getattr(obj, "instance", None)
 
     def __array_function__(self, func, types, *args, **kwargs):
-        """
-        Ensures that high-level NumPy functions (like np.dot, np.linalg.norm) return a
-        normal np.ndarray.
-        """
+        """Ensure that high-level NumPy functions return a normal np.ndarray."""
         result = super().__array_function__(func, types, *args, **kwargs)
         return np.asarray(result)
 
@@ -200,7 +217,6 @@ class ClassDependentAggregator(Aggregator):
             Additional positional arguments.
         **kwargs : dict, optional
             Additional keyword arguments.
-
         """
         self.mapping = mapping
 
@@ -232,4 +248,6 @@ class ClassDependentAggregator(Aggregator):
 
 
 class SizedClassDependentAggregator(SizedAggregator, ClassDependentAggregator):
+    """Aggregator where parameter name and size changes depending on instance type."""
+
     pass

--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any, Callable, Iterable, Mapping, Optional
 
 import numpy as np
+import numpy.typing as npt
 
 from .dataStructure import Aggregator
 
@@ -10,13 +11,13 @@ from .dataStructure import Aggregator
 class NumpyProxyArray(np.ndarray):
     """A numpy array that dynamically updates attributes of container elements."""
 
-    def __new__(cls, aggregator: Aggregator, instance: Any) -> Optional[NumpyProxyArray]:
+    def __new__(cls, aggregator: SizedAggregator, instance: Any) -> Optional[NumpyProxyArray]:
         """
         Create a new NumpyProxyArray instance using data from an aggregator.
 
         Parameters
         ----------
-        aggregator : Aggregator
+        aggregator : SizedAggregator
             The aggregator from which to obtain values.
         instance : Any
             The instance associated with the values.
@@ -38,17 +39,17 @@ class NumpyProxyArray(np.ndarray):
 
         return obj
 
-    def _get_values_from_aggregator(self):
+    def _get_values_from_aggregator(self) -> Any:
         """Refresh data from the underlying container."""
         return self.aggregator._get_values_from_container(
             self.instance, transpose=True, check=True
         )
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Any:
         """Retrieve an item from the aggregated parameter array."""
         return self._get_values_from_aggregator()[index]
 
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: int, value: Any) -> None:
         """
         Modify an individual element in the aggregated parameter list.
 
@@ -58,7 +59,7 @@ class NumpyProxyArray(np.ndarray):
         current_value[index] = value
         self.aggregator.__set__(self.instance, current_value)
 
-    def __array_finalize__(self, obj):
+    def __array_finalize__(self, obj: 'NumpyProxyArray') -> Optional[np.ndarray]:
         """Ensure attributes are copied when creating a new view or slice."""
         if obj is None:
             self.aggregator = None
@@ -71,12 +72,18 @@ class NumpyProxyArray(np.ndarray):
         self.aggregator = getattr(obj, "aggregator", None)
         self.instance = getattr(obj, "instance", None)
 
-    def __array_function__(self, func, types, *args, **kwargs):
+    def __array_function__(
+        self,
+        func: Callable,
+        types: Iterable[type],
+        *args: Iterable[Any],
+        **kwargs: Mapping[str, Any]
+    ) -> np.ndarray:
         """Ensure that high-level NumPy functions return a normal np.ndarray."""
         result = super().__array_function__(func, types, *args, **kwargs)
         return np.asarray(result)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return a fresh representation that reflects live data."""
         return f"NumpyProxyA{self._get_values_from_aggregator().__repr__()[1:]}"
 
@@ -84,7 +91,7 @@ class NumpyProxyArray(np.ndarray):
 class SizedAggregator(Aggregator):
     """Aggregator for sized parameters."""
 
-    def __init__(self, *args, transpose=False, **kwargs):
+    def __init__(self, *args: Any, transpose: bool = False, **kwargs: Any) -> None:
         """
         Initialize a SizedAggregator instance.
 
@@ -103,7 +110,7 @@ class SizedAggregator(Aggregator):
 
         super().__init__(*args, **kwargs)
 
-    def _parameter_shape(self, instance):
+    def _parameter_shape(self, instance: Any) -> tuple[int, ...]:
         values = self._get_values_from_container(instance, transpose=False)
 
         shapes = [el.shape for el in values]
@@ -116,13 +123,15 @@ class SizedAggregator(Aggregator):
 
         return shapes[0]
 
-    def _expected_shape(self, instance):
+    def _expected_shape(self, instance: Any) -> tuple[int, ...]:
         if self.transpose:
             return self._parameter_shape(instance) + (self._n_instances(instance),)
         else:
             return (self._n_instances(instance),) + self._parameter_shape(instance)
 
-    def _get_values_from_container(self, instance, transpose=False, check=False):
+    def _get_values_from_container(
+        self, instance: Any, transpose: bool = False, check: bool = False
+    ) -> np.ndarray:
         value = super()._get_values_from_container(instance, check=False)
 
         if value is None or len(value) == 0:
@@ -139,7 +148,13 @@ class SizedAggregator(Aggregator):
 
         return value
 
-    def _check(self, instance, value, transpose=True, recursive=False):
+    def _check(
+        self,
+        instance: Any,
+        value: npt.ArrayLike,
+        transpose: bool = True,
+        recursive: bool = False
+    ) -> None:
         value_array = np.array(value, ndmin=2)
         if transpose and self.transpose:
             value_array = value_array.T
@@ -155,7 +170,13 @@ class SizedAggregator(Aggregator):
         if recursive:
             super()._check(instance, value, recursive)
 
-    def _prepare(self, instance, value, transpose=False, recursive=False):
+    def _prepare(
+        self,
+        instance: Any,
+        value: npt.ArrayLike,
+        transpose: bool = False,
+        recursive: bool = False
+    ) -> np.ndarray:
         value = np.array(value, ndmin=2)
 
         if transpose and self.transpose:
@@ -166,7 +187,7 @@ class SizedAggregator(Aggregator):
 
         return value
 
-    def __get__(self, instance, cls):
+    def __get__(self, instance: Any, cls: type) -> NumpyProxyArray:
         """
         Retrieve the descriptor value for the given instance.
 
@@ -187,7 +208,7 @@ class SizedAggregator(Aggregator):
 
         return NumpyProxyArray(self, instance)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """
         Set the descriptor value for the given instance.
 
@@ -205,7 +226,7 @@ class SizedAggregator(Aggregator):
 class ClassDependentAggregator(Aggregator):
     """Aggregator where parameter name changes depending on instance type."""
 
-    def __init__(self, *args, mapping, **kwargs):
+    def __init__(self, *args: Any, mapping: dict, **kwargs: Any) -> None:
         """
         Initialize the Aggregator descriptor.
 
@@ -222,7 +243,7 @@ class ClassDependentAggregator(Aggregator):
 
         super().__init__(*args, **kwargs)
 
-    def _get_values_from_container(self, instance, check=False):
+    def _get_values_from_container(self, instance: Any, check: bool = False) -> list:
         container = self._container_obj(instance)
 
         values = []

--- a/CADETProcess/dataStructure/cache.py
+++ b/CADETProcess/dataStructure/cache.py
@@ -1,9 +1,33 @@
+from typing import Any, Optional
+
 from .dataStructure import Structure
 from .parameter import Bool
 
 
 class cached_property_if_locked(property):
-    def __get__(self, instance, cls=None):
+    """
+    A property that caches its value if the instance is locked.
+
+    This property extends the built-in property to cache its value when the instance
+    is locked. The cached value is stored in the instance's `cached_properties` dictionary.
+    """
+
+    def __get__(self, instance: Any, cls: Optional[type] = None) -> Any:
+        """
+        Get the value of the property, using the cache if the instance is locked.
+
+        Parameters
+        ----------
+        instance : Any
+            The instance from which to retrieve the property value.
+        cls : Optional[type], optional
+            The class of the instance, by default None.
+
+        Returns
+        -------
+        Any
+            The value of the property.
+        """
         if instance.lock:
             try:
                 return instance.cached_properties[self.name]
@@ -18,7 +42,8 @@ class cached_property_if_locked(property):
         return value
 
     @property
-    def name(self):
+    def name(self) -> str:
+        """str: name of the property."""
         return self.fget.__name__
 
 

--- a/CADETProcess/dataStructure/cache.py
+++ b/CADETProcess/dataStructure/cache.py
@@ -63,16 +63,17 @@ class CachedPropertiesMixin(Structure):
 
     _lock = Bool(default=False)
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize Cached Properties Mixin Object."""
         super().__init__(*args, **kwargs)
         self.cached_properties = {}
 
     @property
-    def lock(self):
+    def lock(self) -> bool:
         """bool: If True, properties are cached. False otherwise."""
         return self._lock
 
     @lock.setter
-    def lock(self, lock):
+    def lock(self, lock: bool) -> None:
         self._lock = lock
         self.cached_properties = {}

--- a/CADETProcess/dataStructure/dataStructure.py
+++ b/CADETProcess/dataStructure/dataStructure.py
@@ -1,8 +1,10 @@
+from __future__ import annotations
+
 from abc import ABC, ABCMeta
 from collections import OrderedDict
 from functools import wraps
 from inspect import Parameter, Signature
-from typing import Any, Callable, Optional
+from typing import Any, Callable, Iterable, Iterator, Optional, Type
 from warnings import warn
 
 from addict import Dict
@@ -27,7 +29,7 @@ class Descriptor(ABC):
     Parameters
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         pass
 
     def __get__(self, instance: Any, owner: Optional[type[Any]]) -> Any:
@@ -82,19 +84,20 @@ class Descriptor(ABC):
 class ProxyList:
     """A proxy list that dynamically updates attributes of container elements."""
 
-    def __init__(self, aggregator, instance):
+    def __init__(self, aggregator: 'Aggregator', instance: Any) -> None:
+        """Initialize Proxy List."""
         self.aggregator = aggregator
         self.instance = instance
 
-    def _get_values_from_aggregator(self):
+    def _get_values_from_aggregator(self) -> Any:
         """Fetch the latest values from the aggregator."""
         return self.aggregator._get_values_from_container(self.instance, check=True)
 
-    def __getitem__(self, index):
+    def __getitem__(self, index: int) -> Any:
         """Retrieve an item from the aggregated parameter list (live view)."""
         return self._get_values_from_aggregator()[index]
 
-    def __setitem__(self, index, value):
+    def __setitem__(self, index: int, value: Any) -> None:
         """
         Modify an individual element in the aggregated parameter list.
 
@@ -104,11 +107,11 @@ class ProxyList:
         current_value[index] = value
         self.aggregator.__set__(self.instance, current_value)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator:
         """Iterate over aggregated values."""
         return iter(self._get_values_from_aggregator())
 
-    def __len__(self):
+    def __len__(self) -> int:
         """Return the length of the container."""
         return len(self._get_values_from_aggregator())
 
@@ -116,7 +119,7 @@ class ProxyList:
         """str: String representation for debugging."""
         return f"ProxyList({self._get_values_from_aggregator().__repr__()})"
 
-    def __eq__(self, other):
+    def __eq__(self, other: ProxyList) -> bool:
         """Equality comparison."""
         return list(self._get_values_from_aggregator()) == other
 
@@ -124,7 +127,13 @@ class ProxyList:
 class Aggregator:
     """Descriptor aggregating parameters from iterable container of other objects."""
 
-    def __init__(self, parameter_name, container, *args, **kwargs):
+    def __init__(
+        self,
+        parameter_name: str,
+        container: str,
+        *args: dict,
+        **kwargs: dict
+    ) -> None:
         """
         Initialize the Aggregator.
 
@@ -143,7 +152,7 @@ class Aggregator:
         self.parameter_name = parameter_name
         self.container = container
 
-    def _container_obj(self, instance):
+    def _container_obj(self, instance: Any) -> Iterable:
         """
         Retrieve the iterable container of the instance.
 
@@ -169,10 +178,10 @@ class Aggregator:
 
         return container
 
-    def _n_instances(self, instance):
+    def _n_instances(self, instance: Any) -> int:
         return len(self._container_obj(instance))
 
-    def _get_values_from_container(self, instance, check=False):
+    def _get_values_from_container(self, instance: Any, check: bool = False) -> Any:
         container = self._container_obj(instance)
 
         value = [getattr(el, self.parameter_name) for el in container]
@@ -183,7 +192,7 @@ class Aggregator:
 
         return value
 
-    def __get__(self, instance, cls):
+    def __get__(self, instance: Any, cls: Type) -> ProxyList:
         """
         Retrieve the descriptor value for the given instance.
 
@@ -204,7 +213,7 @@ class Aggregator:
 
         return ProxyList(self, instance)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Iterable) -> None:
         """
         Set the descriptor value for the given instance.
 
@@ -225,7 +234,7 @@ class Aggregator:
         for el, el_value in zip(container, value):
             setattr(el, self.parameter_name, el_value)
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(self, instance: Any, value: Any, recursive: bool = False) -> Any:
         """
         Prepare value for setting if necessary.
 
@@ -237,6 +246,9 @@ class Aggregator:
             Instance to retrieve the descriptor value for.
         value : Any
             Value to cast.
+        recursive : bool, optional
+            If True, perform the check recursively. Defaults to False. Only works in
+            case of overriding.
 
         Returns
         -------
@@ -245,7 +257,7 @@ class Aggregator:
         """
         return value
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Iterable, recursive: bool = False) -> None:
         """
         Check the given value.
 
@@ -471,7 +483,7 @@ class Structure(metaclass=AbstractStructMeta):
         List of parameters that have a default value of None.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
         Initialize a Structure instance.
 
@@ -497,7 +509,7 @@ class Structure(metaclass=AbstractStructMeta):
             self._parameters_dict[param] = value
 
     @property
-    def parameters(self):
+    def parameters(self) -> dict:
         """dict: Parameters of the instance."""
         parameters = self._parameters_dict
 
@@ -506,7 +518,7 @@ class Structure(metaclass=AbstractStructMeta):
         return parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: dict) -> None:
         """
         Set parameters for the instance.
 
@@ -528,7 +540,7 @@ class Structure(metaclass=AbstractStructMeta):
                 self._parameters_dict[param] = value
 
     @property
-    def sized_parameters(self):
+    def sized_parameters(self) -> Dict:
         """dict: Sized parameters of the instance."""
         parameters = {
             key: value
@@ -538,13 +550,13 @@ class Structure(metaclass=AbstractStructMeta):
         return Dict(parameters)
 
     @property
-    def aggregated_parameters(self):
+    def aggregated_parameters(self) -> Dict:
         """dict: Aggregated parameters of the instance."""
         parameters = {key: getattr(self, key) for key in self._aggregators}
         return Dict(parameters)
 
     @property
-    def polynomial_parameters(self):
+    def polynomial_parameters(self) -> Dict:
         """dict: Polynomial parameters of the instance."""
         parameters = {
             key: value
@@ -554,12 +566,12 @@ class Structure(metaclass=AbstractStructMeta):
         return Dict(parameters)
 
     @property
-    def required_parameters(self):
+    def required_parameters(self) -> list:
         """list: Parameters that have no default value."""
         return self._required_parameters
 
     @property
-    def missing_parameters(self):
+    def missing_parameters(self) -> list:
         """list: Parameters that are required but not set."""
         missing_parameters = []
         for param in self.required_parameters:
@@ -568,7 +580,7 @@ class Structure(metaclass=AbstractStructMeta):
 
         return missing_parameters
 
-    def check_required_parameters(self):
+    def check_required_parameters(self) -> bool:
         """
         Verify if all required parameters are set.
 
@@ -577,9 +589,7 @@ class Structure(metaclass=AbstractStructMeta):
         bool
             True if all required parameters are set. False otherwise.
 
-        Raises
-        ------
-        Warning
+        Warning:
             If any of the required parameters are missing.
         """
         if len(self.missing_parameters) == 0:
@@ -606,14 +616,14 @@ def frozen_attributes(cls: type) -> type:
     """
     cls._is_frozen = False
 
-    def frozensetattr(self: Any, key: str, value: Any) -> None:
+    def frozensetattr(self: Structure, key: str, value: Any) -> None:
         if self._is_frozen and not hasattr(self, key):
             raise AttributeError(f"{cls.__name__} object has no attribute {key}")
         object.__setattr__(self, key, value)
 
     def init_decorator(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper(self: Any, *args: Any, **kwargs: Any) -> None:
+        def wrapper(self: Structure, *args: Any, **kwargs: Any) -> None:
             func(self, *args, **kwargs)
             self._is_frozen = True
         return wrapper

--- a/CADETProcess/dataStructure/deprecation.py
+++ b/CADETProcess/dataStructure/deprecation.py
@@ -27,9 +27,9 @@ def deprecated_alias(**aliases: str) -> Callable:
     """
 
     # Decorator function: takes the f and returns a f with the new argument names
-    def decorator(f: Callable):
+    def decorator(f: Callable) -> Callable:
         @functools.wraps(f)
-        def wrap_decorated_argument(*args, **kwargs):
+        def wrap_decorated_argument(*args: Any, **kwargs: Any) -> Any:
             rename_kwargs(f.__name__, kwargs, aliases)
             return f(*args, **kwargs)
 
@@ -38,7 +38,7 @@ def deprecated_alias(**aliases: str) -> Callable:
     return decorator
 
 
-def rename_kwargs(func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str]):
+def rename_kwargs(func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str]) -> None:
     """
     Automatically rename deprecated function arguments.
 

--- a/CADETProcess/dataStructure/deprecation.py
+++ b/CADETProcess/dataStructure/deprecation.py
@@ -1,7 +1,6 @@
-from typing import Any, Callable, Dict
 import functools
 import warnings
-
+from typing import Any, Callable, Dict
 
 __all__ = ["deprecated_alias", "rename_kwargs"]
 
@@ -25,6 +24,7 @@ def deprecated_alias(**aliases: str) -> Callable:
     def example_function(new_name):
          return new_name
     """
+
     # Decorator function: takes the f and returns a f with the new argument names
     def decorator(f: Callable):
         @functools.wraps(f)

--- a/CADETProcess/dataStructure/deprecation.py
+++ b/CADETProcess/dataStructure/deprecation.py
@@ -6,7 +6,8 @@ __all__ = ["deprecated_alias", "rename_kwargs"]
 
 
 def deprecated_alias(**aliases: str) -> Callable:
-    """Add alias for deprecated function arguments.
+    """
+    Add alias for deprecated function arguments.
 
     Parameters
     ----------
@@ -38,7 +39,8 @@ def deprecated_alias(**aliases: str) -> Callable:
 
 
 def rename_kwargs(func_name: str, kwargs: Dict[str, Any], aliases: Dict[str, str]):
-    """Helper function for deprecating function arguments.
+    """
+    Automatically rename deprecated function arguments.
 
     Parameters
     ----------

--- a/CADETProcess/dataStructure/diskcache.py
+++ b/CADETProcess/dataStructure/diskcache.py
@@ -1,18 +1,15 @@
-import io
 import functools as ft
+import io
+import os.path as op
 import pickletools
 import sqlite3
-import os.path as op
 
 import dill as pickle
-
 import diskcache
-from diskcache.core import (
-    UNKNOWN, MODE_RAW, MODE_BINARY, MODE_PICKLE, MODE_TEXT
-)
-
+from diskcache.core import MODE_BINARY, MODE_PICKLE, MODE_RAW, MODE_TEXT, UNKNOWN
 
 __all__ = ["DillDisk"]
+
 
 class DillDisk(diskcache.Disk):
     """Cache key and value serialization for SQLite database and files."""
@@ -29,10 +26,7 @@ class DillDisk(diskcache.Disk):
             return sqlite3.Binary(key), True
         elif (
             (type_key is str)
-            or (
-                type_key is int
-                and -9223372036854775808 <= key <= 9223372036854775807
-            )
+            or (type_key is int and -9223372036854775808 <= key <= 9223372036854775807)
             or (type_key is float)
         ):
             return key, True
@@ -79,18 +73,18 @@ class DillDisk(diskcache.Disk):
                 return 0, MODE_RAW, None, sqlite3.Binary(value)
             else:
                 filename, full_path = self.filename(key, value)
-                self._write(full_path, io.BytesIO(value), 'xb')
+                self._write(full_path, io.BytesIO(value), "xb")
                 return len(value), MODE_BINARY, filename, None
         elif type_value is str:
             filename, full_path = self.filename(key, value)
-            self._write(full_path, io.StringIO(value), 'x', 'UTF-8')
+            self._write(full_path, io.StringIO(value), "x", "UTF-8")
             size = op.getsize(full_path)
             return size, MODE_TEXT, filename, None
         elif read:
-            reader = ft.partial(value.read, 2 ** 22)
+            reader = ft.partial(value.read, 2**22)
             filename, full_path = self.filename(key, value)
-            iterator = iter(reader, b'')
-            size = self._write(full_path, iterator, 'xb')
+            iterator = iter(reader, b"")
+            size = self._write(full_path, iterator, "xb")
             return size, MODE_BINARY, filename, None
         else:
             result = pickle.dumps(value, protocol=self.pickle_protocol)
@@ -99,7 +93,7 @@ class DillDisk(diskcache.Disk):
                 return 0, MODE_PICKLE, None, sqlite3.Binary(result)
             else:
                 filename, full_path = self.filename(key, value)
-                self._write(full_path, io.BytesIO(result), 'xb')
+                self._write(full_path, io.BytesIO(result), "xb")
                 return len(result), MODE_PICKLE, filename, None
 
     def fetch(self, mode, filename, value, read):
@@ -117,17 +111,17 @@ class DillDisk(diskcache.Disk):
             return bytes(value) if type(value) is sqlite3.Binary else value
         elif mode == MODE_BINARY:
             if read:
-                return open(op.join(self._directory, filename), 'rb')
+                return open(op.join(self._directory, filename), "rb")
             else:
-                with open(op.join(self._directory, filename), 'rb') as reader:
+                with open(op.join(self._directory, filename), "rb") as reader:
                     return reader.read()
         elif mode == MODE_TEXT:
             full_path = op.join(self._directory, filename)
-            with open(full_path, 'r', encoding='UTF-8') as reader:
+            with open(full_path, "r", encoding="UTF-8") as reader:
                 return reader.read()
         elif mode == MODE_PICKLE:
             if value is None:
-                with open(op.join(self._directory, filename), 'rb') as reader:
+                with open(op.join(self._directory, filename), "rb") as reader:
                     return pickle.load(reader)
             else:
                 return pickle.load(io.BytesIO(value))

--- a/CADETProcess/dataStructure/diskcache.py
+++ b/CADETProcess/dataStructure/diskcache.py
@@ -3,6 +3,7 @@ import io
 import os.path as op
 import pickletools
 import sqlite3
+from typing import Any, Union
 
 import dill as pickle
 import diskcache
@@ -14,11 +15,12 @@ __all__ = ["DillDisk"]
 class DillDisk(diskcache.Disk):
     """Cache key and value serialization for SQLite database and files."""
 
-    def put(self, key):
+    def put(self, key: Any) -> None:
         """
         Convert `key` to fields key and raw for Cache table.
 
-        :param key: key to convert :return: (database key, raw boolean) pair
+        :param key: key to convert
+        :return: (database key, raw boolean) pair
         """
         # pylint: disable=unidiomatic-typecheck
         type_key = type(key)
@@ -36,12 +38,13 @@ class DillDisk(diskcache.Disk):
             result = pickletools.optimize(data)
             return sqlite3.Binary(result), False
 
-    def get(self, key, raw):
+    def get(self, key: Any, raw: Any) -> Any:
         """
         Convert fields `key` and `raw` from Cache table to key.
 
-        :param key: database key to convert :param bool raw: flag indicating raw
-        database storage :return: corresponding Python key
+        :param key: database key to convert
+        :param bool raw: flag indicating raw database storage
+        :return: corresponding Python key
         """
         # pylint: disable=no-self-use,unidiomatic-typecheck
         if raw:
@@ -49,13 +52,19 @@ class DillDisk(diskcache.Disk):
         else:
             return pickle.load(io.BytesIO(key))
 
-    def store(self, value, read, key=UNKNOWN):
+    def store(
+        self,
+        value: Any,
+        read: bool,
+        key: Any = UNKNOWN
+    ) -> tuple[int, int, Union[str, None], Union[Any, sqlite3.Binary]]:
         """
         Convert `value` to fields size, mode, filename, and value for Cache table.
 
-        :param value: value to convert :param bool read: True when value is file-like object :param
-        key: key for item (default UNKNOWN) :return: (size, mode, filename, value) tuple for Cache
-        table
+        :param value: value to convert
+        :param bool read: True when value is file-like object
+        :param key: key for item (default UNKNOWN)
+        :return: (size, mode, filename, value) tuple for Cache table
         """
         # pylint: disable=unidiomatic-typecheck
         type_value = type(value)
@@ -98,13 +107,15 @@ class DillDisk(diskcache.Disk):
                 self._write(full_path, io.BytesIO(result), "xb")
                 return len(result), MODE_PICKLE, filename, None
 
-    def fetch(self, mode, filename, value, read):
+    def fetch(self, mode: int, filename: str, value: Any, read: bool) -> Any:
         """
         Convert fields `mode`, `filename`, and `value` from Cache table to value.
 
-        :param int mode: value mode raw, binary, text, or pickle :param str filename:
-        filename of corresponding value :param value: database value :param bool read:
-        when True, return an open file handle :return: corresponding Python value
+        :param int mode: value mode raw, binary, text, or pickle
+        :param str filename: filename of corresponding value
+        :param value: database value
+        :param bool read: when True, return an open file handle
+        :return: corresponding Python value
         :raises: IOError if the value cannot be read
         """
         # pylint: disable=no-self-use,unidiomatic-typecheck,consider-using-with

--- a/CADETProcess/dataStructure/diskcache.py
+++ b/CADETProcess/dataStructure/diskcache.py
@@ -15,9 +15,10 @@ class DillDisk(diskcache.Disk):
     """Cache key and value serialization for SQLite database and files."""
 
     def put(self, key):
-        """Convert `key` to fields key and raw for Cache table.
-        :param key: key to convert
-        :return: (database key, raw boolean) pair
+        """
+        Convert `key` to fields key and raw for Cache table.
+
+        :param key: key to convert :return: (database key, raw boolean) pair
         """
         # pylint: disable=unidiomatic-typecheck
         type_key = type(key)
@@ -36,10 +37,11 @@ class DillDisk(diskcache.Disk):
             return sqlite3.Binary(result), False
 
     def get(self, key, raw):
-        """Convert fields `key` and `raw` from Cache table to key.
-        :param key: database key to convert
-        :param bool raw: flag indicating raw database storage
-        :return: corresponding Python key
+        """
+        Convert fields `key` and `raw` from Cache table to key.
+
+        :param key: database key to convert :param bool raw: flag indicating raw
+        database storage :return: corresponding Python key
         """
         # pylint: disable=no-self-use,unidiomatic-typecheck
         if raw:
@@ -48,12 +50,12 @@ class DillDisk(diskcache.Disk):
             return pickle.load(io.BytesIO(key))
 
     def store(self, value, read, key=UNKNOWN):
-        """Convert `value` to fields size, mode, filename, and value for Cache
-        table.
-        :param value: value to convert
-        :param bool read: True when value is file-like object
-        :param key: key for item (default UNKNOWN)
-        :return: (size, mode, filename, value) tuple for Cache table
+        """
+        Convert `value` to fields size, mode, filename, and value for Cache table.
+
+        :param value: value to convert :param bool read: True when value is file-like object :param
+        key: key for item (default UNKNOWN) :return: (size, mode, filename, value) tuple for Cache
+        table
         """
         # pylint: disable=unidiomatic-typecheck
         type_value = type(value)
@@ -97,13 +99,12 @@ class DillDisk(diskcache.Disk):
                 return len(result), MODE_PICKLE, filename, None
 
     def fetch(self, mode, filename, value, read):
-        """Convert fields `mode`, `filename`, and `value` from Cache table to
-        value.
-        :param int mode: value mode raw, binary, text, or pickle
-        :param str filename: filename of corresponding value
-        :param value: database value
-        :param bool read: when True, return an open file handle
-        :return: corresponding Python value
+        """
+        Convert fields `mode`, `filename`, and `value` from Cache table to value.
+
+        :param int mode: value mode raw, binary, text, or pickle :param str filename:
+        filename of corresponding value :param value: database value :param bool read:
+        when True, return an open file handle :return: corresponding Python value
         :raises: IOError if the value cannot be read
         """
         # pylint: disable=no-self-use,unidiomatic-typecheck,consider-using-with

--- a/CADETProcess/dataStructure/encoder.py
+++ b/CADETProcess/dataStructure/encoder.py
@@ -1,10 +1,37 @@
 import json
+from typing import Any
 
 import numpy as np
 
 
 class NumpyArrayEncoder(json.JSONEncoder):
-    def default(self, obj):
+    """
+    Custom JSON encoder for NumPy data types.
+
+    This encoder extends `json.JSONEncoder` to support serialization of NumPy integers,
+    floating-point numbers, and arrays. It converts NumPy data types to native Python
+    data types that can be serialized to JSON.
+    """
+
+    def default(self, obj: Any) -> Any:
+        """
+        Convert NumPy data types to native Python data types for JSON serialization.
+
+        Parameters
+        ----------
+        obj : Any
+            The object to serialize.
+
+        Returns
+        -------
+        Any
+            The object converted to a JSON-serializable type.
+
+        Raises
+        ------
+        TypeError
+            If the object is not of a supported type.
+        """
         if isinstance(obj, np.integer):
             return int(obj)
         elif isinstance(obj, np.floating):

--- a/CADETProcess/dataStructure/nested_dict.py
+++ b/CADETProcess/dataStructure/nested_dict.py
@@ -278,7 +278,9 @@ def get_nested_list_value(ls: Sequence[Any], idx_tuple: tuple[int, ...]) -> Any:
 
 
 def set_nested_list_value(
-    ls: Sequence[Any], idx_tuple: tuple[int, ...], value: Any
+    ls: Sequence[Any],
+    idx_tuple: tuple[int, ...],
+    value: Any
 ) -> None:
     """
     Set a value in a nested list structure using an index tuple.

--- a/CADETProcess/dataStructure/nested_dict.py
+++ b/CADETProcess/dataStructure/nested_dict.py
@@ -17,7 +17,8 @@ __all__ = [
 
 
 def check_nested(nested_dict: dict[str, Any], path: str | list) -> bool:
-    """Check if a key path exists in a nested dictionary.
+    """
+    Check if a key path exists in a nested dictionary.
 
     Parameters
     ----------
@@ -42,7 +43,8 @@ def check_nested(nested_dict: dict[str, Any], path: str | list) -> bool:
 
 
 def generate_nested_dict(path: str | list, value: Any = None) -> dict[str, Any]:
-    """Generate a nested dictionary from a dot-separated path.
+    """
+    Generate a nested dictionary from a dot-separated path.
 
     Parameters
     ----------
@@ -66,7 +68,8 @@ def generate_nested_dict(path: str | list, value: Any = None) -> dict[str, Any]:
 
 
 def insert_path(nested_dict: dict[str, Any], path: str | list, value: Any) -> None:
-    """Add a key path to an existing dictionary without overwriting existing keys.
+    """
+    Add a key path to an existing dictionary without overwriting existing keys.
 
     Parameters
     ----------
@@ -93,7 +96,8 @@ def insert_path(nested_dict: dict[str, Any], path: str | list, value: Any) -> No
 
 
 def get_leaves(nested_dict: dict[str, Any]) -> Generator[str, None, None]:
-    """Yield leaf keys of a nested dictionary in dot notation.
+    """
+    Yield leaf keys of a nested dictionary in dot notation.
 
     Parameters
     ----------
@@ -114,7 +118,8 @@ def get_leaves(nested_dict: dict[str, Any]) -> Generator[str, None, None]:
 
 
 def set_nested_value(nested_dict: dict[str, Any], path: str | list, value: Any) -> None:
-    """Set a value in a nested dictionary using a dot-separated path.
+    """
+    Set a value in a nested dictionary using a dot-separated path.
 
     Parameters
     ----------
@@ -137,7 +142,8 @@ def set_nested_value(nested_dict: dict[str, Any], path: str | list, value: Any) 
 
 
 def get_nested_value(nested_dict: dict[str, Any], path: str | list) -> Any:
-    """Retrieve a value from a nested dictionary using a dot-separated path.
+    """
+    Retrieve a value from a nested dictionary using a dot-separated path.
 
     Parameters
     ----------
@@ -167,7 +173,8 @@ def update_dict_recursively(
     updates: dict[str, Any],
     only_existing_keys: bool = False,
 ) -> dict[str, Any]:
-    """Recursively update `target_dict` with values from `updates`.
+    """
+    Recursively update `target_dict` with values from `updates`.
 
     Parameters
     ----------
@@ -201,7 +208,8 @@ def update_dict_recursively(
 
 
 def get_nested_attribute(obj: Any, path: str) -> Any:
-    """Access a nested attribute using a dot-separated path.
+    """
+    Access a nested attribute using a dot-separated path.
 
     Parameters
     ----------
@@ -227,7 +235,8 @@ def get_nested_attribute(obj: Any, path: str) -> Any:
 
 
 def set_nested_attribute(obj: Any, attr_string: str, value: Any) -> None:
-    """Set a nested attribute using a dot-separated path.
+    """
+    Set a nested attribute using a dot-separated path.
 
     Parameters
     ----------
@@ -237,7 +246,6 @@ def set_nested_attribute(obj: Any, attr_string: str, value: Any) -> None:
         The dot-separated path to the nested attribute.
     value : Any
         The value to set.
-
     """
     attributes = attr_string.split(".")
     for attr in attributes[:-1]:
@@ -246,7 +254,8 @@ def set_nested_attribute(obj: Any, attr_string: str, value: Any) -> None:
 
 
 def get_nested_list_value(ls: Sequence[Any], idx_tuple: tuple[int, ...]) -> Any:
-    """Retrieve a value from a nested list structure using an index tuple.
+    """
+    Retrieve a value from a nested list structure using an index tuple.
 
     Parameters
     ----------
@@ -271,7 +280,8 @@ def get_nested_list_value(ls: Sequence[Any], idx_tuple: tuple[int, ...]) -> Any:
 def set_nested_list_value(
     ls: Sequence[Any], idx_tuple: tuple[int, ...], value: Any
 ) -> None:
-    """Set a value in a nested list structure using an index tuple.
+    """
+    Set a value in a nested list structure using an index tuple.
 
     Parameters
     ----------

--- a/CADETProcess/dataStructure/nested_dict.py
+++ b/CADETProcess/dataStructure/nested_dict.py
@@ -32,7 +32,7 @@ def check_nested(nested_dict: dict[str, Any], path: str | list) -> bool:
         True if the item exists and is not a dictionary, False otherwise.
     """
     if isinstance(path, str):
-        path = path.split('.')
+        path = path.split(".")
 
     try:
         value = get_nested_value(nested_dict, path)
@@ -57,7 +57,7 @@ def generate_nested_dict(path: str | list, value: Any = None) -> dict[str, Any]:
         A nested dictionary created from the path.
     """
     if isinstance(path, str):
-        path = path.split('.')
+        path = path.split(".")
 
     nested_dict = {path[-1]: value}
     for key in reversed(path[:-1]):
@@ -83,7 +83,7 @@ def insert_path(nested_dict: dict[str, Any], path: str | list, value: Any) -> No
         If an intermediate key in the path does not exist.
     """
     if isinstance(path, str):
-        path = path.split('.')
+        path = path.split(".")
 
     if len(path) == 1:
         nested_dict.setdefault(path[0], value)
@@ -131,7 +131,7 @@ def set_nested_value(nested_dict: dict[str, Any], path: str | list, value: Any) 
         If an intermediate key in the path does not exist.
     """
     if isinstance(path, str):
-        path = path.split('.')
+        path = path.split(".")
 
     get_nested_value(nested_dict, path[:-1])[path[-1]] = value
 
@@ -157,16 +157,16 @@ def get_nested_value(nested_dict: dict[str, Any], path: str | list) -> Any:
         If the key path does not exist.
     """
     if isinstance(path, str):
-        path = path.split('.')
+        path = path.split(".")
 
     return reduce(getitem, path, nested_dict)
 
 
 def update_dict_recursively(
-        target_dict: dict[str, Any],
-        updates: dict[str, Any],
-        only_existing_keys: bool = False
-        ) -> dict[str, Any]:
+    target_dict: dict[str, Any],
+    updates: dict[str, Any],
+    only_existing_keys: bool = False,
+) -> dict[str, Any]:
     """Recursively update `target_dict` with values from `updates`.
 
     Parameters
@@ -220,7 +220,7 @@ def get_nested_attribute(obj: Any, path: str) -> Any:
     AttributeError
         If any attribute in the path does not exist.
     """
-    attributes = path.split('.')
+    attributes = path.split(".")
     for attr in attributes:
         obj = getattr(obj, attr)
     return obj
@@ -239,7 +239,7 @@ def set_nested_attribute(obj: Any, attr_string: str, value: Any) -> None:
         The value to set.
 
     """
-    attributes = attr_string.split('.')
+    attributes = attr_string.split(".")
     for attr in attributes[:-1]:
         obj = getattr(obj, attr)
     setattr(obj, attributes[-1], value)
@@ -265,14 +265,12 @@ def get_nested_list_value(ls: Sequence[Any], idx_tuple: tuple[int, ...]) -> Any:
     IndexError
         If any index in the path is out of range.
     """
-    return reduce(lambda l, i: l[i], idx_tuple, ls)
+    return reduce(lambda l, i: l[i], idx_tuple, ls)  # noqa: E741
 
 
 def set_nested_list_value(
-        ls: Sequence[Any],
-        idx_tuple: tuple[int, ...],
-        value: Any
-        ) -> None:
+    ls: Sequence[Any], idx_tuple: tuple[int, ...], value: Any
+) -> None:
     """Set a value in a nested list structure using an index tuple.
 
     Parameters

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -27,7 +27,9 @@ class ParameterBase(Descriptor):
     -----
     1. Supports deep copying of default values, allowing mutable defaults without side effects.
     2. Subclasses can further specify type constraints (like `Typed`).
-    3. They can also define immutable parameters (like `Constant`) and options-based parameters (`Switch`).
+    3. They can also define
+      - immutable parameters (like `Constant`) and
+      - options-based parameters (`Switch`).
 
     See Also
     --------
@@ -45,13 +47,14 @@ class ParameterBase(Descriptor):
     """
 
     def __init__(
-            self,
-            *args,
-            default=None,
-            is_optional=False,
-            unit=None,
-            description=None,
-            **kwargs):
+        self,
+        *args,
+        default=None,
+        is_optional=False,
+        unit=None,
+        description=None,
+        **kwargs,
+    ):
         """
         Initialize a Parameter instance.
 
@@ -219,6 +222,7 @@ class ParameterBase(Descriptor):
 
 # %% Constant Parameters
 
+
 class Constant(ParameterBase):
     """
     Parameter that is immutable once set.
@@ -334,6 +338,7 @@ class Switch(ParameterBase):
 
 # %% Typed Parameters
 
+
 class Typed(ParameterBase):
     """
     Mixin for parameters constrained to a specific type.
@@ -396,7 +401,7 @@ class Typed(ParameterBase):
         """
         if ty is not None:
             self.ty = ty
-        elif not hasattr(self, 'ty'):
+        elif not hasattr(self, "ty"):
             raise ValueError(
                 "Type must be provided either in a subclass or during instantiation."
             )
@@ -684,7 +689,7 @@ class TypedList(List, Typed):
         """
         if dtype is not None:
             self.dtype = dtype
-        elif not hasattr(self, 'dtype'):
+        elif not hasattr(self, "dtype"):
             raise ValueError(
                 "dtype must be provided either in a subclass or during instantiation."
             )
@@ -719,9 +724,7 @@ class TypedList(List, Typed):
         try:
             value = np.array(value, dtype=self.dtype).tolist()
         except ValueError:
-            raise ValueError(
-                f"could not convert elements to {self.dtype}"
-            )
+            raise ValueError(f"could not convert elements to {self.dtype}")
 
         if recursive:
             value = super()._prepare(instance, value, recursive)
@@ -745,9 +748,7 @@ class TypedList(List, Typed):
         value_array = np.array(value)
 
         if value_array.dtype != self.dtype:
-            raise ValueError(
-                f"Value entries must be of type {self.dtype}"
-            )
+            raise ValueError(f"Value entries must be of type {self.dtype}")
 
     def _check(self, instance, value, recursive=False):
         """
@@ -778,6 +779,7 @@ class FloatList(TypedList):
 
 
 # %% Ranged Parameters
+
 
 class Ranged(ParameterBase):
     """Descriptor for parameters within specified bounds.
@@ -823,10 +825,14 @@ class Ranged(ParameterBase):
     """
 
     def __init__(
-            self, *args,
-            lb=-math.inf, lb_op=operator.lt,
-            ub=math.inf, ub_op=operator.gt,
-            **kwargs):
+        self,
+        *args,
+        lb=-math.inf,
+        lb_op=operator.lt,
+        ub=math.inf,
+        ub_op=operator.gt,
+        **kwargs,
+    ):
         """
         Initialize the Ranged descriptor.
 
@@ -1016,6 +1022,7 @@ class UnsignedNdArray(NdArray, UnsignedArray):
 
 # %% Sized Parameters
 
+
 class Sized(ParameterBase):
     """
     Descriptor for parameters with size that potentially depends on instance attributes.
@@ -1189,7 +1196,7 @@ class Sized(ParameterBase):
                 expected_size = None
 
             if isinstance(value, (int, float)):
-                value = self.ty((value, ))
+                value = self.ty((value,))
             else:
                 raise ValueError("Cannot cast value from given value.")
 
@@ -1361,6 +1368,7 @@ class SizedUnsignedIntegerList(UnsignedList, IntegerList, SizedList):
 
 # %% Dimensionalized Parameters
 
+
 class DimensionalizedArray(NdArray):
     """
     Parameter descriptor constrained to np.arrays with a specific dimensionality.
@@ -1411,13 +1419,13 @@ class DimensionalizedArray(NdArray):
 
         if n_dim is not None:
             if not isinstance(n_dim, int):
-                raise ValueError('Dimensionality (n_dim) must be an integer.')
+                raise ValueError("Dimensionality (n_dim) must be an integer.")
             self.n_dim = n_dim
 
         # Ensure the dimension is set and valid
         if self.n_dim is None:
             raise ValueError(
-                'Dimensionality (n_dim) must be set during initialization.'
+                "Dimensionality (n_dim) must be set during initialization."
             )
 
     def _check(self, instance, value, recursive=False):
@@ -1504,6 +1512,7 @@ class Matrix(DimensionalizedArray):
 
 # %% Polynomial Parameters
 
+
 class NdPolynomial(SizedNdArray):
     """
     Dependently sized polynomial for n entries.
@@ -1572,11 +1581,11 @@ class NdPolynomial(SizedNdArray):
         The shape of the polynomial array is determined from 'n_entries' and 'n_coeff'
         or from the 'size' keyword argument.
         """
-        if 'default' in kwargs and kwargs['default'] != 0:
+        if "default" in kwargs and kwargs["default"] != 0:
             raise ValueError("Default value for NdPolynomial must always be 0.")
 
         try:
-            size = kwargs['size']
+            size = kwargs["size"]
             if not isinstance(size, tuple):
                 size = (size,)
         except KeyError:
@@ -1610,7 +1619,7 @@ class NdPolynomial(SizedNdArray):
 
         size = (_n_entries, _n_coeff)
 
-        kwargs['size'] = size
+        kwargs["size"] = size
 
         super().__init__(*args, **kwargs)
 
@@ -1666,7 +1675,7 @@ class NdPolynomial(SizedNdArray):
                 v = [v]
             if isinstance(v, (list, tuple)):
                 missing = n_coeff - len(v)
-                v += missing*(0,)
+                v += missing * (0,)
             _value[i, :] = np.array(v)
 
         if single_entry:
@@ -1742,6 +1751,7 @@ class Polynomial(NdPolynomial):
 
 
 # %% Modulated Parameters
+
 
 class DependentlyModulated(Sized):
     """

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -215,7 +215,6 @@ class ParameterBase(Descriptor):
             Value to check.
         recursive : bool, optional
             If True, perform the check recursively. Defaults to False.
-
         """
         return
 
@@ -762,7 +761,6 @@ class TypedList(List, Typed):
             Value to check.
         recursive : bool, optional
             If True, perform the check recursively. Defaults to False.
-
         """
         self.check_dtype(value)
 
@@ -771,10 +769,14 @@ class TypedList(List, Typed):
 
 
 class IntegerList(TypedList):
+    """List of integers."""
+
     dtype = int
 
 
 class FloatList(TypedList):
+    """List of floats."""
+
     dtype = float
 
 
@@ -782,7 +784,8 @@ class FloatList(TypedList):
 
 
 class Ranged(ParameterBase):
-    """Descriptor for parameters within specified bounds.
+    """
+    Descriptor for parameters within specified bounds.
 
     Allows setting values constrained by provided lower and upper bounds. The actual comparisons
     against the bounds can be customized using the `lb_op` and `ub_op` comparison functions.
@@ -888,7 +891,6 @@ class Ranged(ParameterBase):
             Value to check.
         recursive : bool, optional
             If True, perform the check recursively. Defaults to False.
-
         """
         self.check_range(value)
 
@@ -911,7 +913,8 @@ class RangedFloat(Float, Ranged):
 
 # Ranged list / array parameters
 class RangedArray(Ranged):
-    """Parameter descriptor for arrays with elements constrained within some bounds.
+    """
+    Parameter descriptor for arrays with elements constrained within some bounds.
 
     This class extends the Ranged descriptor to support array-like structures
     (lists, numpy arrays, etc.). Each element in the array is individually checked
@@ -941,7 +944,8 @@ class RangedArray(Ranged):
     """
 
     def check_range(self, value):
-        """Check each element of an array-like structure against specified bounds.
+        """
+        Check each element of an array-like structure against specified bounds.
 
         Parameters
         ----------
@@ -1079,9 +1083,9 @@ class Sized(ParameterBase):
             flag = False
         return flag
 
-    def get_size(self, value):
+    def get_size(self, value) -> int | tuple[int]:
         """
-        Determines the size of the provided value.
+        Determine the size of the provided value.
 
         Parameters
         ----------
@@ -1090,7 +1094,7 @@ class Sized(ParameterBase):
 
         Returns
         -------
-        Union[int, Tuple[int, ...]]
+        int | tuple[int]
             Size of the value.
         """
         return len(value)
@@ -1244,7 +1248,20 @@ class SizedTuple(Tuple, Sized):
 class SizedNdArray(NdArray, Sized):
     """Descriptor for NumPy arrays whose size may depend on other instance attributes."""
 
-    def get_size(self, value):
+    def get_size(self, value) -> tuple[int, ...]:
+        """
+        Determine the size of the provided value.
+
+        Parameters
+        ----------
+        value : Any
+            The value for which the size needs to be determined.
+
+        Returns
+        -------
+        tuple[int, ...]
+            Size of the value.
+        """
         return value.shape
 
     def get_expected_size(self, instance):
@@ -1395,7 +1412,6 @@ class DimensionalizedArray(NdArray):
     Notes
     -----
     The n_dim attribute can be set during initialization.
-
     """
 
     n_dim = None
@@ -1700,7 +1716,6 @@ class NdPolynomial(SizedNdArray):
         -------
         np.ndarray
             Polynomial matrix of the desired size prepared as per requirements.
-
         """
         if instance is not None:
             dims = self.get_expected_size(instance)
@@ -1757,8 +1772,8 @@ class DependentlyModulated(Sized):
     """
     Mixin for checking parameter shapes based on other instance attributes.
 
-    This mixin ensures that the size of a parameter is modulo an expected size.
-    If this condition is not met, a ValueError is raised.
+    This mixin ensures that the size of a parameter is modulo an expected size. If this
+    condition is not met, a ValueError is raised.
     """
 
     def check_mod_value(self, instance, value):

--- a/CADETProcess/dataStructure/parameter.py
+++ b/CADETProcess/dataStructure/parameter.py
@@ -1,8 +1,11 @@
 import copy
 import math
 import operator
+import typing as tp
+from typing import Any, Optional, Union
 
 import numpy as np
+import numpy.typing as npt
 
 from .dataStructure import Descriptor
 
@@ -48,13 +51,13 @@ class ParameterBase(Descriptor):
 
     def __init__(
         self,
-        *args,
-        default=None,
-        is_optional=False,
-        unit=None,
-        description=None,
-        **kwargs,
-    ):
+        *args: Any,
+        default: Optional[Any] = None,
+        is_optional: bool = False,
+        unit: Optional[str] = None,
+        description: Optional[str] = None,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize a Parameter instance.
 
@@ -81,12 +84,12 @@ class ParameterBase(Descriptor):
         super().__init__(*args, **kwargs)
 
     @property
-    def default(self):
+    def default(self) -> Any:
         """Any: Get or set the default value of the parameter."""
         return copy.deepcopy(self._default)
 
     @default.setter
-    def default(self, value):
+    def default(self, value: Any) -> None:
         """
         Set the default value of the parameter.
 
@@ -101,7 +104,7 @@ class ParameterBase(Descriptor):
 
         self._default = value
 
-    def get_default_value(self, instance):
+    def get_default_value(self, instance: Any) -> Any:
         """
         Return default values if necessary.
 
@@ -109,8 +112,8 @@ class ParameterBase(Descriptor):
 
         Parameters
         ----------
-        value : Any
-            Value to cast.
+        instance : Any
+            Instance to retrieve the default value for.
 
         Returns
         -------
@@ -126,7 +129,7 @@ class ParameterBase(Descriptor):
 
         return default
 
-    def __get__(self, instance, cls):
+    def __get__(self, instance: Any, cls: type) -> Any:
         """
         Retrieve the descriptor value for the given instance.
 
@@ -155,7 +158,7 @@ class ParameterBase(Descriptor):
 
         return value
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """
         Set the descriptor value for the given instance.
 
@@ -181,7 +184,7 @@ class ParameterBase(Descriptor):
 
         super().__set__(instance, value)
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(self, instance: Any, value: Any, recursive: bool = False) -> Any:
         """
         Prepare value for setting if necessary.
 
@@ -193,6 +196,8 @@ class ParameterBase(Descriptor):
             Instance to retrieve the descriptor value for.
         value : Any
             Value to cast.
+        recursive : bool, optional
+            If True, prepare values recursively.
 
         Returns
         -------
@@ -201,7 +206,7 @@ class ParameterBase(Descriptor):
         """
         return value
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> Any:
         """
         Check the given value.
 
@@ -236,7 +241,7 @@ class Constant(ParameterBase):
     Once set, the value of a Constant parameter cannot be modified.
     """
 
-    def __init__(self, value, *args, **kwargs):
+    def __init__(self, value: Any, *args: Any, **kwargs: Any) -> None:
         """
         Initialize a Constant instance.
 
@@ -251,7 +256,7 @@ class Constant(ParameterBase):
         """
         super().__init__(*args, default=value, **kwargs)
 
-    def __set__(self, instance, value):
+    def __set__(self, instance: Any, value: Any) -> None:
         """
         Disallow modification of the value of a Constant parameter.
 
@@ -277,7 +282,7 @@ class Switch(ParameterBase):
     Assign a value to this parameter from the `valid` list.
     """
 
-    def __init__(self, *args, valid, **kwargs):
+    def __init__(self, *args: Any, valid: list, **kwargs: Any) -> None:
         """
         Initialize a Switch instance.
 
@@ -305,7 +310,7 @@ class Switch(ParameterBase):
 
         super().__init__(*args, **kwargs)
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> None:
         """
         Verify if the value belongs to the valid options.
 
@@ -317,11 +322,6 @@ class Switch(ParameterBase):
             The value to check.
         recursive : bool, optional
             If True, perform the check recursively. Defaults to False.
-
-        Returns
-        -------
-        bool
-            True if the value is among the valid options, otherwise raises an exception.
 
         Raises
         ------
@@ -385,7 +385,7 @@ class Typed(ParameterBase):
     Dictionary
     """
 
-    def __init__(self, *args, ty=None, **kwargs):
+    def __init__(self, *args: Any, ty: Optional[type] = None, **kwargs: Any) -> None:
         """
         Initialize a Typed instance.
 
@@ -407,7 +407,7 @@ class Typed(ParameterBase):
 
         super().__init__(*args, **kwargs)
 
-    def cast_value(self, value):
+    def cast_value(self, value: Any) -> Any:
         """
         Cast the type of the given value.
 
@@ -425,7 +425,7 @@ class Typed(ParameterBase):
         """
         return value
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(self, instance: Any, value: Any, recursive: bool = False) -> Any:
         """
         Prepare and optionally type-cast the value before type validation.
 
@@ -457,7 +457,7 @@ class Typed(ParameterBase):
 
         return value
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> None:
         """
         Validate the value's type against `ty`.
 
@@ -469,11 +469,6 @@ class Typed(ParameterBase):
             Value to check.
         recursive : bool, optional
             If True, perform the check recursively. Defaults to False.
-
-        Returns
-        -------
-        bool
-            True if value's type matches, else raises an exception.
 
         Raises
         ------
@@ -498,7 +493,7 @@ class Bool(Typed):
 
     ty = bool
 
-    def cast_value(self, value):
+    def cast_value(self, value: Any) -> Union[bool, Any]:
         """
         Convert integers 0 and 1 to their respective boolean values.
 
@@ -534,7 +529,7 @@ class Float(Typed):
 
     ty = float
 
-    def cast_value(self, value):
+    def cast_value(self, value: Any) -> Union[float, Any]:
         """
         Convert integers and numpy numbers to float.
 
@@ -593,7 +588,7 @@ class NdArray(Typed):
 
     ty = np.ndarray
 
-    def cast_value(self, value):
+    def cast_value(self, value: Any) -> Any | np.ndarray:
         """
         Cast lists or scalars (int or float) to numpy arrays.
 
@@ -642,7 +637,7 @@ class Callable(ParameterBase):
     Typed
     """
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> None:
         """
         Check if the given value is callable.
 
@@ -673,7 +668,7 @@ class TypedList(List, Typed):
 
     ty = list
 
-    def __init__(self, *args, dtype=None, **kwargs):
+    def __init__(self, *args: Any, dtype: Optional[type] = None, **kwargs: Any) -> None:
         """
         Initialize a Typed instance.
 
@@ -695,7 +690,7 @@ class TypedList(List, Typed):
 
         super().__init__(*args, **kwargs)
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(self, instance: Any, value: Any, recursive: bool = False) -> Any:
         """
         Prepare and optionally cast the array dtype.
 
@@ -730,7 +725,7 @@ class TypedList(List, Typed):
 
         return value
 
-    def check_dtype(self, value):
+    def check_dtype(self, value: Any) -> None:
         """
         Validate if the dtype of values is correct.
 
@@ -749,7 +744,7 @@ class TypedList(List, Typed):
         if value_array.dtype != self.dtype:
             raise ValueError(f"Value entries must be of type {self.dtype}")
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> None:
         """
         Validate the value against the range.
 
@@ -828,19 +823,18 @@ class Ranged(ParameterBase):
     """
 
     def __init__(
-        self,
-        *args,
-        lb=-math.inf,
-        lb_op=operator.lt,
-        ub=math.inf,
-        ub_op=operator.gt,
-        **kwargs,
-    ):
+        self, *args: Any,
+        lb: float = -math.inf, lb_op: tp.Callable = operator.lt,
+        ub: float = math.inf, ub_op: tp.Callable = operator.gt,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize the Ranged descriptor.
 
         Parameters
         ----------
+        *args :
+            Parameters for Parameter Base.
         lb : numeric, optional
             Lower bound. Defaults to negative infinity.
         lb_op : callable, optional
@@ -849,6 +843,9 @@ class Ranged(ParameterBase):
             Upper bound. Defaults to positive infinity.
         ub_op : callable, optional
             Comparison for the upper bound. Defaults to greater than.
+        **kwargs: Optional
+            Additional Parameters for ParameterBase.
+
         """
         self.lb = lb
         self.lb_op = lb_op
@@ -857,7 +854,7 @@ class Ranged(ParameterBase):
 
         super().__init__(*args, **kwargs)
 
-    def check_range(self, value):
+    def check_range(self, value: Any) -> None:
         """
         Validate if the value is within the defined range.
 
@@ -879,7 +876,7 @@ class Ranged(ParameterBase):
         elif self.ub_op(value, self.ub):
             raise ValueError(f"Value {value} is above the upper bound of {self.ub}")
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> None:
         """
         Validate the value against the range.
 
@@ -943,7 +940,7 @@ class RangedArray(Ranged):
     Ranged
     """
 
-    def check_range(self, value):
+    def check_range(self, value: npt.ArrayLike) -> None:
         """
         Check each element of an array-like structure against specified bounds.
 
@@ -989,7 +986,8 @@ class RangedNdArray(NdArray, RangedArray):
 class Unsigned(Ranged):
     """Parameter descriptor for non-negative parameters."""
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize unsigned parameter."""
         super().__init__(*args, lb=0, lb_op=operator.lt, **kwargs)
 
 
@@ -1050,15 +1048,19 @@ class Sized(ParameterBase):
         Validates that the provided value's size matches the expected size.
     """
 
-    def __init__(self, *args, size, **kwargs):
+    def __init__(self, *args: Any, size: Union[int, tuple], **kwargs: Any) -> None:
         """
         Initialize the Sized descriptor.
 
         Parameters
         ----------
+        *args :
+            Parameters for Parameter Base.
         size : int or tuple
             The expected size or dimensions of the parameter. Individual elements
             can be either integers or strings (indicating other instance parameters).
+        **kwargs :
+            Additional parameters for Parameter Base.
         """
         if not isinstance(size, tuple):
             size = (size,)
@@ -1068,7 +1070,7 @@ class Sized(ParameterBase):
         super().__init__(*args, **kwargs)
 
     @property
-    def is_independent(self):
+    def is_independent(self) -> bool:
         """
         Determine whether the size is independent of other parameters.
 
@@ -1083,7 +1085,7 @@ class Sized(ParameterBase):
             flag = False
         return flag
 
-    def get_size(self, value) -> int | tuple[int]:
+    def get_size(self, value: Any) -> int | tuple[int, ...]:
         """
         Determine the size of the provided value.
 
@@ -1094,12 +1096,12 @@ class Sized(ParameterBase):
 
         Returns
         -------
-        int | tuple[int]
+        int | tuple[int, ...]
             Size of the value.
         """
         return len(value)
 
-    def get_expected_size(self, instance):
+    def get_expected_size(self, instance: Any) -> int:
         """
         Compute the expected size based on the instance's other attributes.
 
@@ -1137,7 +1139,7 @@ class Sized(ParameterBase):
 
         return np.prod(size)
 
-    def check_size(self, instance, value):
+    def check_size(self, instance: Any, value: Any) -> None:
         """
         Validate that the provided value's size matches the expected size.
 
@@ -1164,7 +1166,7 @@ class Sized(ParameterBase):
         if size != expected_size:
             raise ValueError(f"Expected size {expected_size}")
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(self, instance: Any, value: Any, recursive: bool = False) -> Any:
         """
         Prepare the value by typecasting and adjusting its size.
 
@@ -1214,7 +1216,7 @@ class Sized(ParameterBase):
 
         return value
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: Any, recursive: bool = False) -> None:
         """
         Validate the provided value's size.
 
@@ -1248,7 +1250,7 @@ class SizedTuple(Tuple, Sized):
 class SizedNdArray(NdArray, Sized):
     """Descriptor for NumPy arrays whose size may depend on other instance attributes."""
 
-    def get_size(self, value) -> tuple[int, ...]:
+    def get_size(self, value: np.ndarray) -> tuple[int, ...]:
         """
         Determine the size of the provided value.
 
@@ -1264,7 +1266,7 @@ class SizedNdArray(NdArray, Sized):
         """
         return value.shape
 
-    def get_expected_size(self, instance):
+    def get_expected_size(self, instance: Optional[Any]) -> tuple:
         """
         Calculate the expected size of a numpy array based on the instance's other attributes.
 
@@ -1297,7 +1299,9 @@ class SizedNdArray(NdArray, Sized):
 
         return expected_size
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(
+            self, instance: object, value: Union[int, float, npt.ArrayLike], recursive: bool = False
+            ) -> np.ndarray:
         """
         Prepare the value for a NumPy array, ensuring it has the expected shape.
 
@@ -1416,7 +1420,7 @@ class DimensionalizedArray(NdArray):
 
     n_dim = None
 
-    def __init__(self, n_dim=None, *args, **kwargs):
+    def __init__(self, n_dim: Optional[int] = None, *args: Any, **kwargs: Any) -> None:
         """
         Initialize the DimensionalizedArray descriptor.
 
@@ -1425,6 +1429,10 @@ class DimensionalizedArray(NdArray):
         n_dim : int, optional
             The number of dimensions the array must have. If not specified,
             it must be set before usage.
+        *args : optional
+            Parameters for NdArray.
+        **kwargs : optional
+            Additional Parameters for NdArray.
 
         Raises
         ------
@@ -1444,7 +1452,7 @@ class DimensionalizedArray(NdArray):
                 "Dimensionality (n_dim) must be set during initialization."
             )
 
-    def _check(self, instance, value, recursive=False):
+    def _check(self, instance: Any, value: npt.ArrayLike, recursive: bool = False) -> None:
         """
         Check the dimensionality of the given value.
 
@@ -1567,7 +1575,13 @@ class NdPolynomial(SizedNdArray):
         Prepare the given polynomial matrix s.t. it adheres to the expected size.
     """
 
-    def __init__(self, *args, n_entries=None, n_coeff=None, **kwargs):
+    def __init__(
+        self,
+        *args: Any,
+        n_entries: Optional[int] = None,
+        n_coeff: Optional[int] = None,
+        **kwargs: Any
+    ) -> None:
         """
         Initialize an NdPolynomial descriptor with specific entries and coefficients.
 
@@ -1639,7 +1653,9 @@ class NdPolynomial(SizedNdArray):
 
         super().__init__(*args, **kwargs)
 
-    def fill_values(self, dims, value):
+    def fill_values(
+        self, dims: tuple[int], value: Union[int, float, np.ndarray, list]
+    ) -> np.ndarray:
         """
         Fill values to generate the polynomial matrix of the desired size.
 
@@ -1699,7 +1715,12 @@ class NdPolynomial(SizedNdArray):
 
         return _value
 
-    def _prepare(self, instance, value, recursive=False):
+    def _prepare(
+        self,
+        instance: object,
+        value: Union[int, float, np.ndarray, list],
+        recursive: bool = False
+    ) -> np.ndarray:
         """
         Prepare the given polynomial matrix s.t. it adheres to the expected size.
 
@@ -1744,7 +1765,7 @@ class Polynomial(NdPolynomial):
         'n_entries'.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """
         Initialize a Polynomial descriptor with a specific coefficient length.
 
@@ -1776,7 +1797,7 @@ class DependentlyModulated(Sized):
     condition is not met, a ValueError is raised.
     """
 
-    def check_mod_value(self, instance, value):
+    def check_mod_value(self, instance: Any, value: Any) -> None:
         """
         Check if the size of the parameter modulo its expected size is zero.
 
@@ -1785,7 +1806,7 @@ class DependentlyModulated(Sized):
 
         Parameters
         ----------
-        instance : object
+        instance : Any
             The instance associated with the parameter.
         value : Any
             The value whose size needs to be validated.

--- a/CADETProcess/dataStructure/parameter_group.py
+++ b/CADETProcess/dataStructure/parameter_group.py
@@ -2,7 +2,8 @@ from CADETProcess import CADETProcessError
 
 
 class ParameterWrapper:
-    """Base class for converting the config from objects such as units.
+    """
+    Base class for converting the config from objects such as units.
 
     Attributes
     ----------
@@ -15,7 +16,6 @@ class ParameterWrapper:
     ------
     CADETProcessError
         If the wrapped_object is no instance of the base_class.
-
     """
 
     _base_class = object
@@ -33,7 +33,8 @@ class ParameterWrapper:
         self._wrapped_object = wrapped_object
 
     @property
-    def parameters(self):
+    def parameters(self) -> dict:
+        """dict: Parameters dictionary."""
         model_parameters = {}
 
         model_parameters[self._model_type] = self.model_parameters["name"]

--- a/CADETProcess/dataStructure/parameter_group.py
+++ b/CADETProcess/dataStructure/parameter_group.py
@@ -1,7 +1,7 @@
 from CADETProcess import CADETProcessError
 
 
-class ParameterWrapper():
+class ParameterWrapper:
     """Base class for converting the config from objects such as units.
 
     Attributes
@@ -36,14 +36,14 @@ class ParameterWrapper():
     def parameters(self):
         model_parameters = {}
 
-        model_parameters[self._model_type] = self.model_parameters['name']
+        model_parameters[self._model_type] = self.model_parameters["name"]
 
-        for key, value in self.model_parameters['parameters'].items():
+        for key, value in self.model_parameters["parameters"].items():
             value = getattr(self._wrapped_object, value)
             if value is not None:
                 model_parameters[key] = value
 
-        for key, value in self.model_parameters.get('fixed', dict()).items():
+        for key, value in self.model_parameters.get("fixed", dict()).items():
             if isinstance(value, list):
                 value = self._wrapped_object.n_comp * value
             model_parameters[key] = value

--- a/CADETProcess/dataStructure/parameter_group.py
+++ b/CADETProcess/dataStructure/parameter_group.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from CADETProcess import CADETProcessError
 
 
@@ -20,7 +22,8 @@ class ParameterWrapper:
 
     _base_class = object
 
-    def __init__(self, wrapped_object):
+    def __init__(self, wrapped_object: Any) -> None:
+        """Construct ParameterWrapper object."""
         if not isinstance(wrapped_object, self._baseClass):
             raise CADETProcessError(f"Expected {self._baseClass}")
 

--- a/CADETProcess/dynamicEvents/event.py
+++ b/CADETProcess/dynamicEvents/event.py
@@ -305,7 +305,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         self.__dict__.pop(duration_name)
 
     @cached_property_if_locked
-    def durations(self):
+    def durations(self) -> list["Duration"]:
         """List of all durations in the process."""
         return self._durations
 
@@ -422,17 +422,17 @@ class EventHandler(CachedPropertiesMixin, Structure):
             self.events[dependent_event].remove_dependency(indep)
 
     @cached_property_if_locked
-    def independent_events(self):
+    def independent_events(self) -> list[Event]:
         """list: All events that are not dependent on other events."""
         return list(filter(lambda evt: evt.is_independent, self.events))
 
     @cached_property_if_locked
-    def dependent_events(self):
+    def dependent_events(self) -> list[Event]:
         """list: All events that are dependent on other events."""
         return list(filter(lambda evt: evt.is_independent is False, self.events))
 
     @cached_property_if_locked
-    def event_parameters(self):
+    def event_parameters(self) -> list[str]:
         """list: Event parameters."""
         return list({evt.parameter_path for evt in self.events})
 
@@ -442,7 +442,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         return list({evt.performer for evt in self.events})
 
     @cached_property_if_locked
-    def event_times(self):
+    def event_times(self) -> list[float]:
         """list: Time of events, sorted by Event time."""
         event_times = list({evt.time for evt in self.events})
         event_times.sort()
@@ -470,7 +470,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         return section_times
 
     @property
-    def n_sections(self):
+    def n_sections(self) -> int:
         """int: Number of sections."""
         return len(self.section_times) - 1
 
@@ -685,7 +685,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
         return parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: dict) -> None:
         """Set event parameters based on provided dictionary."""
         try:
             self.cycle_time = parameters.pop("cycle_time")
@@ -726,7 +726,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
 
         return parameters
 
-    def check_config(self):
+    def check_config(self) -> bool:
         """
         Validate the event configuration.
 
@@ -748,7 +748,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
 
         return flag
 
-    def check_duplicate_events(self):
+    def check_duplicate_events(self) -> bool:
         """
         Ensure no simulateneous events are scheduled for a specific parameter and index.
 
@@ -790,7 +790,7 @@ class EventHandler(CachedPropertiesMixin, Structure):
 
         return flag
 
-    def check_uninitialized_indices(self):
+    def check_uninitialized_indices(self) -> bool:
         """
         Ensure all indices are specified when a parameter isn't initialized.
 
@@ -940,7 +940,7 @@ class Event:
         self.time = time
 
     @property
-    def parameter_path(self):
+    def parameter_path(self) -> str:
         """str: Dot notation path to the target parameter within the evaluation_object."""
         return self._parameter_path
 
@@ -953,7 +953,7 @@ class Event:
         self._parameter_path = parameter_path
 
     @property
-    def parameter_sequence(self):
+    def parameter_sequence(self) -> tuple[str, ...]:
         """tuple: Tuple of parameters path elements."""
         return tuple(self.parameter_path.split("."))
 
@@ -972,7 +972,7 @@ class Event:
         return descriptor
 
     @property
-    def parameter_type(self):
+    def parameter_type(self) -> Type[Any]:
         """type: Type of the parameter."""
         if isinstance(self.parameter_descriptor, Typed):
             return self.parameter_descriptor.ty
@@ -985,7 +985,7 @@ class Event:
         return type(self.current_value)
 
     @property
-    def parameter_shape(self):
+    def parameter_shape(self) -> tuple[int, ...]:
         """tuple: Shape of the parameter array."""
         param_descriptor = self.parameter_descriptor
         if isinstance(param_descriptor, (Float, Integer, Bool)):
@@ -1007,7 +1007,7 @@ class Event:
         return np.array(cur_value).shape
 
     @property
-    def is_sized(self):
+    def is_sized(self) -> bool:
         """bool: True if descriptor is instance of Sized. False otherwise."""
         if isinstance(self.parameter_descriptor, (Float, Integer, Bool)):
             return False
@@ -1023,7 +1023,7 @@ class Event:
         return np.array(self.current_value).size > 1
 
     @property
-    def is_polynomial(self):
+    def is_polynomial(self) -> bool:
         """bool: True if descriptor is instance of NdPolynomial. False otherwise."""
         return check_nested(
             self.event_handler.polynomial_parameters, self.parameter_path
@@ -1082,7 +1082,7 @@ class Event:
             raise e
 
     @property
-    def is_index_specific(self):
+    def is_index_specific(self) -> bool:
         """bool: True if event modifies entry of a parameter array, False otherwise."""
         if len(self.full_indices) > 0:
             return True
@@ -1090,7 +1090,7 @@ class Event:
             return False
 
     @property
-    def full_indices(self):
+    def full_indices(self) -> list[int]:
         """list: Full indices."""
         indices = self.indices
         if self.indices is None and len(self.parameter_shape) > 0:
@@ -1098,7 +1098,7 @@ class Event:
         return unravel(self.parameter_shape, indices)
 
     @property
-    def n_indices(self):
+    def n_indices(self) -> int:
         """int: Number of (full) indices."""
         if len(self.parameter_shape) > 0:
             return len(self.full_indices)
@@ -1106,7 +1106,7 @@ class Event:
             return 0
 
     @property
-    def n_entries(self):
+    def n_entries(self) -> int:
         """int: The number of entries in the event state."""
         if self.is_polynomial:
             return np.array(self.full_state).shape[0]
@@ -1149,7 +1149,7 @@ class Event:
         self._factors.append(factor)
         if transform is None:
 
-            def transform(t):
+            def transform(t: Any) -> Any:
                 return t
 
         self._transforms.append(transform)
@@ -1178,7 +1178,7 @@ class Event:
         del self._transforms[index]
 
     @property
-    def dependencies(self):
+    def dependencies(self) -> list['Event']:
         """list: Events on which the Event depends."""
         return self._dependencies
 
@@ -1191,7 +1191,7 @@ class Event:
             return False
 
     @property
-    def factors(self):
+    def factors(self) -> list[int]:
         """list: Linear coefficients for dependent events."""
         return self._factors
 
@@ -1226,7 +1226,7 @@ class Event:
         return time % cycle_time
 
     @time.setter
-    def time(self, time):
+    def time(self, time: float) -> None:
         if not np.isscalar(time):
             raise TypeError("Expected scalar value")
 
@@ -1383,7 +1383,7 @@ class Event:
         return full_state
 
     @property
-    def index_states(self):
+    def index_states(self) -> dict[tuple, float]:
         """dict[tuple, float]: State values mapped to their respective indices."""
         index_states = {}
         for ind, state in zip(self.full_indices, self.full_state):
@@ -1392,7 +1392,7 @@ class Event:
         return index_states
 
     @property
-    def performer(self):
+    def performer(self) -> str:
         """str: The name of the performer of the event."""
         if len(self.parameter_sequence) == 1:
             return self.parameter_sequence[0]
@@ -1400,7 +1400,7 @@ class Event:
             return ".".join(self.parameter_sequence[:-1])
 
     @property
-    def performer_obj(self):
+    def performer_obj(self) -> Any:
         """any: Performer object from the event handler."""
         return get_nested_attribute(self.event_handler, self.performer)
 
@@ -1414,7 +1414,7 @@ class Event:
             self.event_handler.parameters = parameters
 
     @property
-    def current_value(self):
+    def current_value(self) -> Any:
         """any: Current state of the associated event parameter."""
         if self.parameter_descriptor is not None:
             return getattr(self.performer_obj, self.parameter_sequence[-1])
@@ -1422,12 +1422,12 @@ class Event:
             return get_nested_value(self.event_handler.parameters, self.parameter_path)
 
     @property
-    def parameters(self):
+    def parameters(self) -> dict:
         """dict: list with all parameters."""
         return Dict({param: getattr(self, param) for param in self._parameters})
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: Union[tuple[float, int], dict]) -> None:
         if isinstance(parameters, (float, int)):
             self.time = parameters
         else:
@@ -1477,12 +1477,12 @@ class Duration:
         self._parameters = ["time"]
 
     @property
-    def parameters(self):
+    def parameters(self) -> Dict:
         """dict: list with all parameters."""
         return Dict({param: getattr(self, param) for param in self._parameters})
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: Union[tuple[float, int], dict]) -> None:
         if isinstance(parameters, (float, int)):
             self.time = parameters
         else:

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -1,7 +1,11 @@
+from __future__ import annotations
+
 import itertools
 import warnings
+from typing import Optional
 
 import numpy as np
+import numpy.typing as npt
 import scipy
 from matplotlib.axes import Axes
 from numpy.exceptions import VisibleDeprecationWarning
@@ -38,7 +42,14 @@ class Section(Structure):
 
     coeffs = NdPolynomial(size=("n_entries", "n_poly_coeffs"))
 
-    def __init__(self, start, end, coeffs, is_polynomial=False):
+    def __init__(
+        self,
+        start: float,
+        end: float,
+        coeffs: int | float | npt.ArrayLike,
+        is_polynomial: bool = False
+    ) -> None:
+        """Construct section object."""
         if start > end:
             raise ValueError("End time must be greater than start time")
 
@@ -76,19 +87,19 @@ class Section(Structure):
                 self._poly_der.append(poly_der)
 
     @property
-    def is_polynomial(self):
+    def is_polynomial(self) -> bool:
         """bool: True if Section represents polynomial parameter. False otherwise."""
         if self.degree > 0:
             return True
         return False
 
     @property
-    def n_poly_coeffs(self):
+    def n_poly_coeffs(self) -> int:
         """int: Number of polynomial coefficients."""
         return self.degree + 1
 
     @property
-    def is_single_entry(self):
+    def is_single_entry(self) -> bool:
         """bool: True if Section contains single entry. False otherwise."""
         if self.n_entries > 1:
             return True
@@ -98,7 +109,7 @@ class Section(Structure):
 
         return False
 
-    def value(self, t):
+    def value(self, t: float) -> float:
         """
         Return value of parameter section at time t.
 
@@ -126,7 +137,7 @@ class Section(Structure):
 
     __call__ = value
 
-    def coefficients(self, offset=0):
+    def coefficients(self, offset: float = 0.0) -> np.ndarray:
         """
         Get coefficients at (time) offset.
 
@@ -150,7 +161,7 @@ class Section(Structure):
 
         return np.array(coeffs).reshape(self.parameter_shape)
 
-    def derivative(self, t, order=1):
+    def derivative(self, t: float, order: Optional[int] = 1) -> np.ndarray:
         """
         Return derivative of parameter section at time t.
 
@@ -158,6 +169,8 @@ class Section(Structure):
         ----------
         t : float
             Time at which function is evaluated.
+        order : int, default=1
+            Order of deriviation. @TODO: Not yet implemented.
 
         Returns
         -------
@@ -178,7 +191,7 @@ class Section(Structure):
 
         return deriv
 
-    def integral(self, start=None, end=None):
+    def integral(self, start: Optional[float] = None, end: Optional[float] = None) -> np.ndarray:
         """
         Return integral of function in interval [start, end].
 
@@ -191,7 +204,7 @@ class Section(Structure):
 
         Returns
         -------
-        Y : float
+        Y : np.ndarray
             Value of definite integral between start and end.
 
         Raises
@@ -233,27 +246,28 @@ class TimeLine:
         List of Sections that make up the timeline.
     """
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize TimeLine object."""
         self._sections = []
 
     @property
-    def sections(self):
+    def sections(self) -> list:
         """list: Sections of the TimeLine."""
         return self._sections
 
     @property
-    def degree(self):
+    def degree(self) -> int:
         """int: Degree of the polynomial functions used to represent each Section."""
         if len(self.sections) > 0:
             return self.sections[0].degree
 
     @property
-    def n_entries(self):
+    def n_entries(self) -> int:
         """int: Number of entries in the parameter vector for each Section."""
         if len(self.sections) > 0:
             return self.sections[0].n_entries
 
-    def add_section(self, section):
+    def add_section(self, section: Section) -> None:
         """
         Add a Section to the timeline.
 
@@ -286,7 +300,7 @@ class TimeLine:
 
         self.update_piecewise_poly()
 
-    def update_piecewise_poly(self):
+    def update_piecewise_poly(self) -> None:
         """Update the piecewise polynomial representation of the timeline."""
         x = []
         coeffs = []
@@ -305,13 +319,13 @@ class TimeLine:
         self._piecewise_poly = piecewise_poly
 
     @property
-    def piecewise_poly(self):
+    def piecewise_poly(self) -> list:
         """list: scipy.interpolate.PPoly for each dimension."""
         return self._piecewise_poly
 
-    def value(self, time):
+    def value(self, time: float) -> np.ndarray:
         """
-        np.array: Value of parameter at given time.
+        np.ndarray: Value of parameter at given time.
 
         Parameters
         ----------
@@ -320,7 +334,7 @@ class TimeLine:
         """
         return np.array([p(time) for p in self.piecewise_poly]).T
 
-    def coefficients(self, time):
+    def coefficients(self, time: float) -> np.ndarray:
         """
         Return coefficient of polynomial at given time.
 
@@ -331,7 +345,7 @@ class TimeLine:
 
         Returns
         -------
-        coefficients : np.array
+        coefficients : np.ndarray
             !!! Array of coefficients in ORDER !!!
         """
         section_index = self.section_index(time)
@@ -339,7 +353,7 @@ class TimeLine:
 
         return c
 
-    def integral(self, start=None, end=None):
+    def integral(self, start: Optional[float] = None, end: Optional[float] = None) -> np.ndarray:
         """
         Calculate integral of sections in interval [start, end].
 
@@ -352,7 +366,7 @@ class TimeLine:
 
         Returns
         -------
-        Y : float
+        Y : np.ndarray
             Value of definite integral between start and end.
 
         Raises
@@ -370,7 +384,7 @@ class TimeLine:
 
         return np.array([p.integrate(start, end) for p in self.piecewise_poly]).T
 
-    def section_index(self, time):
+    def section_index(self, time: float) -> int:
         """
         Return the index of the section that contains the specified time.
 
@@ -389,7 +403,7 @@ class TimeLine:
         return np.argmin(time >= section_times) - 1
 
     @property
-    def section_times(self):
+    def section_times(self) -> list[float]:
         """List of float: The start and end times of all sections in the timeline."""
         if len(self.sections) == 0:
             return []
@@ -397,17 +411,17 @@ class TimeLine:
         return [self.sections[0].start] + [sec.end for sec in self.sections]
 
     @property
-    def start(self):
+    def start(self) -> float:
         """float: The start time of the timeline."""
         return self.section_times[0]
 
     @property
-    def end(self):
+    def end(self) -> float:
         """float: The end time of the timeline."""
         return self.section_times[-1]
 
     @plotting.create_and_save_figure
-    def plot(self, ax, x_axis_in_minutes: bool = True) -> Axes:
+    def plot(self, ax: Axes, x_axis_in_minutes: bool = True) -> Axes:
         """
         Plot the state of the timeline over time.
 
@@ -448,7 +462,7 @@ class TimeLine:
         return ax
 
     @classmethod
-    def from_constant(cls, start, end, value):
+    def from_constant(cls, start: float, end: float, value: float) -> TimeLine:
         """
         Create a timeline with a constant value for a given time range.
 
@@ -472,7 +486,12 @@ class TimeLine:
         return tl
 
     @classmethod
-    def from_profile(cls, time, profile, s=1e-6):
+    def from_profile(
+        cls,
+        time: npt.ArrayLike,
+        profile: npt.ArrayLike,
+        s: float = 1e-6
+    ) -> TimeLine:
         """
         Create a timeline from a profile.
 
@@ -514,7 +533,7 @@ class MultiTimeLine:
 
     Attributes
     ----------
-    base_state : np.array
+    base_state : np.ndarray
         The base state that each TimeLine represents.
     n_entries : int
         The number of entries in each TimeLine.
@@ -524,7 +543,7 @@ class MultiTimeLine:
         The degree of the polynomials in each section.
     """
 
-    def __init__(self, base_state, is_polynomial=False):
+    def __init__(self, base_state: list, is_polynomial: bool = False) -> None:
         """
         Initialize a MultiTimeLine instance.
 
@@ -532,6 +551,9 @@ class MultiTimeLine:
         ----------
         base_state : list
             The base state that each TimeLine represents.
+        is_polynomial : bool, optional
+            Option wheter MultiTimeLine is polynomial. The default is False
+
         """
         base_state = np.array(base_state, ndmin=1, dtype=np.float64)
         self.is_polynomial = is_polynomial
@@ -550,28 +572,28 @@ class MultiTimeLine:
         self.time_lines = [TimeLine() for _ in range(self.size)]
 
     @property
-    def degree(self):
+    def degree(self) -> int:
         """int: The degree of the polynomials in each section."""
         return self._degree
 
     @degree.setter
-    def degree(self, degree):
+    def degree(self, degree: int) -> None:
         self._degree = degree
 
     @property
-    def n_entries(self):
+    def n_entries(self) -> int:
         """int: Number of entries handled by MultiTimeline."""
         if self.degree > 0:
             return len(self.base_state)
         return self.base_state.size
 
     @property
-    def size(self):
+    def size(self) -> int:
         """int: Total number of internal TimeLines handled Number by MultiTimeline."""
         return self.base_state.size
 
     @property
-    def section_times(self):
+    def section_times(self) -> list:
         """list: Combined section times of all TimeLines."""
         time_line_sections = [tl.section_times for tl in self.time_lines]
 
@@ -579,7 +601,7 @@ class MultiTimeLine:
 
         return sorted(list(section_times))
 
-    def add_section(self, section, entry_index):
+    def add_section(self, section: Section, entry_index: tuple) -> None:
         """
         Add section to TimeLine with specific entry index.
 
@@ -601,7 +623,7 @@ class MultiTimeLine:
         self.time_lines[index].add_section(section)
 
     @property
-    def combined_time_line(self):
+    def combined_time_line(self) -> TimeLine:
         """TimeLine: Object representing combination of all timelines in the MultiTimeLine."""
         tl = TimeLine()
 
@@ -646,7 +668,10 @@ class MultiTimeLine:
         return tl
 
 
-def generate_indices(shape, indices=None):
+def generate_indices(
+    shape: tuple[int, ...],
+    indices: Optional[list[list[int]]] = None
+) -> list[tuple]:
     """
     Generate tuples representing indices for an array with a given shape.
 
@@ -704,7 +729,7 @@ def generate_indices(shape, indices=None):
     return indices
 
 
-def _validate_indices(shape, indices):
+def _validate_indices(shape: tuple[int, ...], indices: list[list[int]]) -> None:
     """Validate that all indices can be set in an array with shape `shape`."""
     param_ref = np.arange(np.prod(shape)).reshape(shape)
 
@@ -712,7 +737,7 @@ def _validate_indices(shape, indices):
         param_ref[ind]
 
 
-def unravel(shape, indices):
+def unravel(shape: tuple[int, ...], indices: list[int] | tuple) -> list[tuple]:
     """
     Unravel indices of a multi-dimensional array.
 
@@ -746,7 +771,7 @@ def unravel(shape, indices):
     return indices_unraveled
 
 
-def flatten_index(shape, indices):
+def flatten_index(shape: tuple[int], indices: tuple | list[tuple]) -> list[int]:
     """
     Flatten indices to access array.
 
@@ -770,7 +795,7 @@ def flatten_index(shape, indices):
     return [indices_flat_ref[i] for i in indices]
 
 
-def unflatten_index(shape, indices_flat):
+def unflatten_index(shape: tuple[int, ...], indices_flat: int | list[int]) -> list[int]:
     """
     Unflatten indices to access array.
 
@@ -795,7 +820,7 @@ def unflatten_index(shape, indices_flat):
     return indices
 
 
-def get_inhomogeneous_shape(value):
+def get_inhomogeneous_shape(value: np.ndarray) -> list[tuple[int, ...]]:
     """If array is inhomogeneous, return list with shape of every element."""
     with warnings.catch_warnings():  # Catch warnings for compatibility with numpy<1.24
         warnings.simplefilter("error")
@@ -813,7 +838,7 @@ def get_inhomogeneous_shape(value):
     return shape
 
 
-def get_full_shape(inhomogeneous_shape):
+def get_full_shape(inhomogeneous_shape: list) -> tuple[int]:
     """Create full shape from inhomogeneous shape to be used with numpy arrays."""
     first_dimension = len(inhomogeneous_shape)
 
@@ -837,7 +862,9 @@ def get_full_shape(inhomogeneous_shape):
     return dims
 
 
-def extract_inhomogeneous_array(full_array, inhomogeneous_shape):
+def extract_inhomogeneous_array(
+        full_array: np.ndarray, inhomogeneous_shape: tuple[int, ...]
+    ) -> None:
     """Get inhomogeneous array from full_array."""
     array = []
     for i in inhomogeneous_shape:

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -13,7 +13,8 @@ __all__ = ["Section", "TimeLine", "MultiTimeLine"]
 
 
 class Section(Structure):
-    """Helper class to store parameter states between events.
+    """
+    Helper class to store parameter states between events.
 
     Attributes
     ----------
@@ -33,7 +34,6 @@ class Section(Structure):
         if coeffs is int: Set constant value for for all entries
         if coeffs is list: Set value per component (check length!)
         if coeffs is ndarray (or list of lists): set polynomial coefficients
-
     """
 
     coeffs = NdPolynomial(size=("n_entries", "n_poly_coeffs"))
@@ -99,7 +99,8 @@ class Section(Structure):
         return False
 
     def value(self, t):
-        """Return value of parameter section at time t.
+        """
+        Return value of parameter section at time t.
 
         Parameters
         ----------
@@ -115,7 +116,6 @@ class Section(Structure):
         ------
         ValueError
             If t is lower than start or larger than end of section time.
-
         """
         if np.any(t < self.start) or np.any(self.end < t):
             raise ValueError("Time exceeds section times")
@@ -127,7 +127,8 @@ class Section(Structure):
     __call__ = value
 
     def coefficients(self, offset=0):
-        """Get coefficients at (time) offset.
+        """
+        Get coefficients at (time) offset.
 
         Parameters
         ----------
@@ -150,7 +151,8 @@ class Section(Structure):
         return np.array(coeffs).reshape(self.parameter_shape)
 
     def derivative(self, t, order=1):
-        """Return derivative of parameter section at time t.
+        """
+        Return derivative of parameter section at time t.
 
         Parameters
         ----------
@@ -168,7 +170,6 @@ class Section(Structure):
             If t is lower than start or larger than end of section time.
         ValueError
             If order is larger than polynomial degree
-
         """
         if np.any(t < self.start) or np.any(self.end < t):
             raise ValueError("Time exceeds section times")
@@ -178,7 +179,8 @@ class Section(Structure):
         return deriv
 
     def integral(self, start=None, end=None):
-        """Return integral of function in interval [start, end].
+        """
+        Return integral of function in interval [start, end].
 
         Parameters
         ----------
@@ -196,7 +198,6 @@ class Section(Structure):
         ------
         ValueError
             If integration bounds exceed section times.
-
         """
         if start is None:
             start = self.start
@@ -209,7 +210,8 @@ class Section(Structure):
         integ_methods = [p.integ(lbnd=start) for p in self._poly]
         return np.array([i(end) for i in integ_methods])
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: String representation of the Section."""
         args = f"start={self.start}, end={self.end}, coeffs={self.coeffs}"
         if self.degree > 0:
             args += f", degree={self.degree}"
@@ -218,7 +220,8 @@ class Section(Structure):
 
 
 class TimeLine:
-    """Class representing a timeline of time-varying data.
+    """
+    Class representing a timeline of time-varying data.
 
     The timeline is made up of Sections, which are continuous time intervals.
     Each Section represents a piecewise polynomial function that defines the
@@ -251,7 +254,8 @@ class TimeLine:
             return self.sections[0].n_entries
 
     def add_section(self, section):
-        """Add a Section to the timeline.
+        """
+        Add a Section to the timeline.
 
         Parameters
         ----------
@@ -267,7 +271,6 @@ class TimeLine:
             the other Sections in the timeline.
         CADETProcessError
             If the Section introduces a gap in the timeline.
-
         """
         if not isinstance(section, Section):
             raise TypeError("Expected Section")
@@ -284,7 +287,7 @@ class TimeLine:
         self.update_piecewise_poly()
 
     def update_piecewise_poly(self):
-        """Updates the piecewise polynomial representation of the timeline."""
+        """Update the piecewise polynomial representation of the timeline."""
         x = []
         coeffs = []
         for sec in self.sections:
@@ -307,18 +310,19 @@ class TimeLine:
         return self._piecewise_poly
 
     def value(self, time):
-        """np.array: Value of parameter at given time
+        """
+        np.array: Value of parameter at given time.
 
         Parameters
         ----------
         time : np.float or array_like
             time points at which to evaluate.
-
         """
         return np.array([p(time) for p in self.piecewise_poly]).T
 
     def coefficients(self, time):
-        """Return coefficient of polynomial at given time.
+        """
+        Return coefficient of polynomial at given time.
 
         Parameters
         ----------
@@ -329,7 +333,6 @@ class TimeLine:
         -------
         coefficients : np.array
             !!! Array of coefficients in ORDER !!!
-
         """
         section_index = self.section_index(time)
         c = self.sections[section_index].coefficients(time)
@@ -337,7 +340,8 @@ class TimeLine:
         return c
 
     def integral(self, start=None, end=None):
-        """Calculate integral of sections in interval [start, end].
+        """
+        Calculate integral of sections in interval [start, end].
 
         Parameters
         ----------
@@ -355,7 +359,6 @@ class TimeLine:
         ------
         ValueError
             If integration bounds exceed section times.
-
         """
         if start is None:
             start = self.start
@@ -368,7 +371,8 @@ class TimeLine:
         return np.array([p.integrate(start, end) for p in self.piecewise_poly]).T
 
     def section_index(self, time):
-        """Return the index of the section that contains the specified time.
+        """
+        Return the index of the section that contains the specified time.
 
         Parameters
         ----------
@@ -386,7 +390,7 @@ class TimeLine:
 
     @property
     def section_times(self):
-        """list of float: The start and end times of all sections in the timeline."""
+        """List of float: The start and end times of all sections in the timeline."""
         if len(self.sections) == 0:
             return []
 
@@ -404,7 +408,8 @@ class TimeLine:
 
     @plotting.create_and_save_figure
     def plot(self, ax, x_axis_in_minutes: bool = True) -> Axes:
-        """Plot the state of the timeline over time.
+        """
+        Plot the state of the timeline over time.
 
         Parameters
         ----------
@@ -444,7 +449,8 @@ class TimeLine:
 
     @classmethod
     def from_constant(cls, start, end, value):
-        """Create a timeline with a constant value for a given time range.
+        """
+        Create a timeline with a constant value for a given time range.
 
         Parameters
         ----------
@@ -467,7 +473,8 @@ class TimeLine:
 
     @classmethod
     def from_profile(cls, time, profile, s=1e-6):
-        """Create a timeline from a profile.
+        """
+        Create a timeline from a profile.
 
         Parameters
         ----------
@@ -482,7 +489,6 @@ class TimeLine:
         -------
         TimeLine
             A TimeLine instance with polynomial sections created from the profile.
-
         """
         from scipy import interpolate
 
@@ -503,7 +509,8 @@ class TimeLine:
 
 
 class MultiTimeLine:
-    """Class for a collection of TimeLines with the same number of entries.
+    """
+    Class for a collection of TimeLines with the same number of entries.
 
     Attributes
     ----------
@@ -518,13 +525,13 @@ class MultiTimeLine:
     """
 
     def __init__(self, base_state, is_polynomial=False):
-        """Initialize a MultiTimeLine instance.
+        """
+        Initialize a MultiTimeLine instance.
 
         Parameters
         ----------
         base_state : list
             The base state that each TimeLine represents.
-
         """
         base_state = np.array(base_state, ndmin=1, dtype=np.float64)
         self.is_polynomial = is_polynomial
@@ -573,7 +580,8 @@ class MultiTimeLine:
         return sorted(list(section_times))
 
     def add_section(self, section, entry_index):
-        """Add section to TimeLine with specific entry index.
+        """
+        Add section to TimeLine with specific entry index.
 
         Parameters
         ----------
@@ -586,7 +594,6 @@ class MultiTimeLine:
         ------
         ValueError
             If entry index is out of bounds for base_state.
-
         """
         index = flatten_index(self.base_state.shape, entry_index)[0]
         if index > self.size:
@@ -740,7 +747,8 @@ def unravel(shape, indices):
 
 
 def flatten_index(shape, indices):
-    """Flatten indices to access array.
+    """
+    Flatten indices to access array.
 
     Parameters
     ----------
@@ -763,7 +771,8 @@ def flatten_index(shape, indices):
 
 
 def unflatten_index(shape, indices_flat):
-    """Unflatten indices to access array.
+    """
+    Unflatten indices to access array.
 
     Parameters
     ----------

--- a/CADETProcess/equilibria/buffer_capacity.py
+++ b/CADETProcess/equilibria/buffer_capacity.py
@@ -4,9 +4,10 @@ from typing import Optional
 
 import numpy as np
 import numpy.typing as npt
+from matplotlib.axes import Axes
 
 from CADETProcess import CADETProcessError, plotting
-from CADETProcess.processModel import ComponentSystem, ReactionBaseClass
+from CADETProcess.processModel import ComponentSystem, MassActionLaw, ReactionBaseClass
 
 
 def preprocessing(
@@ -92,7 +93,7 @@ def preprocessing(
     return pKa, c_acids_M, pH, indices, scalar_input
 
 
-def c_species_nu(pKa, pH):
+def c_species_nu(pKa: list[float], pH: float | list[float]) -> np.ndarray:
     """
     Compute normalized acid species concentration at given pH.
 
@@ -105,7 +106,7 @@ def c_species_nu(pKa, pH):
 
     Returns
     -------
-    c_species_nu : np.array
+    c_species_nu : np.ndarray
         Normalized acid species concentration.
     """
     pKa = np.array([1.0] + pKa)
@@ -122,7 +123,7 @@ def c_species_nu(pKa, pH):
     return c_species_nu
 
 
-def c_total_nu(pKa, pH):
+def c_total_nu(pKa: list[float], pH: float | list[float]) -> np.ndarray:
     """
     Compute normalized total acid concentration at given pH.
 
@@ -135,13 +136,13 @@ def c_total_nu(pKa, pH):
 
     Returns
     -------
-    c_total_nu : np.array
+    c_total_nu : np.ndarray
         Normalized acid species concentration.
     """
     return sum(c_species_nu(pKa, pH))
 
 
-def z_total_nu(pKa, pH):
+def z_total_nu(pKa: list[float], pH: float | list[float]) -> np.ndarray:
     """
     Compute normalized total charge at given pH.
 
@@ -154,7 +155,7 @@ def z_total_nu(pKa, pH):
 
     Returns
     -------
-    z_total_nu : np.array
+    z_total_nu : np.ndarray
         Normalized acid species concentration.
     """
     c = c_species_nu(pKa, pH)
@@ -162,7 +163,7 @@ def z_total_nu(pKa, pH):
     return np.dot(np.arange(len(c)), c)
 
 
-def eta(pKa, pH):
+def eta(pKa: list[float], pH: float | list[float]) -> np.ndarray:
     """
     Compute degree of dissociation at given pH.
 
@@ -175,13 +176,17 @@ def eta(pKa, pH):
 
     Returns
     -------
-    eta : np.array
+    eta : np.ndarray
         Degree of dissociation.
     """
     return z_total_nu(pKa, pH) / c_total_nu(pKa, pH)
 
 
-def charge_distribution(reaction_system, pH, components=None):
+def charge_distribution(
+    reaction_system: ReactionBaseClass,
+    pH: float | np.ndarray,
+    components: Optional[list] = None
+) -> np.ndarray:
     """
     Calculate charge distribution at given pH.
 
@@ -197,7 +202,7 @@ def charge_distribution(reaction_system, pH, components=None):
 
     Returns
     -------
-    charge_distribution : np.array
+    charge_distribution : np.ndarray
         Degree of protolysis; ratio of the concentration of the species to the
         total concentration.
     """
@@ -229,7 +234,11 @@ def charge_distribution(reaction_system, pH, components=None):
     return z
 
 
-def cummulative_charge_distribution(reaction_system, pH, components=None):
+def cummulative_charge_distribution(
+    reaction_system: ReactionBaseClass,
+    pH: float | np.ndarray,
+    components: Optional[list] = None
+) -> np.ndarray:
     """
     Calculate cummulative charge at given pH.
 
@@ -247,7 +256,7 @@ def cummulative_charge_distribution(reaction_system, pH, components=None):
 
     Returns
     -------
-    cummulative_charge_distribution : np.array
+    cummulative_charge_distribution : np.ndarray
         Degree of dissociation;
     """
     buffer = reaction_system.n_comp * [1]
@@ -268,7 +277,7 @@ def cummulative_charge_distribution(reaction_system, pH, components=None):
     return z_cum
 
 
-def alpha(pKa, pH):
+def alpha(pKa: list, pH: float | list[float]) -> np.ndarray:
     """
     Compute degree of protolysis at given pH.
 
@@ -281,13 +290,13 @@ def alpha(pKa, pH):
 
     Returns
     -------
-    alpha : np.array
+    alpha : np.ndarray
         Degree of protolysis.
     """
     return c_species_nu(pKa, pH) / c_total_nu(pKa, pH)
 
 
-def beta(c_acid, pKa, pH):
+def beta(c_acid: type, pKa: list, pH: float | list[float]) -> np.ndarray:
     """
     Compute buffer capacity of acid at given pH.
 
@@ -302,7 +311,7 @@ def beta(c_acid, pKa, pH):
 
     Returns
     -------
-    beta : np.array
+    beta : np.ndarray
         Buffer capacity.
     """
     a = alpha(pKa, pH)
@@ -320,7 +329,7 @@ def beta(c_acid, pKa, pH):
     return beta
 
 
-def beta_water(pH):
+def beta_water(pH: float | list[float]) -> np.ndarray:
     """
     Compute buffer capacity of water.
 
@@ -338,7 +347,12 @@ def beta_water(pH):
     return np.log(10) * (10 ** (-14) / c_H + c_H)
 
 
-def buffer_capacity(reaction_system, buffer, pH=None, components=None):
+def buffer_capacity(
+    reaction_system: ReactionBaseClass,
+    buffer: list,
+    pH: Optional[float | np.ndarray] = None,
+    components: list = None
+) -> np.ndarray:
     """
     Calculate buffer capacity at given buffer concentration and pH.
 
@@ -356,7 +370,7 @@ def buffer_capacity(reaction_system, buffer, pH=None, components=None):
 
     Returns
     -------
-    buffer_capacity : np.array
+    buffer_capacity : np.ndarray
         Buffer capacity in mM for individual acid components.
         To get overall buffer capacity, component capacities must be summed up.
     """
@@ -378,7 +392,7 @@ def buffer_capacity(reaction_system, buffer, pH=None, components=None):
     return buffer_capacity
 
 
-def ionic_strength(component_system, buffer):
+def ionic_strength(component_system: ComponentSystem, buffer: list) -> np.ndarray:
     """
     Compute ionic strength.
 
@@ -391,7 +405,7 @@ def ionic_strength(component_system, buffer):
 
     Returns
     -------
-    i: np.array
+    i : np.ndarray
         Ionic strength of buffer
     """
     if not isinstance(component_system, ComponentSystem):
@@ -405,7 +419,12 @@ def ionic_strength(component_system, buffer):
 
 
 @plotting.create_and_save_figure
-def plot_buffer_capacity(reaction_system, buffer, pH=None, ax=None):
+def plot_buffer_capacity(
+    reaction_system: MassActionLaw,
+    buffer: list,
+    pH: Optional[np.ndarray] = None,
+    ax: Optional[Axes] = None
+) -> Axes:
     """
     Plot buffer capacity of reaction system over pH at given concentration.
 
@@ -415,9 +434,9 @@ def plot_buffer_capacity(reaction_system, buffer, pH=None, ax=None):
         Reaction system with stoichiometric coefficients and reaction rates.
     buffer : list
         Buffer concentration in mM.
-    pH : np.array, optional
+    pH : Optional[np.ndarray]
         Range of pH to be plotted.
-    ax : Axes
+    ax : Optional[Axes]
         Axes to plot on.
 
     Returns
@@ -451,7 +470,12 @@ def plot_buffer_capacity(reaction_system, buffer, pH=None, ax=None):
 
 
 @plotting.create_and_save_figure
-def plot_charge_distribution(reaction_system, pH=None, plot_cumulative=False, ax=None):
+def plot_charge_distribution(
+    reaction_system: MassActionLaw,
+    pH: Optional[np.ndarray] = None,
+    plot_cumulative: Optional[bool] = False,
+    ax: Optional[Axes] = None,
+) -> Axes:
     """
     Plot charge distribution of components over pH.
 
@@ -459,11 +483,11 @@ def plot_charge_distribution(reaction_system, pH=None, plot_cumulative=False, ax
     ----------
     reaction_system : MassActionLaw
         Reaction system with stoichiometric coefficients and reaction rates.
-    pH : np.array, optional
+    pH : Optional[np.ndarray]
         Range of pH to be plotted.
-    plot_cumulative : Bool
+    plot_cumulative : Optional[bool]
         If True, only plot cumulative charge of each acid.
-    ax : Axes
+    ax : Optional[Axes]
         Axes to plot on.
 
     Returns

--- a/CADETProcess/equilibria/initial_conditions.py
+++ b/CADETProcess/equilibria/initial_conditions.py
@@ -1,16 +1,20 @@
 import numpy as np
 
 from CADETProcess import CADETProcessError
-
-from CADETProcess.processModel import Inlet, Outlet
-from CADETProcess.processModel import Cstr, LumpedRateModelWithoutPores
-from CADETProcess.processModel import FlowSheet
-from CADETProcess.processModel import Process
+from CADETProcess.processModel import (
+    Cstr,
+    FlowSheet,
+    Inlet,
+    LumpedRateModelWithoutPores,
+    Outlet,
+    Process,
+)
 from CADETProcess.simulator import Cadet
 
 
 def simulate_solid_equilibria(
-        binding_model, buffer, unit_model='cstr', flush=None, cadet_install_path=None):
+    binding_model, buffer, unit_model="cstr", flush=None, cadet_install_path=None
+):
     """Simulate initial conditions for solid phase for given buffer.
 
     Parameters
@@ -38,35 +42,35 @@ def simulate_solid_equilibria(
         Initial conditions for solid phase.
 
     """
-    process_name = flow_sheet_name = 'initial_conditions'
+    process_name = flow_sheet_name = "initial_conditions"
     component_system = binding_model.component_system
 
     # Unit Operations
-    buffer_source = Inlet(component_system, name='buffer')
+    buffer_source = Inlet(component_system, name="buffer")
     buffer_source.c = buffer
 
     if flush is None:
         flush = buffer
-    flush_source = Inlet(component_system, 'flush')
+    flush_source = Inlet(component_system, "flush")
     flush_source.c = flush
 
-    if unit_model == 'cstr':
-        unit = Cstr(component_system, 'cstr')
+    if unit_model == "cstr":
+        unit = Cstr(component_system, "cstr")
         unit.init_liquid_volume = 5e-7
         unit.const_solid_volume = 5e-7
 
         Q = 1e-6
-        cycle_time = np.round(1000*unit.volume/Q)
+        cycle_time = np.round(1000 * unit.volume / Q)
         unit.flow_rate = Q
-    elif unit_model == 'column':
-        unit = LumpedRateModelWithoutPores(component_system, name='column')
+    elif unit_model == "column":
+        unit = LumpedRateModelWithoutPores(component_system, name="column")
         unit.length = 0.1
         unit.diameter = 0.01
         unit.axial_dispersion = 1e-6
         unit.total_porosity = 0.7
 
-        Q = 60/(60*1e6)
-        cycle_time = np.round(10*unit.volume/Q)
+        Q = 60 / (60 * 1e6)
+        cycle_time = np.round(10 * unit.volume / Q)
     else:
         raise CADETProcessError("Unknown unit model")
 
@@ -89,7 +93,7 @@ def simulate_solid_equilibria(
     unit.solution_recorder.write_solution_bulk = True
     unit.solution_recorder.write_solution_solid = True
 
-    outlet = Outlet(component_system, name='outlet')
+    outlet = Outlet(component_system, name="outlet")
 
     # flow sheet
     fs = FlowSheet(component_system, name=flow_sheet_name)
@@ -108,23 +112,19 @@ def simulate_solid_equilibria(
     proc.cycle_time = cycle_time
 
     # Create Events and Durations
-    proc.add_event('buffer_on', 'flow_sheet.buffer.flow_rate', Q)
-    proc.add_event(
-        'buffer_off', 'flow_sheet.buffer.flow_rate', 0, 0.9*cycle_time
-    )
+    proc.add_event("buffer_on", "flow_sheet.buffer.flow_rate", Q)
+    proc.add_event("buffer_off", "flow_sheet.buffer.flow_rate", 0, 0.9 * cycle_time)
 
-    proc.add_event('eluent_off', 'flow_sheet.flush.flow_rate', 0.0, 0.0)
-    proc.add_event(
-        'eluent_on', 'flow_sheet.flush.flow_rate', Q, 0.9*cycle_time
-    )
+    proc.add_event("eluent_off", "flow_sheet.flush.flow_rate", 0.0, 0.0)
+    proc.add_event("eluent_on", "flow_sheet.flush.flow_rate", Q, 0.9 * cycle_time)
 
     # Simulator
     process_simulator = Cadet(cadet_install_path)
     proc_results = process_simulator.simulate(proc)
 
-    if unit_model == 'cstr':
+    if unit_model == "cstr":
         init_q = proc_results.solution[unit.name].solid.solution[-1, :]
-    elif unit_model == 'column':
+    elif unit_model == "column":
         init_q = proc_results.solution[unit.name].solid.solution[-1, 0, :]
 
     init_q = np.round(init_q, 14)

--- a/CADETProcess/equilibria/initial_conditions.py
+++ b/CADETProcess/equilibria/initial_conditions.py
@@ -15,7 +15,8 @@ from CADETProcess.simulator import Cadet
 def simulate_solid_equilibria(
     binding_model, buffer, unit_model="cstr", flush=None, cadet_install_path=None
 ):
-    """Simulate initial conditions for solid phase for given buffer.
+    """
+    Simulate initial conditions for solid phase for given buffer.
 
     Parameters
     ----------
@@ -40,7 +41,6 @@ def simulate_solid_equilibria(
     -------
     list
         Initial conditions for solid phase.
-
     """
     process_name = flow_sheet_name = "initial_conditions"
     component_system = binding_model.component_system

--- a/CADETProcess/equilibria/initial_conditions.py
+++ b/CADETProcess/equilibria/initial_conditions.py
@@ -1,7 +1,10 @@
+from typing import Optional
+
 import numpy as np
 
 from CADETProcess import CADETProcessError
 from CADETProcess.processModel import (
+    BindingBaseClass,
     Cstr,
     FlowSheet,
     Inlet,
@@ -13,8 +16,12 @@ from CADETProcess.simulator import Cadet
 
 
 def simulate_solid_equilibria(
-    binding_model, buffer, unit_model="cstr", flush=None, cadet_install_path=None
-):
+    binding_model: BindingBaseClass,
+    buffer: list,
+    unit_model: Optional[str] = 'cstr',
+    flush: Optional[list] = None,
+    cadet_install_path: Optional[str] = None,
+) -> list:
     """
     Simulate initial conditions for solid phase for given buffer.
 

--- a/CADETProcess/equilibria/ptc.py
+++ b/CADETProcess/equilibria/ptc.py
@@ -1,48 +1,52 @@
-"""Pseudo-transient continuation for solving nonlinear equation systems.
+"""
+Pseudo-transient continuation for solving nonlinear equation systems.
 
-The main method is ptc, a pseudo-transient continuation method with
-switched evolution relaxation.
+The main method is ptc, a pseudo-transient continuation method with switched evolution
+relaxation.
 
 This code was written by Samuel Leweke (University of Cologne) in 2020.
-
-"""
+""" # noqa
 
 __author__ = "Samuel Leweke"
 __contact__ = "leweke@math.uni-koeln.de"
 __copyright__ = "Copyright 2020, University of Cologne"
 
-
 import math
+from typing import Callable, Optional
 
 import numpy as np
 import scipy.linalg
 
 
-def scaled_norm2(x, scale):
+def scaled_norm2(x: np.ndarray, scale: np.ndarray) -> float:
+    """Calculate the scaled Euclidean (L2) norm."""
     return math.sqrt(np.sum(np.square(x / scale)) / len(x))
 
 
-def norm2(x):
+def norm2(x: np.ndarray) -> float:
+    """Calculate the karthesian norm."""
     return math.sqrt(np.sum(np.square(x)) / len(x))
 
 
-def jacrow_scale(jacMat, scale):
+def jacrow_scale(jacMat: np.ndarray, scale: np.ndarray) -> np.ndarray:
+    """Scale jacMat with scale."""
     return jacMat / scale[:, None]
 
 
 def ptc(
-    x,
-    f,
-    jacF,
-    tau,
-    tol,
-    scale=None,
-    maxIter=50,
-    maxNonMonotone=5,
-    quiet=True,
-    variant=False,
-):
-    r"""Solve a nonlinear equation system using pseudo-transient continuation.
+        x: np.ndarray,
+        f: Callable[[np.ndarray], np.ndarray],
+        jacF: Callable[[np.ndarray], np.ndarray],
+        tau: float,
+        tol: float,
+        scale: Optional[np.ndarray] = None,
+        maxIter: int = 50,
+        maxNonMonotone: int = 5,
+        quiet: bool = True,
+        variant: bool = False
+    ) -> tuple[int, np.ndarray, float, int]:
+    r"""
+    Solve a nonlinear equation system using pseudo-transient continuation.
 
     The nonlinear equation system f(x) = 0 is solved using pseudo-transient
     continuation (PTC), which introduce pseudo time and computes the steady
@@ -73,7 +77,7 @@ def ptc(
         Initial pseudo time step size.
     tol : TYPE
         Target tolerance for scaled root mean square residual.
-    scale : np.array, optional
+    scale : np.ndarray, optional
         (positive) diagonal scaling coefficients.
         The scaled root mean square norm is given by
         .. math::
@@ -99,13 +103,12 @@ def ptc(
         -1: Failed due to singular Jacobian
          0: Converged with passing residual test
          1: Exceeded maximum number of iterations.
-    x : np.array
+    x : np.ndarray
         Solution.
-    normfk : np.array
+    normfk : np.ndarray
         Scaled root mean square residual.
     k : int
         Number of iterations.
-
     """
     fxk = f(x)
     if scale is None:

--- a/CADETProcess/equilibria/ptc.py
+++ b/CADETProcess/equilibria/ptc.py
@@ -12,9 +12,10 @@ __contact__ = "leweke@math.uni-koeln.de"
 __copyright__ = "Copyright 2020, University of Cologne"
 
 
+import math
+
 import numpy as np
 import scipy.linalg
-import math
 
 
 def scaled_norm2(x, scale):
@@ -30,9 +31,17 @@ def jacrow_scale(jacMat, scale):
 
 
 def ptc(
-        x, f, jacF, tau, tol,
-        scale=None, maxIter=50, maxNonMonotone=5,
-        quiet=True, variant=False):
+    x,
+    f,
+    jacF,
+    tau,
+    tol,
+    scale=None,
+    maxIter=50,
+    maxNonMonotone=5,
+    quiet=True,
+    variant=False,
+):
     r"""Solve a nonlinear equation system using pseudo-transient continuation.
 
     The nonlinear equation system f(x) = 0 is solved using pseudo-transient
@@ -109,7 +118,7 @@ def ptc(
     nNonMonotoneResidual = 0
 
     if not quiet:
-        print('%4i  %12e  %12e  %7f' % (k, normdx, normfk, tau))
+        print("%4i  %12e  %12e  %7f" % (k, normdx, normfk, tau))
 
     while True:
         if normfk <= tol:
@@ -164,7 +173,7 @@ def ptc(
 
         if not quiet:
             normdx = norm2(dx)
-            print('%4i  %12e  %12e  %7f' % (k, normdx, normfk, tau))
+            print("%4i  %12e  %12e  %7f" % (k, normdx, normfk, tau))
 
         # Check terminal condition
         if k > maxIter:

--- a/CADETProcess/equilibria/reaction_equilibria.py
+++ b/CADETProcess/equilibria/reaction_equilibria.py
@@ -1,4 +1,8 @@
+from typing import Optional, Sequence
+
 import numpy as np
+
+from CADETProcess.processModel import MassActionLaw
 
 from . import ptc
 
@@ -6,7 +10,8 @@ from . import ptc
 def calculate_buffer_equilibrium(
     buffer, reaction_system, constant_indices=None, reinit=True, verbose=False
 ):
-    """Calculate buffer equilibrium for given concentration.
+    """
+    Calculate buffer equilibrium for given concentration.
 
     Parameters
     ----------
@@ -56,7 +61,31 @@ def calculate_buffer_equilibrium(
     return np.round(np.abs(sol), 14).tolist()
 
 
-def dydx_mal(c, reaction_system, constant_indices=None, c_init=None):
+def dydx_mal(
+        c: np.ndarray,
+        reaction_system: MassActionLaw,
+        constant_indices: Optional[Sequence[int]] = None,
+        c_init: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+    """
+    Compute the time derivative of concentrations in a mass action law system.
+
+    Parameters
+    ----------
+    c : np.ndarray
+        Concentration vector of components.
+    reaction_system : MassActionLaw
+        Reaction rates and stoichiometric matrix for calculating equilibrium.
+    constant_indices : Optional[Sequence[int]]
+        Indices of components whose concentrations are to be held constant.
+    c_init : Optional[np.ndarray]
+        Initial concentration vector (used to fix constants if constant_indices is provided).
+
+    Returns
+    -------
+    dydx : np.ndarray
+        Time derivative of concentration vector.
+    """
     cc = np.asarray(c, dtype="float64")
     if constant_indices is not None:
         if c_init is None:
@@ -91,7 +120,33 @@ def dydx_mal(c, reaction_system, constant_indices=None, c_init=None):
     return dydx
 
 
-def jac_mal(c, reaction_system, constant_indices=None, c_init=None):
+def jac_mal(
+        c: np.ndarray,
+        reaction_system: MassActionLaw,
+        constant_indices: Optional[Sequence[int]] = None,
+        c_init: Optional[np.ndarray] = None
+    ) -> np.ndarray:
+    """
+    Compute the Jacobian of a mass action law reaction system at given concentrations.
+
+    Parameters
+    ----------
+    c : np.ndarray
+        Current concentrations of components.
+    reaction_system : MassActionLaw
+        Reaction system object containing stoichiometry, exponents, and rate constants.
+    constant_indices : Optional[Sequence[int]]
+        Indices of components to be treated as constant
+        (i.e., their derivatives are zeroed out).
+    c_init : Optional[np.ndarray]
+        Initial concentration vector to reset constants if `constant_indices` is provided.
+
+    Returns
+    -------
+    jac : np.ndarray
+        Jacobian matrix (n_comp x n_comp) of the rate equations.
+
+    """
     cc = np.asarray(c, dtype="float64")
 
     if constant_indices is not None:

--- a/CADETProcess/equilibria/reaction_equilibria.py
+++ b/CADETProcess/equilibria/reaction_equilibria.py
@@ -8,31 +8,34 @@ from . import ptc
 
 
 def calculate_buffer_equilibrium(
-    buffer, reaction_system, constant_indices=None, reinit=True, verbose=False
-):
+    buffer: Sequence[float],
+    reaction_system: MassActionLaw,
+    constant_indices: Optional[Sequence[int]] = None,
+    reinit: bool = True,
+    verbose: bool = False
+) -> list[float]:
     """
     Calculate buffer equilibrium for given concentration.
 
     Parameters
     ----------
     buffer : list of floats
-        buffer concentration in mM
+        Buffer concentration in mM
     reaction_system : MassActionLaw
-        reaction rates and stoichiometric matrix for calculating equilibrium.
+        Reaction rates and stoichiometric matrix for calculating equilibrium.
     constant_indices : list, optional
         Indices of fixed target concentration (e.g. proton concentration/pH).
     reinit: Bool, optional
-        if True, run CADET with initial values to get 'smooth' initial values
+        If True, run CADET with initial values to get 'smooth' initial values
     verbose : Bool, optional
-        if True, print information at every ptc iteration.
+        If True, print information at every ptc iteration.
 
     Returns
     -------
     sol : list of floats.
-        buffer equilbrium concentrations
+        Buffer equilbrium concentrations
     """
-
-    def residual(c):
+    def residual(c: np.ndarray) -> np.ndarray:
         return dydx_mal(
             c,
             reaction_system,
@@ -40,7 +43,7 @@ def calculate_buffer_equilibrium(
             buffer.copy(),
         )
 
-    def jacobian(c):
+    def jacobian(c: np.ndarray) -> np.ndarray:
         return jac_mal(
             c,
             reaction_system,
@@ -52,7 +55,7 @@ def calculate_buffer_equilibrium(
         np.array(buffer.copy()),
         residual,
         jacobian,
-        1e-4,  # init step size
+        1e-4,   # init step size
         1e-14,  # tolerance (scaled l2)
         quiet=not (verbose),
         maxIter=10000,

--- a/CADETProcess/equilibria/reaction_equilibria.py
+++ b/CADETProcess/equilibria/reaction_equilibria.py
@@ -4,11 +4,8 @@ from . import ptc
 
 
 def calculate_buffer_equilibrium(
-        buffer,
-        reaction_system,
-        constant_indices=None,
-        reinit=True,
-        verbose=False):
+    buffer, reaction_system, constant_indices=None, reinit=True, verbose=False
+):
     """Calculate buffer equilibrium for given concentration.
 
     Parameters
@@ -29,6 +26,7 @@ def calculate_buffer_equilibrium(
     sol : list of floats.
         buffer equilbrium concentrations
     """
+
     def residual(c):
         return dydx_mal(
             c,
@@ -49,9 +47,9 @@ def calculate_buffer_equilibrium(
         np.array(buffer.copy()),
         residual,
         jacobian,
-        1e-4,   # init step size
+        1e-4,  # init step size
         1e-14,  # tolerance (scaled l2)
-        quiet=not(verbose),
+        quiet=not (verbose),
         maxIter=10000,
     )
 
@@ -59,7 +57,7 @@ def calculate_buffer_equilibrium(
 
 
 def dydx_mal(c, reaction_system, constant_indices=None, c_init=None):
-    cc = np.asarray(c, dtype='float64')
+    cc = np.asarray(c, dtype="float64")
     if constant_indices is not None:
         if c_init is None:
             c_init = c
@@ -75,11 +73,11 @@ def dydx_mal(c, reaction_system, constant_indices=None, c_init=None):
 
     for r_i in range(reaction_system.n_reactions):
         fwd_indices = np.where(exp_fwd[:, r_i] > 0.0)
-        prod = np.prod(cc[fwd_indices]**exp_fwd[:, r_i][fwd_indices])
+        prod = np.prod(cc[fwd_indices] ** exp_fwd[:, r_i][fwd_indices])
         r_fwd = k_fwd[r_i] * prod
 
         bwd_indices = np.where(exp_bwd[:, r_i] > 0.0)
-        prod = np.prod(cc[bwd_indices]**exp_bwd[:, r_i][bwd_indices])
+        prod = np.prod(cc[bwd_indices] ** exp_bwd[:, r_i][bwd_indices])
         r_bwd = k_bwd[r_i] * prod
 
         r[r_i] = r_fwd - r_bwd
@@ -94,7 +92,7 @@ def dydx_mal(c, reaction_system, constant_indices=None, c_init=None):
 
 
 def jac_mal(c, reaction_system, constant_indices=None, c_init=None):
-    cc = np.asarray(c, dtype='float64')
+    cc = np.asarray(c, dtype="float64")
 
     if constant_indices is not None:
         if c_init is None:

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -14,7 +14,8 @@ class FractionationEvaluator:
     """Dummy Evaluator to enable caching."""
 
     def evaluate(self, fractionator):
-        """Evaluate the fractionator.
+        """
+        Evaluate the fractionator.
 
         Parameters
         ----------
@@ -30,7 +31,8 @@ class FractionationEvaluator:
 
     __call__ = evaluate
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: Name of the FractionationEvaluator."""
         return __class__.__name__
 
 
@@ -38,7 +40,8 @@ class FractionationOptimizer:
     """Configuration for fractionating Chromatograms."""
 
     def __init__(self, optimizer=None, log_level="WARNING"):
-        """Initialize the FractionationOptimizer.
+        """
+        Initialize the FractionationOptimizer.
 
         Parameters
         ----------
@@ -65,7 +68,8 @@ class FractionationOptimizer:
 
     @optimizer.setter
     def optimizer(self, optimizer):
-        """Set the optimizer.
+        """
+        Set the optimizer.
 
         Parameters
         ----------
@@ -89,7 +93,8 @@ class FractionationOptimizer:
         use_total_concentration_components=True,
         allow_empty_fractions=True,
     ):
-        """Set up the Fractionator for optimizing the fractionation times of Chromatograms.
+        """
+        Set up the Fractionator for optimizing the fractionation times of Chromatograms.
 
         Parameters
         ----------
@@ -108,7 +113,6 @@ class FractionationOptimizer:
         -------
         Fractionator
             The Fractionator object that has been set up using the provided arguments.
-
         """
         frac = Fractionator(
             simulation_results,
@@ -146,7 +150,8 @@ class FractionationOptimizer:
         bad_metrics=None,
         n_objectives=1,
     ):
-        """Set up the OptimizationProblem for optimizing the fractionation times.
+        """
+        Set up the OptimizationProblem for optimizing the fractionation times.
 
         Parameters
         ----------
@@ -273,7 +278,8 @@ class FractionationOptimizer:
         return_optimization_results=False,
         save_results=False,
     ):
-        """Optimize the fractionation times with respect to purity constraints.
+        """
+        Optimize the fractionation times with respect to purity constraints.
 
         Parameters
         ----------
@@ -336,7 +342,6 @@ class FractionationOptimizer:
         CADETProcess.solution.SolutionIO
         CADETProcess.optimization.OptimizationProblem
         CADETProcess.optimization.OptimizerBase
-
         """
         if not isinstance(simulation_results, SimulationResults):
             raise TypeError("Expected SimulationResults.")
@@ -401,5 +406,6 @@ class FractionationOptimizer:
     evaluate = optimize_fractionation
     __call__ = evaluate
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Name of the FractionationOptimizer."""
         return self.__class__.__name__

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -1,7 +1,7 @@
 import os
 from collections import defaultdict
 from functools import wraps
-from typing import Any, Optional
+from typing import Any, Callable, Optional
 
 import numpy as np
 from addict import Dict
@@ -139,11 +139,13 @@ class Fractionator(EventHandler):
         """ComponentSystem: The component system of the chromatograms."""
         return self.chromatograms[0].component_system
 
-    def _call_by_chrom_name(func):
         """Enable calling functions with chromatogram object or name."""
 
+    def _call_by_chrom_name(func: Callable) -> Callable:
         @wraps(func)
-        def wrapper_call_by_chrom_name(self, chrom, *args, **kwargs):
+        def wrapper_call_by_chrom_name(
+                self: 'Fractionator', chrom: str | SolutionIO, *args: Any, **kwargs: Any
+            ) -> Any:
             """Enable calling functions with chromatogram object or name."""
             if isinstance(chrom, str):
                 try:
@@ -156,7 +158,8 @@ class Fractionator(EventHandler):
 
     @property
     def chromatograms(self) -> list[SolutionIO]:
-        """list: Chromatograms to be fractionized.
+        """
+        list[SolutionIO]: Chromatograms to be fractionized.
 
         See Also
         --------
@@ -203,7 +206,8 @@ class Fractionator(EventHandler):
 
     @property
     def cycle_time(self) -> float:
-        """float: The cycle time of the Fractionator.
+        """
+        The cycle time of the Fractionator.
 
         Note that in some situations, it might be desired to set a custom cycle time
         for calculating the performance indicators. For this purpose, overwrite the
@@ -243,6 +247,10 @@ class Fractionator(EventHandler):
             Axes to plot on. If None, a new figure is created.
         x_axis_in_minutes: bool, optional
             Option to use x-aches (time) in minutes, default is set to True.
+        *args : Any
+            Optional Parameter passed down to plot function.
+        **kwargs : Any
+            Additional Parameter passed down to plot function.
 
         Returns
         -------
@@ -439,9 +447,11 @@ class Fractionator(EventHandler):
 
         Parameters
         ----------
+        chrom_index : int
+            index of the chromatogram
         start : float
             start time of the fraction
-        start : float
+        end : float
             end time of the fraction
 
         Returns
@@ -509,7 +519,8 @@ class Fractionator(EventHandler):
 
     @property
     def mass_balance_difference(self) -> np.ndarray:
-        """ndarray: Difference in mass balance between m_feed and fraction pools.
+        """
+        ndarray: Difference in mass balance between m_feed and fraction pools.
 
         The mass balance is calculated as the difference between the feed mass (m_feed)
         and the mass in the fraction pools. It represents the discrepancy or change in
@@ -537,7 +548,8 @@ class Fractionator(EventHandler):
 
     @property
     def eluent_consumption(self) -> np.ndarray:
-        """ndarray: Specific eluent consumption in corresponding fraction pool.
+        """
+        ndarray: Specific eluent consumption in corresponding fraction pool.
 
         Notes
         -----
@@ -733,7 +745,10 @@ class Fractionator(EventHandler):
         return self.parameters
 
     def save(
-        self, case_dir: str, start: float = 0, end: Optional[float] = None
+        self,
+        case_dir: str,
+        start: float = 0,
+        end: Optional[float] = None
     ) -> None:
         """
         Save chromatogram and purity plots to a specified directory.

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -19,7 +19,8 @@ __all__ = ["Fractionator"]
 
 
 class Fractionator(EventHandler):
-    """Class for Chromatogram Fractionation.
+    """
+    Class for Chromatogram Fractionation.
 
     This class is responsible for setting events for starting and ending fractionation,
     handling multiple chromatograms, and calculating various performance metrics.
@@ -31,7 +32,6 @@ class Fractionator(EventHandler):
     performance_keys : list
         Keys for performance metrics including mass, concentration, purity, recovery,
         productivity, and eluent consumption.
-
     """
 
     name = String(default="Fractionator")
@@ -52,7 +52,8 @@ class Fractionator(EventHandler):
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        """Initialize the Fractionator.
+        """
+        Initialize the Fractionator.
 
         Parameters
         ----------
@@ -66,7 +67,6 @@ class Fractionator(EventHandler):
             Variable length argument list.
         **kwargs
             Arbitrary keyword arguments.
-
         """
         self.components: Optional[list[str]] = components
         self.use_total_concentration_components: bool = use_total_concentration_components
@@ -81,7 +81,8 @@ class Fractionator(EventHandler):
 
     @simulation_results.setter
     def simulation_results(self, simulation_results: SimulationResults) -> None:
-        """Set the simulation results.
+        """
+        Set the simulation results.
 
         Parameters
         ----------
@@ -94,7 +95,6 @@ class Fractionator(EventHandler):
             If simulation_results is not of type SimulationResults.
         CADETProcessError
             If the simulation results do not contain any chromatograms.
-
         """
         if not isinstance(simulation_results, SimulationResults):
             raise TypeError("Expected SimulationResults")
@@ -140,7 +140,7 @@ class Fractionator(EventHandler):
         return self.chromatograms[0].component_system
 
     def _call_by_chrom_name(func):
-        """Decorator to enable calling functions with chromatogram object or name."""
+        """Enable calling functions with chromatogram object or name."""
 
         @wraps(func)
         def wrapper_call_by_chrom_name(self, chrom, *args, **kwargs):
@@ -173,7 +173,7 @@ class Fractionator(EventHandler):
 
     @property
     def chromatogram_names(self) -> list[str]:
-        """list: Chromatogram names"""
+        """list[str]: Names of chromatogram."""
         return [chrom.name for chrom in self.chromatograms]
 
     @property
@@ -183,6 +183,7 @@ class Fractionator(EventHandler):
 
     @property
     def chromatogram_events(self) -> dict[SolutionIO, list[Event]]:
+        """dict[SolutionIO, list[Event]]: Events sorted by chromatogram."""
         chrom_events = {
             chrom: sorted(events, key=lambda evt: evt.time)
             for chrom, events in self._chromatogram_events.items()
@@ -197,7 +198,7 @@ class Fractionator(EventHandler):
 
     @property
     def n_comp(self) -> int:
-        """int: Number of components to be fractionized"""
+        """int: Number of components to be fractionized."""
         return self.chromatograms[0].n_comp
 
     @property
@@ -231,7 +232,8 @@ class Fractionator(EventHandler):
         *args: Any,
         **kwargs: Any,
     ) -> Axes:
-        """Plot the signal without the waste fractions.
+        """
+        Plot the signal without the waste fractions.
 
         Parameters
         ----------
@@ -251,7 +253,6 @@ class Fractionator(EventHandler):
         --------
         CADETProcess.plot
         plot_purity
-
         """
         if chromatogram is None:
             chromatogram = list(
@@ -335,7 +336,8 @@ class Fractionator(EventHandler):
     def set_fractionation_state(
         self, chrom: SolutionIO, state: int | list[float]
     ) -> None:
-        """Set fractionation states of Chromatogram.
+        """
+        Set fractionation states of Chromatogram.
 
         Parameters
         ----------
@@ -351,7 +353,6 @@ class Fractionator(EventHandler):
             If state is integer and the state >= the n_comp.
             If the length of the states is unequal the state_length.
             If the sum of the states is not equal to 1.
-
         """
         if chrom not in self.chromatograms:
             raise CADETProcessError("Chromatogram not in Fractionator")
@@ -385,7 +386,8 @@ class Fractionator(EventHandler):
 
     @property
     def fraction_pools(self) -> list[FractionPool]:
-        """List of the component and waste fraction pools.
+        """
+        List of the component and waste fraction pools.
 
         For every event, the end time is determined and a Fraction object is
         created which holds information about start and end time, as well as
@@ -396,7 +398,6 @@ class Fractionator(EventHandler):
         -------
         fraction_pools : list
             List with fraction pools.
-
         """
         if self._fraction_pools is None:
             self._fraction_pools = [
@@ -433,7 +434,8 @@ class Fractionator(EventHandler):
         return self._fraction_pools
 
     def _create_fraction(self, chrom_index: int, start: float, end: float) -> Fraction:
-        """Helper function to create Fraction object calculate mass.
+        """
+        Create Fraction object calculate mass.
 
         Parameters
         ----------
@@ -446,19 +448,18 @@ class Fractionator(EventHandler):
         -------
         fraction : Fraction
             Chromatogram fraction
-
         """
         fraction = self.chromatograms[chrom_index].create_fraction(start, end)
 
         return fraction
 
     def add_fraction(self, fraction: Fraction, target: int) -> None:
-        """Add Fraction to the FractionPool of target component.
+        """
+        Add Fraction to the FractionPool of target component.
 
         Notes
         -----
         Waste is always the last fraction
-
         """
         if not isinstance(fraction, Fraction):
             raise TypeError("Expected Fraction")
@@ -574,7 +575,8 @@ class Fractionator(EventHandler):
         time: float,
         chromatogram: Optional[SolutionIO | str] = None,
     ) -> None:
-        """Add a fractionation event.
+        """
+        Add a fractionation event.
 
         Parameters
         ----------
@@ -592,7 +594,6 @@ class Fractionator(EventHandler):
         ------
         CADETProcessError
             If the chromatogram is not found.
-
         """
         if chromatogram is None and self.n_chromatograms > 1:
             raise CADETProcessError(
@@ -621,7 +622,8 @@ class Fractionator(EventHandler):
         self.reset()
 
     def initial_values(self, purity_required: float | list[float] = 0.95) -> None:
-        """Create events from chromatogram with minimum purity.
+        """
+        Create events from chromatogram with minimum purity.
 
         Function creates fractions for areas in the chromatogram, where the
         local purity profile is higher than the purity required.
@@ -635,7 +637,6 @@ class Fractionator(EventHandler):
         ------
         ValueError
             If the size of the purity parameter does not match the number of components
-
         """
         if isinstance(purity_required, float):
             purity_required = [purity_required] * self.n_comp
@@ -707,6 +708,7 @@ class Fractionator(EventHandler):
 
     @property
     def parameters(self) -> Dict:
+        """dict: Parameters of the fractionator."""
         parameters = super().parameters
         parameters["fractionation_states"] = {
             chrom.name: self.fractionation_states[chrom] for chrom in self.chromatograms
@@ -727,6 +729,7 @@ class Fractionator(EventHandler):
 
     @property
     def section_dependent_parameters(self) -> Dict:
+        """dict: Section dependent parameters of the fractionator."""
         return self.parameters
 
     def save(
@@ -762,4 +765,5 @@ class Fractionator(EventHandler):
             )
 
     def __str__(self) -> str:
+        """str: String representation of the fractionator."""
         return self.__class__.__name__

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -7,7 +7,8 @@ __all__ = ["Fraction", "FractionPool"]
 
 
 class Fraction(Structure):
-    """A class representing a fraction of a mixture.
+    """
+    A class representing a fraction of a mixture.
 
     A fraction is defined by its mass and volume, and can be used to calculate
     properties such as cumulative mass, purity, and concentration.
@@ -50,7 +51,8 @@ class Fraction(Structure):
 
     @property
     def fraction_mass(self):
-        """np.ndarray: Cumulative mass all species in the fraction.
+        """
+        np.ndarray: Cumulative mass all species in the fraction.
 
         See Also
         --------
@@ -62,7 +64,8 @@ class Fraction(Structure):
 
     @property
     def purity(self):
-        """np.ndarray: Purity of the fraction.
+        """
+        np.ndarray: Purity of the fraction.
 
         Invalid values are replaced by zero.
 
@@ -79,7 +82,8 @@ class Fraction(Structure):
 
     @property
     def concentration(self):
-        """np.ndarray: Component concentrations of the fraction.
+        """
+        np.ndarray: Component concentrations of the fraction.
 
         Invalid values are replaced by zero.
 
@@ -93,12 +97,14 @@ class Fraction(Structure):
 
         return np.nan_to_num(concentration)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: String representation of the fraction."""
         return f"{self.__class__.__name__}(mass={self.mass},volume={self.volume})"
 
 
 class FractionPool(Structure):
-    """Collection of pooled fractions.
+    """
+    Collection of pooled fractions.
 
     This class manages multiple fractions of a mixture, facilitating the
     calculation of cumulative properties of the pool, such as total volume,
@@ -137,7 +143,8 @@ class FractionPool(Structure):
     _parameters = ["n_comp"]
 
     def __init__(self, n_comp, *args, **kwargs):
-        """Initialize a FractionPool instance.
+        """
+        Initialize a FractionPool instance.
 
         Parameters
         ----------
@@ -150,7 +157,8 @@ class FractionPool(Structure):
         super().__init__(*args, **kwargs)
 
     def add_fraction(self, fraction):
-        """Add a fraction to the fraction pool.
+        """
+        Add a fraction to the fraction pool.
 
         Parameters
         ----------
@@ -201,7 +209,8 @@ class FractionPool(Structure):
 
     @property
     def purity(self):
-        """Total purity of components in the fraction pool.
+        """
+        Total purity of components in the fraction pool.
 
         Invalid values are replaced by zero.
 
@@ -223,7 +232,8 @@ class FractionPool(Structure):
 
     @property
     def concentration(self):
-        """Total concentration of components in the fraction pool.
+        """
+        Total concentration of components in the fraction pool.
 
         Invalid values are replaced by zero.
 
@@ -236,12 +246,12 @@ class FractionPool(Structure):
         --------
         mass
         volume
-
         """
         with np.errstate(divide="ignore", invalid="ignore"):
             concentration = self.mass / self.volume
 
         return np.nan_to_num(concentration)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: String representation of the fraction pool."""
         return f"{self.__class__.__name__}(n_comp={self.n_comp})"

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 import numpy as np
 
 from CADETProcess import CADETProcessError
@@ -45,12 +47,12 @@ class Fraction(Structure):
     _parameters = ["mass", "volume", "start", "end"]
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
         """int: Number of components in the fraction."""
         return self.mass.size
 
     @property
-    def fraction_mass(self):
+    def fraction_mass(self) -> np.ndarray:
         """
         np.ndarray: Cumulative mass all species in the fraction.
 
@@ -63,7 +65,7 @@ class Fraction(Structure):
         return sum(self.mass)
 
     @property
-    def purity(self):
+    def purity(self) -> np.ndarray:
         """
         np.ndarray: Purity of the fraction.
 
@@ -81,7 +83,7 @@ class Fraction(Structure):
         return np.nan_to_num(purity)
 
     @property
-    def concentration(self):
+    def concentration(self) -> np.ndarray:
         """
         np.ndarray: Component concentrations of the fraction.
 
@@ -142,7 +144,7 @@ class FractionPool(Structure):
 
     _parameters = ["n_comp"]
 
-    def __init__(self, n_comp, *args, **kwargs):
+    def __init__(self, n_comp: int, *args: Any, **kwargs: Any) -> None:
         """
         Initialize a FractionPool instance.
 
@@ -150,13 +152,17 @@ class FractionPool(Structure):
         ----------
         n_comp : int
             The number of components each fraction in the pool should have.
+        *args : Optional
+            Optional Parameters for Structure class.
+        **kwargs : Optional
+            Additional Parameters for Structure class.
         """
         self._fractions = []
         self.n_comp = n_comp
 
         super().__init__(*args, **kwargs)
 
-    def add_fraction(self, fraction):
+    def add_fraction(self, fraction: Fraction) -> None:
         """
         Add a fraction to the fraction pool.
 
@@ -181,34 +187,34 @@ class FractionPool(Structure):
         self._fractions.append(fraction)
 
     @property
-    def fractions(self):
+    def fractions(self) -> list[Fraction]:
         """list: List of fractions in the pool."""
         if len(self._fractions) == 0:
             return [Fraction(np.zeros((self.n_comp,)), 0)]
         return self._fractions
 
     @property
-    def n_fractions(self):
+    def n_fractions(self) -> int:
         """int: Number of fractions in the pool."""
         return len(self._fractions)
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """float: Sum of all fraction volumes in the fraction pool."""
         return sum(frac.volume for frac in self.fractions)
 
     @property
-    def mass(self):
+    def mass(self) -> np.ndarray:
         """np.ndarray: Cumulative component mass in the fraction pool."""
         return np.sum([frac.mass for frac in self.fractions], axis=0)
 
     @property
-    def pool_mass(self):
+    def pool_mass(self) -> float:
         """float: Sum of cumulative component mass in the fraction pool."""
         return sum(frac.fraction_mass for frac in self.fractions)
 
     @property
-    def purity(self):
+    def purity(self) -> np.ndarray:
         """
         Total purity of components in the fraction pool.
 
@@ -231,7 +237,7 @@ class FractionPool(Structure):
         return np.nan_to_num(purity)
 
     @property
-    def concentration(self):
+    def concentration(self) -> np.ndarray:
         """
         Total concentration of components in the fraction pool.
 

--- a/CADETProcess/fractionation/fractions.py
+++ b/CADETProcess/fractionation/fractions.py
@@ -1,11 +1,7 @@
 import numpy as np
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import (
-    UnsignedInteger, UnsignedFloat, Vector
-)
-
+from CADETProcess.dataStructure import Structure, UnsignedFloat, UnsignedInteger, Vector
 
 __all__ = ["Fraction", "FractionPool"]
 
@@ -45,7 +41,7 @@ class Fraction(Structure):
     start = UnsignedFloat()
     end = UnsignedFloat()
 
-    _parameters = ['mass', 'volume', 'start', 'end']
+    _parameters = ["mass", "volume", "start", "end"]
 
     @property
     def n_comp(self):
@@ -76,7 +72,7 @@ class Fraction(Structure):
         fraction_mass
         concentration
         """
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             purity = self.mass / self.fraction_mass
 
         return np.nan_to_num(purity)
@@ -92,15 +88,13 @@ class Fraction(Structure):
         mass
         volume
         """
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             concentration = self.mass / self.volume
 
         return np.nan_to_num(concentration)
 
     def __repr__(self):
-        return \
-            f"{self.__class__.__name__}" \
-            f"(mass={self.mass},volume={self.volume})"
+        return f"{self.__class__.__name__}(mass={self.mass},volume={self.volume})"
 
 
 class FractionPool(Structure):
@@ -140,7 +134,7 @@ class FractionPool(Structure):
 
     n_comp = UnsignedInteger()
 
-    _parameters = ['n_comp']
+    _parameters = ["n_comp"]
 
     def __init__(self, n_comp, *args, **kwargs):
         """Initialize a FractionPool instance.
@@ -171,10 +165,10 @@ class FractionPool(Structure):
             of components in the pool.
         """
         if not isinstance(fraction, Fraction):
-            raise CADETProcessError('Expected Fraction')
+            raise CADETProcessError("Expected Fraction")
 
         if fraction.n_comp != self.n_comp:
-            raise CADETProcessError('Number of components does not match.')
+            raise CADETProcessError("Number of components does not match.")
 
         self._fractions.append(fraction)
 
@@ -222,7 +216,7 @@ class FractionPool(Structure):
         pool_mass
         concentration
         """
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             purity = self.mass / self.pool_mass
 
         return np.nan_to_num(purity)
@@ -244,7 +238,7 @@ class FractionPool(Structure):
         volume
 
         """
-        with np.errstate(divide='ignore', invalid='ignore'):
+        with np.errstate(divide="ignore", invalid="ignore"):
             concentration = self.mass / self.volume
 
         return np.nan_to_num(concentration)

--- a/CADETProcess/log.py
+++ b/CADETProcess/log.py
@@ -19,6 +19,7 @@ import logging
 import time
 from functools import wraps
 from pathlib import Path
+from typing import Any, Callable, Optional
 
 import pathos
 
@@ -30,7 +31,7 @@ LOG_FORMAT = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
 loggers = {}
 
 
-def get_logger(name, level=None):
+def get_logger(name: str, level: Optional[str] = None) -> logging.Logger:
     """
     Retrieve logger from loggers dictionary. Create new one if it does not already exist.
 
@@ -59,7 +60,7 @@ def get_logger(name, level=None):
     return logger
 
 
-def update_loggers(log_directory, save_log):
+def update_loggers(log_directory: str, save_log: bool) -> None:
     """
     Update the file handlers of all logger objects in the loggers dictionary.
 
@@ -74,7 +75,12 @@ def update_loggers(log_directory, save_log):
         update_file_handlers(log_directory, logger, name, save_log)
 
 
-def update_file_handlers(log_directory, logger, name, save_log):
+def update_file_handlers(
+    log_directory: str,
+    logger: logging.Logger,
+    name: str,
+    save_log: Optional[bool]
+) -> None:
     """
     Update the file handlers of a logger object.
 
@@ -101,7 +107,13 @@ def update_file_handlers(log_directory, logger, name, save_log):
         add_file_handler(log_directory, logger, name, level)
 
 
-def add_file_handler(log_directory, logger, name, level, overwrite=False):
+def add_file_handler(
+    log_directory: str,
+    logger: logging.Logger,
+    name: str,
+    level: str,
+    overwrite: Optional[bool] = False
+) -> None:
     """
     Add a file handler to a logger object.
 
@@ -133,7 +145,7 @@ def add_file_handler(log_directory, logger, name, level, overwrite=False):
     logger.addHandler(file_handler)
 
 
-def log_time(logger_name, level=None):
+def log_time(logger_name: str, level: Optional[int] = None) -> Callable:
     """
     Log execution time of function.
 
@@ -144,9 +156,9 @@ def log_time(logger_name, level=None):
     level : int, optional
         Log level.
     """
-    def log_time_decorator(function):
+    def log_time_decorator(function: Callable) -> Any:
         @wraps(function)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             start = time.time()
             result = function(*args, **kwargs)
             elapsed = time.time() - start
@@ -159,7 +171,7 @@ def log_time(logger_name, level=None):
     return log_time_decorator
 
 
-def log_exceptions(logger_name, level=None):
+def log_exceptions(logger_name: str, level: Optional[int] = None) -> Callable:
     """
     Log exceptions.
 
@@ -171,9 +183,9 @@ def log_exceptions(logger_name, level=None):
         Log level.
     """
 
-    def log_exception_decorator(function):
+    def log_exception_decorator(function: Callable) -> Callable:
         @wraps(function)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             logger = get_logger(logger_name, level=None)
             try:
                 return function(*args, **kwargs)
@@ -191,27 +203,27 @@ def log_exceptions(logger_name, level=None):
     return log_exception_decorator
 
 
-def log_results(logger_name, level=None):
+def log_results(logger_name: str, level: Optional[int] = None) -> Callable:
     """
     Log results.
 
     Parameters
     ----------
     logger_name : str
-        name of the logger
+        Name of the logger
+    level : int
+        Log level.
     """
-
-    def log_results_decorator(function):
+    def log_results_decorator(function: Callable) -> Callable:
         @wraps(function)
-        def wrapper(*args, **kwargs):
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
             logger = get_logger(logger_name, level=None)
 
-            logger.debug("{} was called with {}, {}".format(function, *args, **kwargs))
+            logger.debug('{} was called with {}, {}'.format(
+                    function, *args, **kwargs))
             results = function(*args, **kwargs)
-            logger.debug(f"Results: {results}")
+            logger.debug(f'Results: {results}')
 
             return results
-
         return wrapper
-
     return log_results_decorator

--- a/CADETProcess/log.py
+++ b/CADETProcess/log.py
@@ -15,20 +15,17 @@ The CADETProcess.log module provides functionality for logging events in CADET-P
 
 """
 
-from functools import wraps
 import logging
-from pathlib import Path
 import time
+from functools import wraps
+from pathlib import Path
 
 import pathos
 
+__all__ = ["loggers", "get_logger"]
 
-__all__ = ['loggers', 'get_logger']
 
-
-LOG_FORMAT = logging.Formatter(
-    '%(asctime)s:%(levelname)s:%(name)s:%(message)s'
-)
+LOG_FORMAT = logging.Formatter("%(asctime)s:%(levelname)s:%(name)s:%(message)s")
 
 loggers = {}
 
@@ -121,14 +118,11 @@ def add_file_handler(log_directory, logger, name, level, overwrite=False):
     log_directory.mkdir(exist_ok=True)
 
     if overwrite:
-        mode = 'w'
+        mode = "w"
     else:
-        mode = 'a'
+        mode = "a"
 
-    file_handler = logging.FileHandler(
-        log_directory / f'{name}.log',
-        mode=mode
-    )
+    file_handler = logging.FileHandler(log_directory / f"{name}.log", mode=mode)
     file_handler.setFormatter(LOG_FORMAT)
     file_handler.setLevel(level)
 
@@ -143,6 +137,7 @@ def log_time(logger_name, level=None):
     logger_name : str
         name of the logger
     """
+
     def log_time_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
@@ -150,9 +145,11 @@ def log_time(logger_name, level=None):
             result = function(*args, **kwargs)
             elapsed = time.time() - start
             logger = get_logger(logger_name, level=None)
-            logger.debug(f'Execution of {str(function)} took {elapsed} s')
+            logger.debug(f"Execution of {str(function)} took {elapsed} s")
             return result
+
         return wrapper
+
     return log_time_decorator
 
 
@@ -164,6 +161,7 @@ def log_exceptions(logger_name, level=None):
     logger_name : str
         name of the logger
     """
+
     def log_exception_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
@@ -180,6 +178,7 @@ def log_exceptions(logger_name, level=None):
                 raise e
 
         return wrapper
+
     return log_exception_decorator
 
 
@@ -191,16 +190,18 @@ def log_results(logger_name, level=None):
     logger_name : str
         name of the logger
     """
+
     def log_results_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
             logger = get_logger(logger_name, level=None)
 
-            logger.debug('{} was called with {}, {}'.format(
-                    function, *args, **kwargs))
+            logger.debug("{} was called with {}, {}".format(function, *args, **kwargs))
             results = function(*args, **kwargs)
-            logger.debug(f'Results: {results}')
+            logger.debug(f"Results: {results}")
 
             return results
+
         return wrapper
+
     return log_results_decorator

--- a/CADETProcess/log.py
+++ b/CADETProcess/log.py
@@ -13,7 +13,7 @@ The CADETProcess.log module provides functionality for logging events in CADET-P
     loggers
     get_logger
 
-"""
+"""  # noqa
 
 import logging
 import time
@@ -31,7 +31,8 @@ loggers = {}
 
 
 def get_logger(name, level=None):
-    """Retrieve logger from loggers dictionary. Create new one if it does not already exist.
+    """
+    Retrieve logger from loggers dictionary. Create new one if it does not already exist.
 
     Parameters
     ----------
@@ -59,7 +60,8 @@ def get_logger(name, level=None):
 
 
 def update_loggers(log_directory, save_log):
-    """Update the file handlers of all logger objects in the loggers dictionary.
+    """
+    Update the file handlers of all logger objects in the loggers dictionary.
 
     Parameters
     ----------
@@ -73,7 +75,8 @@ def update_loggers(log_directory, save_log):
 
 
 def update_file_handlers(log_directory, logger, name, save_log):
-    """Update the file handlers of a logger object.
+    """
+    Update the file handlers of a logger object.
 
     Parameters
     ----------
@@ -99,7 +102,8 @@ def update_file_handlers(log_directory, logger, name, save_log):
 
 
 def add_file_handler(log_directory, logger, name, level, overwrite=False):
-    """Add a file handler to a logger object.
+    """
+    Add a file handler to a logger object.
 
     Parameters
     ----------
@@ -130,14 +134,16 @@ def add_file_handler(log_directory, logger, name, level, overwrite=False):
 
 
 def log_time(logger_name, level=None):
-    """Log execution time of function.
+    """
+    Log execution time of function.
 
     Parameters
     ----------
-    logger_name : str
-        name of the logger
+    logger_name : str, optional
+        Name of the logger.
+    level : int, optional
+        Log level.
     """
-
     def log_time_decorator(function):
         @wraps(function)
         def wrapper(*args, **kwargs):
@@ -154,12 +160,15 @@ def log_time(logger_name, level=None):
 
 
 def log_exceptions(logger_name, level=None):
-    """Log exceptions.
+    """
+    Log exceptions.
 
     Parameters
     ----------
     logger_name : str
-        name of the logger
+        Name of the logger.
+    level : int
+        Log level.
     """
 
     def log_exception_decorator(function):
@@ -183,7 +192,8 @@ def log_exceptions(logger_name, level=None):
 
 
 def log_results(logger_name, level=None):
-    """Log results.
+    """
+    Log results.
 
     Parameters
     ----------

--- a/CADETProcess/metric.py
+++ b/CADETProcess/metric.py
@@ -4,12 +4,15 @@ import numpy as np
 
 
 class MetricBase(ABC):
-    """Base Class for metrics used in Optimization, Fractionation, Comparison.
+    """
+    Abstract base class for metrics used in optimization, fractionation, and comparison.
 
-    See Also
-    --------
-    PerformanceIndicator
-    DifferenceMetric
+    Attributes
+    ----------
+    n_metrics : int
+        Number of metrics, default is 1.
+    bad_metrics : float
+        Value representing a bad metric, default is infinity.
 
     """
 
@@ -18,10 +21,38 @@ class MetricBase(ABC):
 
     @abstractmethod
     def evaluate(self):
+        """
+        Evaluate the metric.
+
+        This method should be implemented by subclasses to perform specific metric calculations.
+        """
         pass
 
     def __call__(self, *args, **kwargs):
+        """
+        Invoke the evaluate method.
+
+        Parameters
+        ----------
+        *args : tuple
+            Variable length argument list passed to evaluate.
+        **kwargs : dict
+            Arbitrary keyword arguments passed to evaluate.
+
+        Returns
+        -------
+        Any
+            The result of the metric evaluation.
+        """
         return self.evaluate(*args, **kwargs)
 
     def __str__(self):
+        """
+        Return the class name as the string representation of the instance.
+
+        Returns
+        -------
+        str
+            The name of the class.
+        """
         return self.__class__.__name__

--- a/CADETProcess/metric.py
+++ b/CADETProcess/metric.py
@@ -12,6 +12,7 @@ class MetricBase(ABC):
     DifferenceMetric
 
     """
+
     n_metrics = 1
     bad_metrics = np.inf
 

--- a/CADETProcess/metric.py
+++ b/CADETProcess/metric.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from typing import Any
 
 import numpy as np
 
@@ -20,7 +21,7 @@ class MetricBase(ABC):
     bad_metrics = np.inf
 
     @abstractmethod
-    def evaluate(self):
+    def evaluate(self) -> Any:
         """
         Evaluate the metric.
 
@@ -28,7 +29,7 @@ class MetricBase(ABC):
         """
         pass
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         """
         Invoke the evaluate method.
 
@@ -46,7 +47,7 @@ class MetricBase(ABC):
         """
         return self.evaluate(*args, **kwargs)
 
-    def __str__(self):
+    def __str__(self) -> str:
         """
         Return the class name as the string representation of the instance.
 

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -1,12 +1,16 @@
 import warnings
 from copy import deepcopy
 from functools import wraps
-from typing import Any, NoReturn, Optional
+from typing import Any, NoReturn, Optional, Union
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
+from addict import Dict
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
-from CADETProcess import CADETProcessError, plotting
+from CADETProcess import CADETProcessError, SimulationResults, plotting
 from CADETProcess.dataStructure import (
     Integer,
     Structure,
@@ -61,11 +65,11 @@ class ZoneBaseClass(UnitBaseClass):
         name: str,
         n_columns: int = 1,
         flow_direction: int = 1,
-        initial_state: list = None,
-        valve_parameters: dict = None,
-        *args,
-        **kwargs,
-    ) -> NoReturn:
+        initial_state: Optional[list] = None,
+        valve_parameters: Optional[dict] = None,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize a ZoneBaseClass instance.
 
@@ -83,6 +87,10 @@ class ZoneBaseClass(UnitBaseClass):
             Initial state of the zone.
         valve_parameters : dict
             Additional parameters to setup mixer/splitter valves.
+        *args : Optional
+            Additional Parameters passed down to UnitBaseClass
+        **kwargs : Optional
+            Additional Parameters passed down to UnitBaseClass
         """
         self.n_columns = n_columns
         self.flow_direction = flow_direction
@@ -106,7 +114,8 @@ class ZoneBaseClass(UnitBaseClass):
 
     @initial_state.setter
     def initial_state(
-        self, initial_state: list[dict[str, list]] | dict[str, list]
+        self,
+        initial_state: list[dict[str, list]] | dict[str, list]
     ) -> NoReturn:
         if initial_state is None:
             self._initial_state = initial_state
@@ -122,11 +131,11 @@ class ZoneBaseClass(UnitBaseClass):
 
     def _setup_valve(
         self,
-        component_system,
-        name,
-        unit_type=Cstr,
-        **valve_parameters,
-    ):
+        component_system: ComponentSystem,
+        name: str,
+        unit_type: Union[Cstr, TubularReactor] = Cstr,
+        **valve_parameters: dict
+    ) -> None:
         if unit_type not in (Cstr, TubularReactor):
             raise ValueError(
                 "Unknown unit type. Must be one of `Cstr`, `TubularReactor`."
@@ -235,17 +244,17 @@ class CarouselBuilder(Structure):
         self._column = column
 
     @wraps(FlowSheet.add_unit)
-    def add_unit(self, *args, **kwargs):
+    def add_unit(self, *args: Any, **kwargs: Any) -> None:
         """Wrap FlowSheet.add_unit to add a unit to the flow sheet."""
         self.flow_sheet.add_unit(*args, **kwargs)
 
     @wraps(FlowSheet.add_connection)
-    def add_connection(self, *args, **kwargs):
+    def add_connection(self, *args: Any, **kwargs: Any) -> None:
         """Wrap FlowSheet.add_connection to add a connection between units."""
         self.flow_sheet.add_connection(*args, **kwargs)
 
     @wraps(FlowSheet.set_output_state)
-    def set_output_state(self, *args, **kwargs) -> NoReturn:
+    def set_output_state(self, *args: Any, **kwargs: Any) -> None:
         """Wrap FlowSheet.set_output_state to set the output state of a unit."""
         self.flow_sheet.set_output_state(*args, **kwargs)
 
@@ -304,7 +313,7 @@ class CarouselBuilder(Structure):
 
         return flow_sheet
 
-    def _add_units(self, flow_sheet: FlowSheet) -> NoReturn:
+    def _add_units(self, flow_sheet: FlowSheet) -> None:
         """Add units to flow_sheet."""
         col_index = 0
         for unit in self.flow_sheet.units:
@@ -394,7 +403,7 @@ class CarouselBuilder(Structure):
         """float: cycle time of the process."""
         return self.n_columns * self.switch_time
 
-    def _add_events(self, process):
+    def _add_events(self, process: Process) -> None:
         """Add events to process."""
         process.cycle_time = self.n_columns * self.switch_time
         process.add_duration("switch_time", self.switch_time)
@@ -467,13 +476,19 @@ class CarouselBuilder(Structure):
 
                 position_counter += zone.n_columns
 
-    def carousel_state(self, t) -> float:
-        """int: Carousel state at given time.
+    def carousel_state(self, t: float) -> int:
+        """
+        Return carousel state at given time.
 
         Parameters
         ----------
         t: float
             Time
+
+        Returns
+        -------
+        int:
+             Carousel state at given time.
         """
         return int(np.floor((t % self.cycle_time) / self.switch_time))
 
@@ -630,7 +645,7 @@ class SMBBuilder(CarouselBuilder):
 
         self.add_connection(zone_IV, zone_I)
 
-    def _validate_binding_model(self, binding_model):
+    def _validate_binding_model(self, binding_model: BindingBaseClass) -> None:
         """
         Validate that the provided binding model matches the required type.
 
@@ -649,7 +664,7 @@ class SMBBuilder(CarouselBuilder):
                 f"Invalid binding model. Expected {self.binding_model_type}."
             )
 
-    def _get_zone_flow_rates(self, m, switch_time):
+    def _get_zone_flow_rates(self, m: list, switch_time: float) -> list[float]:
         m1, m2, m3, m4 = m
 
         Vc = self.column.volume
@@ -662,7 +677,7 @@ class SMBBuilder(CarouselBuilder):
 
         return [Q_I, Q_II, Q_III, Q_IV]
 
-    def _get_unit_flow_rates(self, Q_zones):
+    def _get_unit_flow_rates(self, Q_zones: list[float]) -> list[float]:
         Q_I, Q_II, Q_III, Q_IV = Q_zones
 
         Q_feed = Q_III - Q_II
@@ -672,7 +687,7 @@ class SMBBuilder(CarouselBuilder):
 
         return [Q_feed, Q_eluent, Q_raffinate, Q_extract]
 
-    def _get_split_ratios(self, Q_zones, Q_units):
+    def _get_split_ratios(self, Q_zones: list[float], Q_units: list[float]) -> tuple[float, float]:
         Q_I, Q_II, Q_III, Q_IV = Q_zones
         Q_feed, Q_eluent, Q_raffinate, Q_extract = Q_units
 
@@ -908,7 +923,7 @@ class SMBBuilder(CarouselBuilder):
 
         return fig, ax
 
-    def _plot_triangle(self, ax, *design_parameters):
+    def _plot_triangle(self, ax: Axes, *design_parameters: Any) -> None:
         """
         Plot a theoretical triangle diagram for SMB processes.
 
@@ -944,7 +959,7 @@ class LinearSMBBuilder(SMBBuilder):
 
     binding_model_type = Linear
 
-    def _validate_binding_model(self, binding_model):
+    def _validate_binding_model(self, binding_model: BindingBaseClass) -> None:
         """
         Validate the binding model for compatibility with Langmuir SMB systems.
 
@@ -1082,7 +1097,7 @@ class LinearSMBBuilder(SMBBuilder):
 
     def _plot_triangle(
         self,
-        ax,
+        ax: Axes,
         HA: float,
         HB: float,
     ) -> NoReturn:
@@ -1365,7 +1380,18 @@ class LangmuirSMBBuilder(SMBBuilder):
 
         return [m1, m2, m3, m4]
 
-    def _plot_triangle(self, ax, HA, HB, bA, bB, cFA, cFB, wG, wF):
+    def _plot_triangle(
+        self,
+        ax: Axes,
+        HA: float,
+        HB: float,
+        bA: float,
+        bB: float,
+        cFA: float,
+        cFB: float,
+        wG: float,
+        wF: float
+    ) -> None:
         """
         Plot SMB triangle for Langmuir isotherm.
 
@@ -1441,7 +1467,11 @@ class CarouselSolutionBulk(SolutionBase):
 
     _coordinates = ["axial_coordinates", "radial_coordinates"]
 
-    def __init__(self, builder, simulation_results):
+    def __init__(
+        self,
+        builder: CarouselBuilder,
+        simulation_results: SimulationResults
+    ) -> None:
         if not builder.column.solution_recorder.write_solution_bulk:
             raise CADETProcessError(
                 "Cannot instantiate CarouselSolutionBulk if solution is not stored. "
@@ -1452,45 +1482,49 @@ class CarouselSolutionBulk(SolutionBase):
         self.simulation_results = simulation_results
 
     @property
-    def component_system(self):
+    def component_system(self) -> ComponentSystem:
         return self.builder.component_system
 
     @property
-    def solution(self):
+    def solution(self) -> Dict:
         return self.simulation_results.solution
 
     @property
-    def axial_coordinates(self):
+    def axial_coordinates(self) -> npt.ArrayLike:
         return self.simulation_results.solution.column_0.bulk.axial_coordinates
 
     @property
-    def radial_coordinates(self):
-        radial_coordinates = (
+    def radial_coordinates(self) -> npt.ArrayLike:
+        radial_coordinates = \
             self.simulation_results.solution.column_0.bulk.radial_coordinates
-        )
         if radial_coordinates is not None and len(radial_coordinates) == 1:
             radial_coordinates = None
 
         return radial_coordinates
 
     @property
-    def time(self):
+    def time(self) -> float:
         return self.simulation_results.solution.column_0.bulk.time
 
     def plot_at_time(
         self,
-        t,
-        y_min=None,
-        y_max=None,
-        axs=None,
-    ):
-        """
-        Plot bulk solution over space at given time.
+        t: float,
+        y_min: Optional[float] = None,
+        y_max: Optional[float] = None,
+        axs: Optional[Axes] = None,
+    ) -> tuple[Figure, Axes]:
+        """Plot bulk solution over space at given time.
 
         Parameters
         ----------
         t : float
             time for plotting
+        y_min : float, optional
+            Set minimum for plotting purposes.
+            If None, y_min is set to minimum of the data.
+        y_max : float, optional
+            Set maximum for plotting purposes.
+            If None, y_max is set to minimum of the data
         ax : Axes
             Axes to plot on.
 

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -40,7 +40,8 @@ __all__ = [
 
 
 class ZoneBaseClass(UnitBaseClass):
-    """Base class for a multi-column zone with configurable columns and flow directions.
+    """
+    Base class for a multi-column zone with configurable columns and flow directions.
 
     Attributes
     ----------
@@ -481,7 +482,8 @@ class CarouselBuilder(Structure):
         carousel_positions: np.typing.NDArray[int],
         carousel_state: int,
     ) -> np.ndarray[int]:
-        """Determine index of column unit at given carousel position and state.
+        """
+        Determine index of column unit at given carousel position and state.
 
         Parameters
         ----------
@@ -504,7 +506,8 @@ class CarouselBuilder(Structure):
         t: float,
         carousel_positions: np.typing.NDArray[int],
     ) -> int:
-        """Determine index of column unit at given carousel position and time.
+        """
+        Determine index of column unit at given carousel position and time.
 
         Parameters
         ----------
@@ -1099,7 +1102,6 @@ class LinearSMBBuilder(SMBBuilder):
             Henry coefficient of strongly binding component.
         HB : float
             Henry coefficient of strongly binding component.
-
         """
         # Bounds
         lb = HB - 0.3 * (HA - HB)
@@ -1431,10 +1433,10 @@ class LangmuirSMBBuilder(SMBBuilder):
 
 
 class CarouselSolutionBulk(SolutionBase):
-    """Solution at unit inlet or outlet.
+    """
+    Solution at unit inlet or outlet.
 
     N_COLUMNS * NCOL * NRAD
-
     """
 
     _coordinates = ["axial_coordinates", "radial_coordinates"]
@@ -1482,7 +1484,8 @@ class CarouselSolutionBulk(SolutionBase):
         y_max=None,
         axs=None,
     ):
-        """Plot bulk solution over space at given time.
+        """
+        Plot bulk solution over space at given time.
 
         Parameters
         ----------

--- a/CADETProcess/modelBuilder/compartmentBuilder.py
+++ b/CADETProcess/modelBuilder/compartmentBuilder.py
@@ -8,6 +8,17 @@ from CADETProcess.processModel import Cstr, FlowSheet, Inlet, Outlet, Process
 
 
 class CompartmentBuilder(metaclass=StructMeta):
+    """
+    Class to build complex compartment models of bioreactors.
+
+    Attributes
+    ----------
+    name : str
+        Name of the CompartmentBuilder.
+    n_compartments : int
+        Number of compartments in the bioreactor.
+    """
+
     name = String()
     n_compartments = UnsignedInteger()
 
@@ -22,7 +33,8 @@ class CompartmentBuilder(metaclass=StructMeta):
         particle_reaction_model=None,
         name=None,
     ):
-        """Initialize builder.
+        """
+        Initialize builder.
 
         Parameters
         ----------
@@ -42,7 +54,6 @@ class CompartmentBuilder(metaclass=StructMeta):
             Particle reaction model for all compartments. The default is None.
         name : str, optional
             Name of the model. The default is None.
-
         """
         self.component_system = component_system
         if name is None:
@@ -72,7 +83,7 @@ class CompartmentBuilder(metaclass=StructMeta):
 
     @property
     def _real_compartments(self):
-        """list: Compartment units excluding pseudo units s.a. Inlet/Outlet"""
+        """list: Compartment units excluding pseudo units s.a. Inlet/Outlet."""
         compartments = []
         for i in range(self.n_compartments):
             name = f"compartment_{i}"
@@ -85,7 +96,7 @@ class CompartmentBuilder(metaclass=StructMeta):
     @property
     @wraps(Cstr.binding_model)
     def binding_model(self):
-        """Wrapper around master compartment to set binding model"""
+        """Wrapper around master compartment to set binding model."""
         return self._compartment_model.binding_model
 
     @binding_model.setter
@@ -100,7 +111,7 @@ class CompartmentBuilder(metaclass=StructMeta):
     @property
     @wraps(Cstr.bulk_reaction_model)
     def bulk_reaction_model(self):
-        """Wrapper around master compartment to set bulk reaction model"""
+        """Wrapper around master compartment to set bulk reaction model."""
         return self._compartment_model.bulk_reaction_model
 
     @bulk_reaction_model.setter
@@ -115,7 +126,7 @@ class CompartmentBuilder(metaclass=StructMeta):
     @property
     @wraps(Cstr.particle_reaction_model)
     def particle_reaction_model(self):
-        """Wrapper around master compartment to set particle reaction model"""
+        """Wrapper around master compartment to set particle reaction model."""
         return self._compartment_model.particle_reaction_model
 
     @particle_reaction_model.setter
@@ -128,15 +139,18 @@ class CompartmentBuilder(metaclass=StructMeta):
                 compartment.particle_reaction_model = particle_reaction_model
 
     @property
-    def flow_sheet(self):
+    def flow_sheet(self) -> FlowSheet:
+        """FlowSheet: FlowSheet of the compartment builder."""
         return self._flow_sheet
 
     @property
-    def process(self):
+    def process(self) -> Process:
+        """Process: Process of the compartment builder."""
         return self._process
 
     @property
-    def cycle_time(self):
+    def cycle_time(self) -> float:
+        """float: Cycle time of the process."""
         return self.process.cycle_time
 
     @cycle_time.setter
@@ -144,7 +158,7 @@ class CompartmentBuilder(metaclass=StructMeta):
         self.process.cycle_time = cycle_time
 
     def _add_compartments(self, compartment_volumes):
-        """Instantiate compartments and add to FlowSheet"""
+        """Instantiate compartments and add to FlowSheet."""
         self.n_compartments = len(compartment_volumes)
 
         for i, vol in enumerate(compartment_volumes):
@@ -161,7 +175,7 @@ class CompartmentBuilder(metaclass=StructMeta):
             self.flow_sheet.add_unit(unit)
 
     def _add_connections(self, connections_matrix):
-        """Add connections and flow rates between compartments to FlowSheet"""
+        """Add connections and flow rates between compartments to FlowSheet."""
         try:
             if isinstance(connections_matrix, list):
                 arr = np.array(connections_matrix)
@@ -195,7 +209,8 @@ class CompartmentBuilder(metaclass=StructMeta):
 
     @property
     def init_c(self):
-        """np.array: Initial conditions of compartments.
+        """
+        np.array: Initial conditions of compartments.
 
         Parameters
         ----------
@@ -212,8 +227,6 @@ class CompartmentBuilder(metaclass=StructMeta):
         ------
         ValueError
             If init_c does not contain correct shape.
-
-
         """
         return self._init_c
 
@@ -241,7 +254,8 @@ class CompartmentBuilder(metaclass=StructMeta):
     def add_tracer(
         self, compartment_index, c, t_inj, flow_rate, t_start=0, flow_rate_filter=True
     ):
-        """Add tracer injection to compartment model.
+        """
+        Add tracer injection to compartment model.
 
         For this purpose, a new inlet source is instantiated and connected to
         the corresponding compartment. Then, an Event is added which modifies
@@ -267,7 +281,6 @@ class CompartmentBuilder(metaclass=StructMeta):
         ------
         CADETProcessError
             If compartment is not a real compartment.
-
         """
         tracer = Inlet(self.component_system, "tracer")
         tracer.flow_rate = flow_rate
@@ -307,6 +320,6 @@ class CompartmentBuilder(metaclass=StructMeta):
 
 
 class CompartmentModel(Cstr):
-    """Dummy Class for checking binding and reaction models"""
+    """Dummy Class for checking binding and reaction models."""
 
     pass

--- a/CADETProcess/numerics.py
+++ b/CADETProcess/numerics.py
@@ -38,7 +38,6 @@ def round_to_significant_digits(
     >>> round_to_significant_digits(values, 2)
     array([ 1.2e-05,  6.8e+03,  0.0e+00])
     """
-
     if digits is None:
         return values
 

--- a/CADETProcess/numerics.py
+++ b/CADETProcess/numerics.py
@@ -1,7 +1,10 @@
 import numpy as np
 
 
-def round_to_significant_digits(values: np.ndarray | list[float], digits: int) -> np.ndarray:
+def round_to_significant_digits(
+    values: np.ndarray | list[float],
+    digits: int,
+) -> np.ndarray:
     """
     Round an array of numbers to the specified number of significant digits.
 

--- a/CADETProcess/optimization/__init__.py
+++ b/CADETProcess/optimization/__init__.py
@@ -107,10 +107,11 @@ from .pymooAdapter import NSGA2, U_NSGA3
 import importlib
 
 try:
-   from .axAdapater import BotorchModular, GPEI, NEHVI, qNParEGO
-   ax_imported = True
+    from .axAdapater import BotorchModular, GPEI, NEHVI, qNParEGO
+
+    ax_imported = True
 except ImportError:
-   ax_imported = False
+    ax_imported = False
 
 
 def __getattr__(name):

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -295,9 +295,11 @@ class AxInterface(OptimizerBase):
 
     def _post_processing(self, trial):
         """
-        ax holds the data of the model in a dataframe
-        an experiment consists of trials which consist of arms
-        in a sequential experiment, each trial only has one arm.
+        Run post processing.
+
+        Ax holds the data of the model in a dataframe an experiment consists of trials
+        which consist of arms in a sequential experiment, each trial only has one arm.
+
         Arms are evaluated. These hold the parameters.
         """
         op = self.optimization_problem
@@ -356,16 +358,16 @@ class AxInterface(OptimizerBase):
         )
 
     def _setup_model(self):
-        """constructs a pre-instantiated `Model` class that specifies the
-        surrogate model (e.g. Gaussian Process) and acquisition function,
+        """
+        Initialize a pre-instantiated `Model` class.
+
+        The class specifies the surrogate model (e.g. Gaussian Process) and acquisition function,
         which are used in the bayesian optimization algorithm.
         """
         raise NotImplementedError
 
     def _setup_optimization_config(self, objectives, outcome_constraints):
-        """instantiates an optimization configuration for Ax for single objective
-        or multi objective optimization
-        """
+        """Initialize an optimization configuration for Ax."""
         raise NotImplementedError
 
     def _run(self, optimization_problem, x0):
@@ -512,15 +514,14 @@ class MultiObjectiveAxInterface(AxInterface):
 
 
 class GPEI(SingleObjectiveAxInterface):
-    """
-    Bayesian optimization algorithm with a Gaussian Process (GP) surrogate model
-    and a Expected Improvement (EI) acquisition function for single objective
-    """
+    """Gaussian Process with Expected Improvement for single objectives."""
 
     def __repr__(self):
+        """str: String representation of the optimization algorithm."""
         return "GPEI"
 
     def train_model(self):
+        """Train model."""
         return Models.GPEI(
             experiment=self.ax_experiment, data=self.ax_experiment.fetch_data()
         )
@@ -528,13 +529,17 @@ class GPEI(SingleObjectiveAxInterface):
 
 class BotorchModular(SingleObjectiveAxInterface):
     """
-    implements a modular single objective bayesian optimization algorithm.
-    It takes 2 optional arguments and uses the BOTORCH_MODULAR API of Ax
-    to construct a Model, which connects both componenns with the respective
-    transforms necessary
+    Modular bayesian optimization algorithm.
 
-    acquisition_fn: AcquisitionFunction class
-    surrogate_model: Model class
+    BotorchModular takes 2 optional arguments and uses the BOTORCH_MODULAR API of Ax to construct
+    a Model which connects both components with the respective transforms necessary.
+
+    Attributes
+    ----------
+    acquisition_fn: type, optional
+        AcquisitionFunction class. The default is LogExpectedImprovement.
+    surrogate_model: type, optional
+        Model class. The default is SingleTaskGP.
     """
 
     acquisition_fn = Typed(ty=type, default=LogExpectedImprovement)
@@ -543,12 +548,14 @@ class BotorchModular(SingleObjectiveAxInterface):
     _specific_options = ["acquisition_fn", "surrogate_model"]
 
     def __repr__(self):
+        """str: String representation of the optimization algorithm."""
         afn = self.acquisition_fn.__name__
         smn = self.surrogate_model.__name__
 
         return f"BotorchModular({smn}+{afn})"
 
     def train_model(self):
+        """Train model."""
         raise NotImplementedError(
             "This model is currently broken. Please use Only GPEI or NEHVI"
         )
@@ -561,21 +568,19 @@ class BotorchModular(SingleObjectiveAxInterface):
 
 
 class NEHVI(MultiObjectiveAxInterface):
-    """
-    Multi objective Bayesian optimization algorithm, which acquires new points
-    with noisy expected hypervolume improvement (NEHVI) and approximates the
-    model with a Fixed Noise Gaussian Process
-    """
+    """Noisy expected hypervolume improvement multi-objective algorithm."""
 
     supports_single_objective = False
 
     def __repr__(self):
+        """str: String representation of the optimization algorithm."""
         smn = "SingleTaskGP"
         afn = "NEHVI"
 
         return f"{smn}+{afn}"
 
     def train_model(self):
+        """Train model."""
         return Models.MOO(
             experiment=self.ax_experiment, data=self.ax_experiment.fetch_data()
         )
@@ -583,25 +588,30 @@ class NEHVI(MultiObjectiveAxInterface):
 
 class qNParEGO(MultiObjectiveAxInterface):
     """
-    Multi objective Bayesian optimization algorithm with the qNParEGO acquisition function.
-    ParEGO transforms the MOO problem into a single objective problem by applying a randomly weighted augmented
-    Chebyshev scalarization to the objectives, and maximizing the expected improvement of that scalarized
-    quantity (Knowles, 2006). Recently, Daulton et al. (2020) used a multi-output Gaussian process and compositional
-    Monte Carlo objective to extend ParEGO to the batch setting (qParEGO), which proved to be a strong baseline for
-    MOBO. Additionally, the authors proposed a noisy variant (qNParEGO), but the empirical evaluation of qNParEGO
-    was limited. [Daulton et al. 2021 "Parallel Bayesian Optimization of Multiple Noisy Objectives with Expected
-    Hypervolume Improvement"]
+    qNParEGO multi-objective algorithm.
+
+    ParEGO transforms the MOO problem into a single objective problem by applying a
+    randomly weighted augmented Chebyshev scalarization to the objectives, and
+    maximizing the expected improvement of that scalarized quantity (Knowles, 2006).
+    Recently, Daulton et al. (2020) used a multi-output Gaussian process and
+    compositional Monte Carlo objective to extend ParEGO to the batch setting (qParEGO),
+    which proved to be a strong baseline for MOBO. Additionally, the authors proposed a
+    noisy variant (qNParEGO), but the empirical evaluation of qNParEGO was limited.
+    [Daulton et al. 2021 "Parallel Bayesian Optimization of Multiple Noisy Objectives
+    with Expected Hypervolume Improvement"]
     """
 
     supports_single_objective = False
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: String representation of the algorithm."""
         smn = "SingleTaskGP"
         afn = "qNParEGO"
 
         return f"{smn}+{afn}"
 
     def train_model(self):
+        """Train model."""
         return Models.MOO(
             experiment=self.ax_experiment,
             data=self.ax_experiment.fetch_data(),

--- a/CADETProcess/optimization/cache.py
+++ b/CADETProcess/optimization/cache.py
@@ -1,15 +1,14 @@
-from collections import defaultdict
-from pathlib import Path
 import shutil
 import tempfile
+from collections import defaultdict
+from pathlib import Path
 
 from diskcache import Cache, FanoutCache
 
-from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import DillDisk
 
 
-class ResultsCache():
+class ResultsCache:
     """Cache to store (intermediate) results.
 
     Optinally uses diskcache library to store large objects in sqlite database.
@@ -51,7 +50,7 @@ class ResultsCache():
         """Initialize ResultsCache."""
         if self.use_diskcache:
             if self.directory is None:
-                self.directory = Path(tempfile.mkdtemp(prefix='diskcache-'))
+                self.directory = Path(tempfile.mkdtemp(prefix="diskcache-"))
 
             if self.directory.exists():
                 shutil.rmtree(self.directory, ignore_errors=True)
@@ -60,20 +59,20 @@ class ResultsCache():
 
             if self.n_shards == 1:
                 self.cache = Cache(
-                   self.directory.as_posix(),
-                   disk=DillDisk,
-                   disk_min_file_size=2**18,    # 256 kb
-                   size_limit=2**36,            # 64 GB
-                   tag_index=True,
+                    self.directory.as_posix(),
+                    disk=DillDisk,
+                    disk_min_file_size=2**18,  # 256 kb
+                    size_limit=2**36,  # 64 GB
+                    tag_index=True,
                 )
             else:
                 self.cache = FanoutCache(
-                   self.directory.as_posix(),
-                   shards=self.n_shards,
-                   disk=DillDisk,
-                   disk_min_file_size=2**18,    # 256 kb
-                   size_limit=2**36,            # 64 GB
-                   tag_index=True,
+                    self.directory.as_posix(),
+                    shards=self.n_shards,
+                    disk=DillDisk,
+                    disk_min_file_size=2**18,  # 256 kb
+                    size_limit=2**36,  # 64 GB
+                    tag_index=True,
                 )
             self.directory = self.cache.directory
         else:

--- a/CADETProcess/optimization/cache.py
+++ b/CADETProcess/optimization/cache.py
@@ -2,6 +2,7 @@ import shutil
 import tempfile
 from collections import defaultdict
 from pathlib import Path
+from typing import Any, Optional
 
 from diskcache import Cache, FanoutCache
 
@@ -39,7 +40,13 @@ class ResultsCache:
     CADETProcess.optimization.OptimizationProblem.add_evaluator
     """
 
-    def __init__(self, use_diskcache=False, directory=None, n_shards=1):
+    def __init__(
+            self,
+        use_diskcache: bool = False,
+        directory: Optional[str] = None,
+        n_shards: int = 1,
+    ) -> None:
+        """Initialize ResultsCache Object."""
         self.use_diskcache = use_diskcache
         self.directory = directory
         self.n_shards = n_shards
@@ -47,7 +54,7 @@ class ResultsCache:
 
         self.tags = defaultdict(list)
 
-    def init_cache(self):
+    def init_cache(self) -> None:
         """Initialize ResultsCache."""
         if self.use_diskcache:
             if self.directory is None:
@@ -79,7 +86,13 @@ class ResultsCache:
         else:
             self.cache = {}
 
-    def set(self, key, value, tag=None, close=True):
+    def set(
+        self,
+        key: Any,
+        value: Any,
+        tag: Optional[str] = None,
+        close: bool = True
+    ) -> None:
         """
         Add entry to cache.
 
@@ -104,7 +117,7 @@ class ResultsCache:
         if close:
             self.close()
 
-    def get(self, key, close=True):
+    def get(self, key: Any, close: bool = True) -> Any:
         """
         Get entry from cache.
 
@@ -127,7 +140,7 @@ class ResultsCache:
 
         return value
 
-    def delete(self, key, close=True):
+    def delete(self, key: Any, close: Optional[bool] = True) -> None:
         """
         Remove entry from cache.
 
@@ -148,7 +161,7 @@ class ResultsCache:
         if close:
             self.close()
 
-    def prune(self, tag, close=True):
+    def prune(self, tag: str, close: Optional[bool] = True) -> None:
         """
         Remove tagged entries from cache.
 
@@ -173,12 +186,12 @@ class ResultsCache:
         if close:
             self.close()
 
-    def close(self):
+    def close(self) -> None:
         """Close cache."""
         if self.use_diskcache:
             self.cache.close()
 
-    def delete_database(self, reinit=False):
+    def delete_database(self, reinit: Optional[bool] = False) -> None:
         """
         Delte database.
 

--- a/CADETProcess/optimization/cache.py
+++ b/CADETProcess/optimization/cache.py
@@ -9,7 +9,8 @@ from CADETProcess.dataStructure import DillDisk
 
 
 class ResultsCache:
-    """Cache to store (intermediate) results.
+    """
+    Cache to store (intermediate) results.
 
     Optinally uses diskcache library to store large objects in sqlite database.
 
@@ -79,7 +80,8 @@ class ResultsCache:
             self.cache = {}
 
     def set(self, key, value, tag=None, close=True):
-        """Add entry to cache.
+        """
+        Add entry to cache.
 
         Parameters
         ----------
@@ -177,7 +179,8 @@ class ResultsCache:
             self.cache.close()
 
     def delete_database(self, reinit=False):
-        """Delte database.
+        """
+        Delte database.
 
         Parameters
         ----------

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -1,11 +1,10 @@
 import hashlib
 
-from addict import Dict
 import numpy as np
+from addict import Dict
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import Bool, Float, Vector
+from CADETProcess.dataStructure import Bool, Float, Structure, Vector
 
 
 def hash_array(array: np.ndarray) -> str:
@@ -84,25 +83,25 @@ class Individual(Structure):
     is_feasible = Bool()
 
     def __init__(
-            self,
-            x,
-            f=None,
-            g=None,
-            f_min=None,
-            x_transformed=None,
-            cv_bounds=None,
-            cv_lincon=None,
-            cv_lineqcon=None,
-            cv_nonlincon=None,
-            m=None,
-            m_min=None,
-            independent_variable_names=None,
-            objective_labels=None,
-            nonlinear_constraint_labels=None,
-            meta_score_labels=None,
-            variable_names=None,
-            is_feasible=True,
-            ):
+        self,
+        x,
+        f=None,
+        g=None,
+        f_min=None,
+        x_transformed=None,
+        cv_bounds=None,
+        cv_lincon=None,
+        cv_lineqcon=None,
+        cv_nonlincon=None,
+        m=None,
+        m_min=None,
+        independent_variable_names=None,
+        objective_labels=None,
+        nonlinear_constraint_labels=None,
+        meta_score_labels=None,
+        variable_names=None,
+        is_feasible=True,
+    ):
         self.x = x
         if x_transformed is None:
             x_transformed = x
@@ -132,7 +131,9 @@ class Individual(Structure):
             variable_names = [s.decode() for s in variable_names]
         self.variable_names = variable_names
         if isinstance(independent_variable_names, np.ndarray):
-            independent_variable_names = [s.decode() for s in independent_variable_names]
+            independent_variable_names = [
+                s.decode() for s in independent_variable_names
+            ]
         self.independent_variable_names = independent_variable_names
         if isinstance(objective_labels, np.ndarray):
             objective_labels = [s.decode() for s in objective_labels]
@@ -302,11 +303,11 @@ class Individual(Structure):
         return similar_x and similar_f and similar_g and similar_m
 
     def is_similar_x(
-            self,
-            other: "Individual",
-            tol: float = 1e-1,
-            use_transformed: bool = False,
-            ) -> bool:
+        self,
+        other: "Individual",
+        tol: float = 1e-1,
+        use_transformed: bool = False,
+    ) -> bool:
         """Determine if individual is similar to other based on parameter values.
 
         Parameters
@@ -394,9 +395,9 @@ class Individual(Structure):
 
     def __repr__(self) -> str:
         if self.g is None:
-            return f'{self.__class__.__name__}({self.x}, {self.f})'
+            return f"{self.__class__.__name__}({self.x}, {self.f})"
         else:
-            return f'{self.__class__.__name__}({self.x}, {self.f}, {self.g})'
+            return f"{self.__class__.__name__}({self.x}, {self.f}, {self.g})"
 
     def to_dict(self) -> dict:
         """Convert individual to a dictionary.

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -1,6 +1,8 @@
 import hashlib
+from typing import Optional
 
 import numpy as np
+import numpy.typing as npt
 from addict import Dict
 
 from CADETProcess import CADETProcessError
@@ -85,24 +87,25 @@ class Individual(Structure):
 
     def __init__(
         self,
-        x,
-        f=None,
-        g=None,
-        f_min=None,
-        x_transformed=None,
-        cv_bounds=None,
-        cv_lincon=None,
-        cv_lineqcon=None,
-        cv_nonlincon=None,
-        m=None,
-        m_min=None,
-        independent_variable_names=None,
-        objective_labels=None,
-        nonlinear_constraint_labels=None,
-        meta_score_labels=None,
-        variable_names=None,
-        is_feasible=True,
-    ):
+        x: npt.ArrayLike,
+        f: Optional[npt.ArrayLike] = None,
+        g: Optional[npt.ArrayLike] = None,
+        f_min: Optional[npt.ArrayLike] = None,
+        x_transformed: Optional[npt.ArrayLike] = None,
+        cv_bounds: Optional[npt.ArrayLike] = None,
+        cv_lincon: Optional[npt.ArrayLike] = None,
+        cv_lineqcon: Optional[npt.ArrayLike] = None,
+        cv_nonlincon: Optional[npt.ArrayLike] = None,
+        m: Optional[npt.ArrayLike] = None,
+        m_min: Optional[npt.ArrayLike] = None,
+        independent_variable_names: list[str] = None,
+        objective_labels: list[str] = None,
+        nonlinear_constraint_labels: list[str] = None,
+        meta_score_labels: list[str] = None,
+        variable_names: list[str] = None,
+        is_feasible: bool = True,
+    ) -> None:
+        """Initialize Individual Object."""
         self.x = x
         if x_transformed is None:
             x_transformed = x

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -8,7 +8,8 @@ from CADETProcess.dataStructure import Bool, Float, Structure, Vector
 
 
 def hash_array(array: np.ndarray) -> str:
-    """Compute a hash value for an array of floats using the sha256 hash function.
+    """
+    Compute a hash value for an array of floats using the sha256 hash function.
 
     Parameters
     ----------
@@ -202,7 +203,6 @@ class Individual(Structure):
         -------
         np.ndarray
             All constraint violations combined.
-
         """
         cvs = (self.cv_bounds, self.cv_lincon, self.cv_lineqcon, self.cv_nonlincon)
         return np.concatenate([cv for cv in cvs if cv is not None])
@@ -223,7 +223,8 @@ class Individual(Structure):
         return self.m_min / self.m
 
     def dominates(self, other: "Individual") -> bool:
-        """Determine if individual dominates other.
+        """
+        Determine if individual dominates other.
 
         Parameters
         ----------
@@ -269,7 +270,8 @@ class Individual(Structure):
         return False
 
     def is_similar(self, other: "Individual", tol: float = 1e-1) -> bool:
-        """Determine if individual is similar to other.
+        """
+        Determine if individual is similar to other.
 
         Parameters
         ----------
@@ -308,7 +310,8 @@ class Individual(Structure):
         tol: float = 1e-1,
         use_transformed: bool = False,
     ) -> bool:
-        """Determine if individual is similar to other based on parameter values.
+        """
+        Determine if individual is similar to other based on parameter values.
 
         Parameters
         ----------
@@ -331,7 +334,8 @@ class Individual(Structure):
         return similar_x
 
     def is_similar_f(self, other: "Individual", tol: float = 1e-1) -> bool:
-        """Determine if individual is similar to other based on objective values.
+        """
+        Determine if individual is similar to other based on objective values.
 
         Parameters
         ----------
@@ -351,7 +355,8 @@ class Individual(Structure):
         return similar_f
 
     def is_similar_g(self, other: "Individual", tol: float | None = 1e-1) -> bool:
-        """Determine if individual is similar to other based on constraint values.
+        """
+        Determine if individual is similar to other based on constraint values.
 
         Parameters
         ----------
@@ -371,7 +376,8 @@ class Individual(Structure):
         return similar_g
 
     def is_similar_m(self, other: "Individual", tol: float | None = 1e-1) -> bool:
-        """Determine if individual is similar to other based on meta score values.
+        """
+        Determine if individual is similar to other based on meta score values.
 
         Parameters
         ----------
@@ -391,16 +397,19 @@ class Individual(Structure):
         return similar_m
 
     def __str__(self) -> str:
+        """str: String representation of the individual."""
         return str(list(self.x))
 
     def __repr__(self) -> str:
+        """str: String representation of the individual."""
         if self.g is None:
             return f"{self.__class__.__name__}({self.x}, {self.f})"
         else:
             return f"{self.__class__.__name__}({self.x}, {self.f}, {self.g})"
 
     def to_dict(self) -> dict:
-        """Convert individual to a dictionary.
+        """
+        Convert individual to a dictionary.
 
         Returns
         -------
@@ -441,7 +450,8 @@ class Individual(Structure):
 
     @classmethod
     def from_dict(cls, data: dict) -> "Individual":
-        """Create Individual from dictionary representation of its attributes.
+        """
+        Create Individual from dictionary representation of its attributes.
 
         Parameters
         ----------

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import copy
 import inspect
 import math
@@ -109,11 +111,11 @@ class OptimizationProblem(Structure):
 
     def __init__(
         self,
-        name,
-        use_diskcache=True,
-        cache_directory=None,
-        log_level="INFO",
-    ):
+        name: str,
+        use_diskcache: bool = True,
+        cache_directory: Optional[str] = None,
+        log_level: str = 'INFO'
+    ) -> None:
         """
         Initialize OptimizationProblem.
 
@@ -149,11 +151,17 @@ class OptimizationProblem(Structure):
         self._multi_criteria_decision_functions = []
         self._callbacks = []
 
-    def untransforms(func):
+    def untransforms(func: tp.Callable) -> tp.Callable:
         """Untransform population or individual before calling function."""
 
         @wraps(func)
-        def wrapper_untransforms(self, x, *args, untransform=False, **kwargs):
+        def wrapper_untransforms(
+            self: OptimizationProblem,
+            x: npt.ArrayLike,
+            *args: Any,
+            untransform: Optional[bool] = False,
+            **kwargs: Any,
+        ) -> Any:
             x = np.array(x, ndmin=1)
             if untransform:
                 x = self.untransform(x)
@@ -162,13 +170,17 @@ class OptimizationProblem(Structure):
 
         return wrapper_untransforms
 
-    def gets_dependent_values(func):
+    def gets_dependent_values(func: tp.Callable) -> tp.Callable:
         """Get dependent values of individual before calling function."""
 
         @wraps(func)
         def wrapper_gets_dependent_values(
-            self, x, *args, get_dependent_values=False, **kwargs
-        ):
+            self: OptimizationProblem,
+            x: npt.ArrayLike,
+            *args: Any,
+            get_dependent_values: Optional[bool] = False,
+            **kwargs: Any,
+        ) -> Any:
             if get_dependent_values:
                 x = self.get_dependent_values(x)
 
@@ -176,11 +188,15 @@ class OptimizationProblem(Structure):
 
         return wrapper_gets_dependent_values
 
-    def ensures2d(func):
+    def ensures2d(func: tp.Callable) -> tp.Callable:
         """Ensure X array is an ndarray with ndmin=2."""
 
         @wraps(func)
-        def wrapper_ensures2d(self, X: npt.ArrayLike, *args, **kwargs) -> Any:
+        def wrapper_ensures2d(
+            self: OptimizationProblem,
+            X: npt.ArrayLike,
+            *args: Any, **kwargs: Any
+        ) -> Any:
             # Convert to 2D population
             X = np.array(X)
             X_2d = np.array(X, ndmin=2)
@@ -197,14 +213,17 @@ class OptimizationProblem(Structure):
 
         return wrapper_ensures2d
 
-    def ensures_minimization(scores):
+    def ensures_minimization(scores: npt.ArrayLike) -> tp.Callable:
         """Convert maximization problems to minimization problems."""
 
-        def wrap(func):
+        def wrap(func: tp.Callable) -> tp.Callable:
             @wraps(func)
             def wrapper_ensures_minimization(
-                self, *args, ensure_minimization=False, **kwargs
-            ):
+                self: OptimizationProblem,
+                *args: Any,
+                ensure_minimization: bool = False,
+                **kwargs: Any
+            ) -> Any:
                 s = func(self, *args, **kwargs)
 
                 if ensure_minimization:
@@ -216,7 +235,7 @@ class OptimizationProblem(Structure):
 
         return wrap
 
-    def transform_maximization(self, s, scores):
+    def transform_maximization(self: Any, s: list[float], scores: str | list) -> list[float]:
         """Transform maximization problems to minimization problems."""
         factors = []
         if scores == "objectives":
@@ -235,7 +254,7 @@ class OptimizationProblem(Structure):
         return s
 
     @property
-    def evaluation_objects(self):
+    def evaluation_objects(self) -> list:
         """list: Objects to be evaluated during optimization.
 
         See Also
@@ -251,11 +270,13 @@ class OptimizationProblem(Structure):
         return list(self._evaluation_objects_dict.values())
 
     @property
-    def evaluation_objects_dict(self):
+    def evaluation_objects_dict(self) -> dict:
         """dict: Evaluation objects names and objects."""
         return self._evaluation_objects_dict
 
-    def add_evaluation_object(self, evaluation_object, name=None):
+    def add_evaluation_object(
+        self, evaluation_object: Any, name: Optional[str] = None
+    ) -> None:
         """
         Add evaluation object to the optimization problem.
 
@@ -287,17 +308,17 @@ class OptimizationProblem(Structure):
         self._evaluation_objects_dict[name] = evaluation_object
 
     @property
-    def variables(self):
+    def variables(self) -> list:
         """list: List of all optimization variables."""
         return self._variables
 
     @property
-    def variable_names(self):
+    def variable_names(self) -> list:
         """list: Optimization variable names."""
         return [var.name for var in self.variables]
 
     @property
-    def n_variables(self):
+    def n_variables(self) -> int:
         """int: Number of optimization variables."""
         return len(self.variables)
 
@@ -317,7 +338,7 @@ class OptimizationProblem(Structure):
         return len(self.independent_variables)
 
     @property
-    def independent_variable_indices(self):
+    def independent_variable_indices(self) -> list:
         """list: Indices of indpeendent variables."""
         return [
             i
@@ -326,42 +347,42 @@ class OptimizationProblem(Structure):
         ]
 
     @property
-    def dependent_variables(self):
+    def dependent_variables(self) -> list:
         """list: OptimizationVaribles with dependencies."""
         return list(filter(lambda var: var.is_independent is False, self.variables))
 
     @property
-    def dependent_variable_names(self):
+    def dependent_variable_names(self) -> list:
         """list: Dependent optimization variable names."""
         return [var.name for var in self.dependent_variables]
 
     @property
-    def n_dependent_variables(self):
+    def n_dependent_variables(self) -> int:
         """int: Number of dependent optimization variables."""
         return len(self.dependent_variables)
 
     @property
-    def variables_dict(self):
+    def variables_dict(self) -> dict:
         """dict: All optimization variables indexed by variable name."""
         return {var.name: var for var in self.variables}
 
     @property
-    def variable_values(self):
-        """list: Values of optimization variables."""
+    def variable_values(self) -> np.ndarray:
+        """np.ndarray: Values of optimization variables."""
         return np.array([var.value for var in self.variables])
 
     def add_variable(
         self,
-        name,
-        evaluation_objects=-1,
-        parameter_path=None,
-        lb=-math.inf,
-        ub=math.inf,
-        transform=None,
-        indices=None,
-        significant_digits=None,
-        pre_processing=None,
-    ):
+        name: str,
+        evaluation_objects: Optional[list | object | int] = -1,
+        parameter_path: Optional[str] = None,
+        lb: float = -math.inf,
+        ub: float = math.inf,
+        transform: Optional[str] = None,
+        indices: Optional[int | tuple[int]] = None,
+        significant_digits: Optional[int] = None,
+        pre_processing: Optional[tp.Callable] = None
+    ) -> None:
         """
         Add optimization variable to the OptimizationProblem.
 
@@ -456,7 +477,7 @@ class OptimizationProblem(Structure):
 
         return var
 
-    def remove_variable(self, var_name):
+    def remove_variable(self, var_name: str) -> None:
         """
         Remove optimization variable from the OptimizationProblem.
 
@@ -483,7 +504,7 @@ class OptimizationProblem(Structure):
         self.__dict__.pop(var_name)
 
     @property
-    def parameter_variables(self):
+    def parameter_variables(self) -> dict:
         """dict: List of variables for every evaluation object parameter.
 
         Notes
@@ -527,7 +548,7 @@ class OptimizationProblem(Structure):
 
         return parameter_variables
 
-    def check_duplicate_variables(self):
+    def check_duplicate_variables(self) -> bool:
         """Raise warning if duplicate variables exist."""
         flag = True
 
@@ -566,8 +587,11 @@ class OptimizationProblem(Structure):
         return flag
 
     def add_variable_dependency(
-        self, dependent_variable, independent_variables, transform
-    ):
+        self,
+        dependent_variable: str,
+        independent_variables: str | list,
+        transform: tp.Callable,
+    ) -> None:
         """
         Add dependency between two optimization variables.
 
@@ -683,7 +707,11 @@ class OptimizationProblem(Structure):
 
     @untransforms
     @gets_dependent_values
-    def set_variables(self, x, evaluation_objects=-1):
+    def set_variables(
+        self,
+        x: npt.ArrayLike,
+        evaluation_objects: Optional[list | object | int] = -1
+    ) -> list:
         """
         Set the values from the x-vector to the EvaluationObjects.
 
@@ -699,7 +727,7 @@ class OptimizationProblem(Structure):
 
         Returns
         -------
-        evaluation_object : list
+        list
             Evaluation Objects with set parameters.
 
         Raises
@@ -755,7 +783,7 @@ class OptimizationProblem(Structure):
         if not self.cache.use_diskcache and parallelization_backend.n_cores != 1:
             raise CADETProcessError("Cannot use dict cache for multiprocessing.")
 
-        def target_wrapper(x):
+        def target_wrapper(x: npt.ArrayLike) -> np.ndarray:
             results = self._evaluate_individual(
                 target_functions=target_functions,
                 x=x,
@@ -772,7 +800,7 @@ class OptimizationProblem(Structure):
         self,
         target_functions: list[tp.Callable],
         x: npt.ArrayLike,
-        force=False,
+        force: bool = False,
     ) -> np.ndarray:
         """
         Evaluate target functions for set of parameters.
@@ -813,7 +841,7 @@ class OptimizationProblem(Structure):
 
         return results
 
-    def _evaluate(self, x, func, force=False):
+    def _evaluate(self, x: npt.ArrayLike, func: 'Evaluator', force: bool = False) -> np.ndarray:
         """
         Iterate over all evaluation objects and evaluate at x.
 
@@ -902,21 +930,27 @@ class OptimizationProblem(Structure):
         return results
 
     @property
-    def evaluators(self):
+    def evaluators(self) -> list['Evaluator']:
         """list: Evaluators in OptimizationProblem."""
         return self._evaluators
 
     @property
-    def evaluators_dict_reference(self):
+    def evaluators_dict_reference(self) -> dict:
         """dict: Evaluator objects indexed by original_callable."""
         return {evaluator.evaluator: evaluator for evaluator in self.evaluators}
 
     @property
-    def evaluators_dict(self):
+    def evaluators_dict(self) -> dict:
         """dict: Evaluator objects indexed by name."""
         return {evaluator.name: evaluator for evaluator in self.evaluators}
 
-    def add_evaluator(self, evaluator, name=None, args=None, kwargs=None):
+    def add_evaluator(
+        self,
+        evaluator: tp.Callable,
+        name: Optional[str] = None,
+        args: Optional[tuple] = None,
+        kwargs: Optional[dict] = None
+    ) -> None:
         """
         Add Evaluator to OptimizationProblem.
 
@@ -962,17 +996,17 @@ class OptimizationProblem(Structure):
         self._evaluators.append(evaluator)
 
     @property
-    def objectives(self):
+    def objectives(self) -> list:
         """list: Objective functions."""
         return self._objectives
 
     @property
-    def objective_names(self):
+    def objective_names(self) -> list:
         """list: Objective function names."""
         return [obj.name for obj in self.objectives]
 
     @property
-    def objective_labels(self):
+    def objective_labels(self) -> list:
         """list: Objective function metric labels."""
         labels = []
         for obj in self.objectives:
@@ -981,23 +1015,22 @@ class OptimizationProblem(Structure):
         return labels
 
     @property
-    def n_objectives(self):
+    def n_objectives(self) -> int:
         """int: Number of objectives."""
         return sum([obj.n_total_metrics for obj in self.objectives])
 
     def add_objective(
         self,
-        objective,
-        name=None,
-        n_objectives=1,
-        minimize=True,
-        bad_metrics=None,
-        evaluation_objects=-1,
-        labels=None,
-        requires=None,
-        *args,
-        **kwargs,
-    ):
+        objective: tp.callable | MetricBase,
+        name: Optional[str] = None,
+        n_objectives: Optional[int] = 1,
+        minimize: Optional[bool] = True,
+        bad_metrics: Optional[float | list[float]] = None,
+        evaluation_objects: None | int | list = -1,
+        labels: Optional[str] = None,
+        requires: Optional['Evaluator' | list] = None,
+        *args: Any, **kwargs: Any
+    ) -> None:
         """
         Add objective function to optimization problem.
 
@@ -1131,7 +1164,7 @@ class OptimizationProblem(Structure):
             force=force,
         )
 
-    def evaluate_objectives_population(self, *args, **kwargs):
+    def evaluate_objectives_population(self, *args: Any, **kwargs: Any) -> None:
         """
         Evaluate objective functions for each individual in a population.
 
@@ -1160,7 +1193,12 @@ class OptimizationProblem(Structure):
 
     @untransforms
     @gets_dependent_values
-    def objective_jacobian(self, x, ensure_minimization=False, dx=1e-3):
+    def objective_jacobian(
+        self,
+        x: npt.ArrayLike,
+        ensure_minimization: Optional[bool] = False,
+        dx: Optional[float] = 1e-3
+    ) -> np.ndarray:
         """
         Compute jacobian of objective functions using finite differences.
 
@@ -1168,12 +1206,14 @@ class OptimizationProblem(Structure):
         ----------
         x : array_like
             Value of the optimization variables in untransformed space.
+        ensure_minimization : bool, default=False
+            Flag that ensures minimization objective.
         dx : float
             Increment to x to use for determining the function gradient.
 
         Returns
         -------
-        jacobian: np.array
+        jacobian: npt.ArrayLike
             Value of the partial derivatives at point x.
 
         See Also
@@ -1182,23 +1222,26 @@ class OptimizationProblem(Structure):
         approximate_jac
         """
         jacobian = approximate_jac(
-            x, self.evaluate_objectives, dx, ensure_minimization=ensure_minimization
+            x,
+            self.evaluate_objectives,
+            dx,
+            ensure_minimization=ensure_minimization
         )
 
         return jacobian
 
     @property
-    def nonlinear_constraints(self):
+    def nonlinear_constraints(self) -> list:
         """list: Nonlinear constraint functions."""
         return self._nonlinear_constraints
 
     @property
-    def nonlinear_constraint_names(self):
+    def nonlinear_constraint_names(self) -> list:
         """list: Nonlinear constraint function names."""
         return [nonlincon.name for nonlincon in self.nonlinear_constraints]
 
     @property
-    def nonlinear_constraint_labels(self):
+    def nonlinear_constraint_labels(self) -> list:
         """list: Nonlinear constraint function metric labels."""
         labels = []
         for nonlincon in self.nonlinear_constraints:
@@ -1207,7 +1250,7 @@ class OptimizationProblem(Structure):
         return labels
 
     @property
-    def nonlinear_constraints_bounds(self):
+    def nonlinear_constraints_bounds(self) -> list:
         """list: Bounds of nonlinear constraint functions."""
         bounds = []
         for nonlincon in self.nonlinear_constraints:
@@ -1216,7 +1259,7 @@ class OptimizationProblem(Structure):
         return bounds
 
     @property
-    def n_nonlinear_constraints(self):
+    def n_nonlinear_constraints(self) -> int:
         """int: Number of nonlinear_constraints."""
         return sum(
             [nonlincon.n_total_metrics for nonlincon in self.nonlinear_constraints]
@@ -1224,18 +1267,17 @@ class OptimizationProblem(Structure):
 
     def add_nonlinear_constraint(
         self,
-        nonlincon,
-        name=None,
-        n_nonlinear_constraints=1,
-        bad_metrics=None,
-        evaluation_objects=-1,
-        bounds=0,
-        comparison_operator="le",
-        labels=None,
-        requires=None,
-        *args,
-        **kwargs,
-    ):
+        nonlincon: tp.Callable,
+        name: Optional[str] = None,
+        n_nonlinear_constraints: Optional[int] = 1,
+        bad_metrics: Optional[float | list[float]] = None,
+        evaluation_objects: Optional[int | list | object] = -1,
+        bounds: Optional[float | list[float]] = 0,
+        comparison_operator: Optional[str] = 'le',
+        labels: Optional[str] = None,
+        requires: Optional[list | 'Evaluator'] = None,
+        *args: Optional[tuple], **kwargs: Optional[dict]
+    ) -> None:
         """
         Add nonliner constraint function to optimization problem.
 
@@ -1382,7 +1424,7 @@ class OptimizationProblem(Structure):
             force=force,
         )
 
-    def evaluate_nonlinear_constraints_population(self, *args, **kwargs):
+    def evaluate_nonlinear_constraints_population(self, *args: Any, **kwargs: Any) -> None:
         """
         Evaluate nonlinear constraint functions for each individual in a population.
 
@@ -1465,7 +1507,9 @@ class OptimizationProblem(Structure):
 
         return G_transformed - bounds_transformed
 
-    def evaluate_nonlinear_constraints_violation_population(self, *args, **kwargs):
+    def evaluate_nonlinear_constraints_violation_population(
+        self, *args: Any, **kwargs: Any
+    ) -> None:
         """
         Evaluate nonlinear constraint violation for each individual in a population.
 
@@ -1498,7 +1542,9 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def check_nonlinear_constraints(
-        self, x: npt.ArrayLike, cv_nonlincon_tol: Optional[float | np.ndarray] = 0.0
+        self,
+        x: npt.ArrayLike,
+        cv_nonlincon_tol: Optional[float | np.ndarray] = 0.0
     ) -> bool:
         """
         Check if all nonlinear constraints are met.
@@ -1539,7 +1585,7 @@ class OptimizationProblem(Structure):
 
     @untransforms
     @gets_dependent_values
-    def nonlinear_constraint_jacobian(self, x, dx=1e-3):
+    def nonlinear_constraint_jacobian(self, x: npt.ArrayLike, dx: float = 1e-3) -> npt.ArrayLike:
         """
         Compute jacobian of the nonlinear constraints at point x.
 
@@ -1565,32 +1611,32 @@ class OptimizationProblem(Structure):
         return jacobian
 
     @property
-    def callbacks(self):
+    def callbacks(self) -> list:
         """list: Callback functions for recording progress."""
         return self._callbacks
 
     @property
-    def callback_names(self):
+    def callback_names(self) -> list:
         """list: Callback function names."""
         return [obj.name for obj in self.callbacks]
 
     @property
-    def n_callbacks(self):
+    def n_callbacks(self) -> int:
         """int: Number of callback functions."""
         return len(self.callbacks)
 
     def add_callback(
         self,
-        callback,
-        name=None,
-        evaluation_objects=-1,
-        requires=None,
-        frequency=1,
-        callbacks_dir=None,
-        keep_progress=False,
-        *args,
-        **kwargs,
-    ):
+        callback: tp.Callable,
+        name: Optional[str] = None,
+        evaluation_objects: Optional[int | list | object] = -1,
+        requires: Optional['Evaluator' | list] = None,
+        frequency: int = 1,
+        callbacks_dir: Optional[str] = None,
+        keep_progress: bool = False,
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """
         Add callback function for processing (intermediate) results.
 
@@ -1726,7 +1772,7 @@ class OptimizationProblem(Structure):
         if not self.cache.use_diskcache and parallelization_backend.n_cores != 1:
             raise CADETProcessError("Cannot use dict cache for multiprocessing.")
 
-        def evaluate_callbacks(ind):
+        def evaluate_callbacks(ind: Individual) -> None:
             for callback in self.callbacks:
                 if not (
                     current_iteration == "final"
@@ -1746,7 +1792,7 @@ class OptimizationProblem(Structure):
 
         parallelization_backend.evaluate(evaluate_callbacks, population)
 
-    def evaluate_callbacks_population(self, *args, **kwargs):
+    def evaluate_callbacks_population(self, *args: Any, **kwargs: Any) -> None:
         """
         Evaluate callbacks functions for each individual in a population.
 
@@ -1774,17 +1820,17 @@ class OptimizationProblem(Structure):
         self.evaluate_callbacks(*args, *kwargs)
 
     @property
-    def meta_scores(self):
+    def meta_scores(self) -> list:
         """list: Meta scores for multi criteria selection."""
         return self._meta_scores
 
     @property
-    def meta_score_names(self):
+    def meta_score_names(self) -> list:
         """list: Meta score function names."""
         return [meta_score.name for meta_score in self.meta_scores]
 
     @property
-    def meta_score_labels(self):
+    def meta_score_labels(self) -> int:
         """int: Meta score function metric labels."""
         labels = []
         for meta_score in self.meta_scores:
@@ -1793,19 +1839,19 @@ class OptimizationProblem(Structure):
         return labels
 
     @property
-    def n_meta_scores(self):
+    def n_meta_scores(self) -> int:
         """int: Number of meta score functions."""
         return sum([meta_score.n_total_metrics for meta_score in self.meta_scores])
 
     def add_meta_score(
         self,
-        meta_score,
-        name=None,
-        n_meta_scores=1,
-        minimize=True,
-        evaluation_objects=-1,
-        requires=None,
-    ):
+        meta_score: tp.Callable,
+        name: Optional[str] = None,
+        n_meta_scores: int = 1,
+        minimize: bool = True,
+        evaluation_objects: Optional[object | int | list] = -1,
+        requires: Optional['Evaluator' | list] = None
+    ) -> None:
         """
         Add Meta score to the OptimizationProblem.
 
@@ -1923,7 +1969,7 @@ class OptimizationProblem(Structure):
             force=force,
         )
 
-    def evaluate_meta_scores_population(self, *args, **kwargs):
+    def evaluate_meta_scores_population(self, *args: Any, **kwargs: Any) -> None:
         """
         Evaluate meta scores for each individual in a population.
 
@@ -1951,21 +1997,25 @@ class OptimizationProblem(Structure):
         self.evaluate_meta_scores(*args, *kwargs)
 
     @property
-    def multi_criteria_decision_functions(self):
+    def multi_criteria_decision_functions(self) -> list:
         """list: Multi criteria decision functions."""
         return self._multi_criteria_decision_functions
 
     @property
-    def multi_criteria_decision_function_names(self):
+    def multi_criteria_decision_function_names(self) -> list:
         """list: Multi criteria decision function names."""
         return [mcdf.name for mcdf in self.multi_criteria_decision_functions]
 
     @property
-    def n_multi_criteria_decision_functions(self):
+    def n_multi_criteria_decision_functions(self) -> int:
         """int: number of multi criteria decision functions."""
         return len(self.multi_criteria_decision_functions)
 
-    def add_multi_criteria_decision_function(self, decision_function, name=None):
+    def add_multi_criteria_decision_function(
+        self,
+        decision_function: tp.Callable,
+        name: Optional[str] = None
+    ) -> None:
         """
         Add multi criteria decision function to OptimizationProblem.
 
@@ -2038,7 +2088,7 @@ class OptimizationProblem(Structure):
         return pareto_population
 
     @property
-    def lower_bounds(self):
+    def lower_bounds(self) -> list:
         """list: Lower bounds of all OptimizationVariables.
 
         See Also
@@ -2049,7 +2099,7 @@ class OptimizationProblem(Structure):
         return [var.lb for var in self.variables]
 
     @property
-    def lower_bounds_transformed(self):
+    def lower_bounds_transformed(self) -> list:
         """list: Transformed lower bounds of all OptimizationVariables.
 
         See Also
@@ -2060,7 +2110,7 @@ class OptimizationProblem(Structure):
         return [var.transformer.lb for var in self.variables]
 
     @property
-    def lower_bounds_independent(self):
+    def lower_bounds_independent(self) -> list:
         """list: Lower bounds of independent OptimizationVariables.
 
         See Also
@@ -2071,7 +2121,7 @@ class OptimizationProblem(Structure):
         return [var.lb for var in self.independent_variables]
 
     @property
-    def lower_bounds_independent_transformed(self):
+    def lower_bounds_independent_transformed(self) -> list:
         """list: Transformed lower bounds of independent OptimizationVariables.
 
         See Also
@@ -2082,7 +2132,7 @@ class OptimizationProblem(Structure):
         return [var.transformer.lb for var in self.independent_variables]
 
     @property
-    def upper_bounds(self):
+    def upper_bounds(self) -> list:
         """list: Upper bounds of all OptimizationVariables.
 
         See Also
@@ -2093,7 +2143,7 @@ class OptimizationProblem(Structure):
         return [var.ub for var in self.variables]
 
     @property
-    def upper_bounds_transformed(self):
+    def upper_bounds_transformed(self) -> list:
         """list: Transformed upper bounds of all OptimizationVariables.
 
         See Also
@@ -2104,7 +2154,7 @@ class OptimizationProblem(Structure):
         return [var.transformer.ub for var in self.variables]
 
     @property
-    def upper_bounds_independent(self):
+    def upper_bounds_independent(self) -> list:
         """list: Upper bounds of independent OptimizationVariables.
 
         See Also
@@ -2115,7 +2165,7 @@ class OptimizationProblem(Structure):
         return [var.ub for var in self.independent_variables]
 
     @property
-    def upper_bounds_independent_transformed(self):
+    def upper_bounds_independent_transformed(self) -> list:
         """list: Transformed upper bounds of independent OptimizationVariables.
 
         See Also
@@ -2127,7 +2177,7 @@ class OptimizationProblem(Structure):
 
     @untransforms
     @gets_dependent_values
-    def evaluate_bounds(self, x):
+    def evaluate_bounds(self, x: npt.ArrayLike) -> np.ndarray:
         """
         Calculate bound violation.
 
@@ -2161,7 +2211,9 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def check_bounds(
-        self, x: npt.ArrayLike, cv_bounds_tol: Optional[float | np.ndarray] = 0.0
+        self,
+        x: npt.ArrayLike,
+        cv_bounds_tol: Optional[float | np.ndarray] = 0.0
     ) -> bool:
         """
         Check if all bound constraints are kept.
@@ -2206,7 +2258,7 @@ class OptimizationProblem(Structure):
         return flag
 
     @property
-    def linear_constraints(self):
+    def linear_constraints(self) -> list:
         """list: Linear inequality constraints of OptimizationProblem.
 
         See Also
@@ -2219,11 +2271,16 @@ class OptimizationProblem(Structure):
         return self._linear_constraints
 
     @property
-    def n_linear_constraints(self):
+    def n_linear_constraints(self) -> int:
         """int: Number of linear inequality constraints."""
         return len(self.linear_constraints)
 
-    def add_linear_constraint(self, opt_vars, lhs=1.0, b=0.0):
+    def add_linear_constraint(
+        self,
+        opt_vars: list[str],
+        lhs: Optional[float | list[float]] = 1.0,
+        b: Optional[float] = 0.0
+    ) -> None:
         """
         Add linear inequality constraints.
 
@@ -2231,7 +2288,7 @@ class OptimizationProblem(Structure):
         ----------
         opt_vars : list of strings
             Names of the OptimizationVariable to be added.
-        lhs : float or list, optional
+        lhs : float or list of float, optional
             Left-hand side / coefficients of the constraints.
             If scalar, same coefficient is used for all variables.
         b : float, optional
@@ -2270,7 +2327,7 @@ class OptimizationProblem(Structure):
 
         self._linear_constraints.append(lincon)
 
-    def remove_linear_constraint(self, index):
+    def remove_linear_constraint(self, index: int) -> None:
         """
         Remove linear inequality constraint.
 
@@ -2287,7 +2344,7 @@ class OptimizationProblem(Structure):
         del self._linear_constraints[index]
 
     @property
-    def A(self):
+    def A(self) -> np.ndarray:
         """
         np.ndarray: LHS Matrix of linear inequality constraints.
 
@@ -2310,7 +2367,7 @@ class OptimizationProblem(Structure):
         return A
 
     @property
-    def A_transformed(self):
+    def A_transformed(self) -> np.ndarray:
         """
         np.ndarray: LHS Matrix of linear inequality constraints in transformed space.
 
@@ -2342,7 +2399,7 @@ class OptimizationProblem(Structure):
         return A_t
 
     @property
-    def A_independent(self):
+    def A_independent(self) -> np.ndarray:
         """
         np.ndarray: LHS Matrix of linear inequality constraints for indep variables.
 
@@ -2355,7 +2412,7 @@ class OptimizationProblem(Structure):
         return self.A[:, self.independent_variable_indices]
 
     @property
-    def A_independent_transformed(self):
+    def A_independent_transformed(self) -> np.ndarray:
         """
         np.ndarray: LHS of lin ineqs for indep variables in transformed space.
 
@@ -2368,7 +2425,7 @@ class OptimizationProblem(Structure):
         return self.A_transformed[:, self.independent_variable_indices]
 
     @property
-    def b(self):
+    def b(self) -> np.ndarray:
         """
         np.ndarray: Vector form of linear constraints.
 
@@ -2384,7 +2441,7 @@ class OptimizationProblem(Structure):
         return np.array(b)
 
     @property
-    def b_transformed(self):
+    def b_transformed(self) -> np.ndarray:
         """list: Vector form of linear constraints in transformed space.
 
         Transforms b to multiple variables. When the bounds of an optimization
@@ -2396,7 +2453,6 @@ class OptimizationProblem(Structure):
         See Also
         --------
         b
-
         """
         # TODO: weird error when b_t is not float that b is not incremented
         b_t = self.b.copy()
@@ -2429,7 +2485,7 @@ class OptimizationProblem(Structure):
 
     @untransforms
     @gets_dependent_values
-    def evaluate_linear_constraints(self, x):
+    def evaluate_linear_constraints(self, x: npt.ArrayLike) -> np.ndarray:
         """
         Calculate value of linear inequality constraints at point x.
 
@@ -2456,7 +2512,9 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def check_linear_constraints(
-        self, x: npt.ArrayLike, cv_lincon_tol: Optional[float | np.ndarray] = 0.0
+        self,
+        x: npt.ArrayLike,
+        cv_lincon_tol: Optional[float | np.ndarray] = 0.0
     ) -> bool:
         """
         Check if linear inequality constraints are met at point x.
@@ -2505,7 +2563,7 @@ class OptimizationProblem(Structure):
         return flag
 
     @property
-    def linear_equality_constraints(self):
+    def linear_equality_constraints(self) -> list:
         """list: Linear equality constraints of OptimizationProblem.
 
         See Also
@@ -2518,11 +2576,17 @@ class OptimizationProblem(Structure):
         return self._linear_equality_constraints
 
     @property
-    def n_linear_equality_constraints(self):
+    def n_linear_equality_constraints(self) -> int:
         """int: Number of linear equality constraints."""
         return len(self.linear_equality_constraints)
 
-    def add_linear_equality_constraint(self, opt_vars, lhs=1, beq=0, eps=0.0):
+    def add_linear_equality_constraint(
+        self,
+        opt_vars: list[str],
+        lhs: Optional[float | list[float]] = 1.,
+        beq: Optional[float] = 0.0,
+        eps: Optional[float] = 0.0,
+    ) -> None:
         """
         Add linear equality constraints.
 
@@ -2533,8 +2597,11 @@ class OptimizationProblem(Structure):
         lhs : float or list, optional
             Left-hand side / coefficients of the constraints.
             If scalar, same coefficient is used for all variables.
-        b : float, optional
-            Constraint of inequality constraint. The default is zero.
+            The default is 1.0
+        beq : float, optional
+            Constraint of inequality constraint. The default is 0.0.
+        eps : float, optional
+            Error tolerance. The default is 0.0.
 
         Raises
         ------
@@ -2570,7 +2637,7 @@ class OptimizationProblem(Structure):
 
         self._linear_equality_constraints.append(lineqcon)
 
-    def remove_linear_equality_constraint(self, index):
+    def remove_linear_equality_constraint(self, index: int) -> None:
         """
         Remove linear equality constraint.
 
@@ -2587,7 +2654,7 @@ class OptimizationProblem(Structure):
         del self._linear_equality_constraints[index]
 
     @property
-    def Aeq(self):
+    def Aeq(self) -> np.ndarray:
         """
         np.ndarray: LHS Matrix form of linear equality constraints.
 
@@ -2607,7 +2674,7 @@ class OptimizationProblem(Structure):
         return Aeq
 
     @property
-    def Aeq_transformed(self):
+    def Aeq_transformed(self) -> np.ndarray:
         """
         np.ndarray: LHS Matrix of linear equality constraints in transformed space.
 
@@ -2639,7 +2706,7 @@ class OptimizationProblem(Structure):
         return Aeq_t
 
     @property
-    def Aeq_independent(self):
+    def Aeq_independent(self) -> np.ndarray:
         """
         np.ndarray: LHS Matrix of linear inequality constraints for indep variables.
 
@@ -2652,7 +2719,7 @@ class OptimizationProblem(Structure):
         return self.Aeq[:, self.independent_variable_indices]
 
     @property
-    def Aeq_independent_transformed(self):
+    def Aeq_independent_transformed(self) -> np.ndarray:
         """
         np.ndarray: LHS of lin ineqs for indep variables in transformed space.
 
@@ -2665,7 +2732,7 @@ class OptimizationProblem(Structure):
         return self.Aeq_transformed[:, self.independent_variable_indices]
 
     @property
-    def beq(self):
+    def beq(self) -> np.ndarray:
         """
         np.ndarray: Vector form of linear equality constraints.
 
@@ -2680,7 +2747,7 @@ class OptimizationProblem(Structure):
         return np.array(beq)
 
     @property
-    def beq_transformed(self):
+    def beq_transformed(self) -> np.ndarray:
         """list: Vector form of linear constraints in transformed space.
 
         Transforms b to multiple variables. When the bounds of an optimization
@@ -2724,7 +2791,7 @@ class OptimizationProblem(Structure):
         return beq_t
 
     @property
-    def eps_lineq(self):
+    def eps_lineq(self) -> np.ndarray:
         """
         np.array: Relaxation tolerance for linear equality constraints.
 
@@ -2738,7 +2805,7 @@ class OptimizationProblem(Structure):
 
     @untransforms
     @gets_dependent_values
-    def evaluate_linear_equality_constraints(self, x):
+    def evaluate_linear_equality_constraints(self, x: npt.ArrayLike) -> np.array:
         """
         Calculate value of linear equality constraints at point x.
 
@@ -2749,7 +2816,7 @@ class OptimizationProblem(Structure):
 
         Returns
         -------
-        constraints: np.array
+        constraints: npt.ArrayLike
             Value of the linear euqlity constraints at point x
 
         See Also
@@ -2859,12 +2926,12 @@ class OptimizationProblem(Structure):
         return untransform
 
     @property
-    def cached_steps(self):
+    def cached_steps(self) -> list:
         """list: Cached evaluation steps."""
         return self.objectives + self.nonlinear_constraints + self.meta_scores
 
     @property
-    def cache_directory(self):
+    def cache_directory(self) -> str:
         """pathlib.Path: Path for results cache database."""
         if self._cache_directory is None:
             if "XDG_CACHE_HOME" in os.environ:
@@ -2885,14 +2952,14 @@ class OptimizationProblem(Structure):
         return _cache_directory
 
     @cache_directory.setter
-    def cache_directory(self, cache_directory):
+    def cache_directory(self, cache_directory: str) -> None:
         self._cache_directory = cache_directory
 
-    def setup_cache(self, n_shards=1):
+    def setup_cache(self, n_shards: Optional[int] = 1) -> None:
         """Set up cache to store (intermediate) results."""
         self.cache = ResultsCache(self.use_diskcache, self.cache_directory, n_shards)
 
-    def delete_cache(self, reinit=False):
+    def delete_cache(self, reinit: Optional[bool] = False) -> None:
         """Delete cache with (intermediate) results."""
         try:
             self.cache.delete_database()
@@ -2901,7 +2968,7 @@ class OptimizationProblem(Structure):
         if reinit:
             self.setup_cache()
 
-    def prune_cache(self, tag=None, close=True):
+    def prune_cache(self, tag: Optional[str] = None, close: Optional[bool] = True) -> None:
         """
         Prune cache with (intermediate) results.
 
@@ -2940,10 +3007,10 @@ class OptimizationProblem(Structure):
         """
 
         class CustomModel:
-            def __init__(self, log_space_indices: list):
+            def __init__(self, log_space_indices: list) -> None:
                 self.log_space_indices = log_space_indices
 
-            def compute_negative_log_likelihood(self, x):
+            def compute_negative_log_likelihood(self, x: np.ndarray) -> float:
                 return np.sum(np.log(x[self.log_space_indices]))
 
         if include_dependent_variables:
@@ -3300,7 +3367,7 @@ class OptimizationProblem(Structure):
 
         return parameters
 
-    def check_linear_constraints_transforms(self):
+    def check_linear_constraints_transforms(self) -> bool:
         """
         Check that variables used in linear constraints only use linear transforms.
 
@@ -3331,7 +3398,7 @@ class OptimizationProblem(Structure):
 
         return flag
 
-    def check_linear_constraints_dependency(self):
+    def check_linear_constraints_dependency(self) -> bool:
         """
         Check that variables used in linear constraints are independent.
 
@@ -3362,7 +3429,7 @@ class OptimizationProblem(Structure):
 
         return flag
 
-    def check_config(self, ignore_linear_constraints=False):
+    def check_config(self, ignore_linear_constraints: Optional[bool] = False) -> bool:
         """
         Check if the OptimizationProblem is configured correctly.
 
@@ -3511,16 +3578,17 @@ class OptimizationVariable:
 
     def __init__(
         self,
-        name,
-        evaluation_objects=None,
-        parameter_path=None,
-        lb=-math.inf,
-        ub=math.inf,
-        transform=None,
-        indices=None,
-        significant_digits=None,
-        pre_processing=None,
-    ):
+        name: str,
+        evaluation_objects: Optional[list] = None,
+        parameter_path: Optional[str] = None,
+        lb: float = -math.inf,
+        ub: float = math.inf,
+        transform: Optional[TransformerBase] = None,
+        indices: Optional[int] = None,
+        significant_digits: Optional[int] = None,
+        pre_processing: Optional[tp.Callable] = None
+    ) -> None:
+        """Initialize Optimization Variable."""
         self.name = name
         self._value = None
 
@@ -3563,12 +3631,12 @@ class OptimizationVariable:
         self.pre_processing = pre_processing
 
     @property
-    def parameter_path(self):
+    def parameter_path(self) -> str:
         """str: Path of the evaluation_object parameter in dot notation."""
         return self._parameter_path
 
     @parameter_path.setter
-    def parameter_path(self, parameter_path):
+    def parameter_path(self, parameter_path: str) -> None:
         if parameter_path is not None:
             for eval_obj in self.evaluation_objects:
                 parameters = eval_obj.parameters.to_dict()  # Workaround addict issue #136
@@ -3577,25 +3645,25 @@ class OptimizationVariable:
         self._parameter_path = parameter_path
 
     @property
-    def parameter_sequence(self):
+    def parameter_sequence(self) -> tuple:
         """tuple: Tuple of parameters path elements."""
         return tuple(self.parameter_path.split("."))
 
     @property
-    def performer(self):
+    def performer(self) -> str:
         """str: The name of the performer of the variable."""
         if len(self.parameter_sequence) == 1:
             return self.parameter_sequence[0]
         else:
             return ".".join(self.parameter_sequence[:-1])
 
-    def _performer_obj(self, evaluation_object):
+    def _performer_obj(self, evaluation_object: Any) -> Any:
         if len(self.parameter_sequence) == 1:
             return evaluation_object
 
         return get_nested_attribute(evaluation_object, self.performer)
 
-    def _parameter_descriptor(self, evaluation_object):
+    def _parameter_descriptor(self, evaluation_object: Any) -> Any:
         performer_obj = self._performer_obj(evaluation_object)
         performer_class = type(performer_obj)
         try:
@@ -3608,7 +3676,7 @@ class OptimizationVariable:
 
         return descriptor
 
-    def _parameter_type(self, evaluation_object):
+    def _parameter_type(self, evaluation_object: Any) -> type:
         """type: Type of the parameter."""
         parameter_descriptor = self._parameter_descriptor(evaluation_object)
         if isinstance(parameter_descriptor, Typed):
@@ -3622,7 +3690,9 @@ class OptimizationVariable:
 
         return type(current_value)
 
-    def _get_parameter_shape(self, evaluation_object):
+    def _get_parameter_shape(
+        self, evaluation_object: object
+    ) -> list[tuple[int, ...]] | tuple[int, ...]:
         parameter_descriptor = self._parameter_descriptor(evaluation_object)
 
         if isinstance(parameter_descriptor, (Float, Integer, Bool)):
@@ -3647,7 +3717,7 @@ class OptimizationVariable:
 
         return shape
 
-    def _current_value(self, evaluation_object):
+    def _current_value(self, evaluation_object: Any) -> Any:
         parameter_descriptor = self._parameter_descriptor(evaluation_object)
 
         if parameter_descriptor is not None:
@@ -3658,7 +3728,7 @@ class OptimizationVariable:
                 get_nested_value(evaluation_object.parameters, self.parameter_path)
             )
 
-    def _is_sized(self, evaluation_object):
+    def _is_sized(self, evaluation_object: Any) -> bool:
         """bool: True if descriptor is instance of Sized. False otherwise."""
         parameter_descriptor = self._parameter_descriptor(evaluation_object)
 
@@ -3676,13 +3746,13 @@ class OptimizationVariable:
             )
         return np.array(current_value, dtype=object).size > 1
 
-    def _is_polynomial(self, evaluation_object):
+    def _is_polynomial(self, evaluation_object: Any) -> bool:
         """bool: True if descriptor is instance of NdPolynomial. False otherwise."""
         polynomial_parameters = evaluation_object.polynomial_parameters.to_dict()  # Workaround addict issue #136 # noqa: E501
         return check_nested(polynomial_parameters, self.parameter_path)
 
     @property
-    def indices(self) -> None | list[int]:
+    def indices(self) -> list[int]:
         """list[int]: List of parameter indices that are modified by optimization variable."""
         if self._indices is None:
             return
@@ -3704,7 +3774,7 @@ class OptimizationVariable:
         return indices
 
     @indices.setter
-    def indices(self, indices):
+    def indices(self, indices: list | int | None) -> None:
         if self.evaluation_objects is None and indices is not None:
             raise ValueError("Cannot specify indices without evaluation object.")
 
@@ -3738,7 +3808,7 @@ class OptimizationVariable:
             raise e
 
     @property
-    def is_index_specific(self):
+    def is_index_specific(self) -> bool:
         """bool: True if variable modifies entry of a parameter array, False otherwise."""
         if self.indices is not None:
             return True
@@ -3746,7 +3816,7 @@ class OptimizationVariable:
             return False
 
     @property
-    def full_indices(self):
+    def full_indices(self) -> list[int]:
         """list: Full indices."""
         full_indices = []
         for eval_ind, eval_obj in zip(self.indices, self.evaluation_objects):
@@ -3767,7 +3837,7 @@ class OptimizationVariable:
         return full_indices
 
     @property
-    def n_indices(self):
+    def n_indices(self) -> int:
         """int: Number of (full) indices."""
         if self.indices is not None:
             return len(self.full_indices)
@@ -3819,7 +3889,7 @@ class OptimizationVariable:
         """
         return self.transformer.untransform(x, *args, **kwargs)
 
-    def add_dependency(self, dependencies, transform):
+    def add_dependency(self, dependencies: list, transform: tp.Callable) -> None:
         """
         Add dependency of Variable on other Variables.
 
@@ -3843,17 +3913,17 @@ class OptimizationVariable:
         self.dependency_transform = transform
 
     @property
-    def dependencies(self):
+    def dependencies(self) -> list:
         """list: Independent variables on which the Variable depends."""
         return self._dependencies
 
     @property
-    def is_independent(self):
+    def is_independent(self) -> bool:
         """bool: True if Variable is independent, False otherwise."""
         return len(self.dependencies) == 0
 
     @property
-    def value(self):
+    def value(self) -> float:
         """float: Value of the parameter.
 
         If the Variable is not independent, the value is calculated from its
@@ -3876,13 +3946,13 @@ class OptimizationVariable:
             return value
 
     @value.setter
-    def value(self, value):
+    def value(self, value: Any) -> None:
         if not self.is_independent:
             raise CADETProcessError("Cannot set value for dependent variables")
 
         self.set_value(value)
 
-    def set_value(self, value):
+    def set_value(self, value: Any) -> None:
         """Set value to evaluation_objects."""
         if not np.isscalar(value):
             raise TypeError("Expected scalar value")
@@ -3965,7 +4035,7 @@ class OptimizationVariable:
             # Set the value:
             self._set_value_in_evaluation_object(eval_obj, new_value)
 
-    def _set_value_in_evaluation_object(self, evaluation_object, value):
+    def _set_value_in_evaluation_object(self, evaluation_object: object, value: Any) -> None:
         """Set the value to the evaluation object."""
         if self.pre_processing is not None:
             value = self.pre_processing(value)
@@ -3978,7 +4048,7 @@ class OptimizationVariable:
             evaluation_object.parameters = parameters
 
     @property
-    def transformed_bounds(self):
+    def transformed_bounds(self) -> list:
         """list: Transformed bounds of the parameter."""
         return [self.transform(self.lb), self.transform(self.ub)]
 
@@ -4008,14 +4078,20 @@ class Evaluator(Structure):
     args = Tuple()
     kwargs = Dict()
 
-    def __init__(self, evaluator, name, args=None, kwargs=None):
+    def __init__(
+        self,
+        evaluator: tp.Callable,
+        name: str,
+        args: Any = None,
+        kwargs: Any = None
+    ) -> None:
         self.evaluator = evaluator
         self.name = name
         self.args = args
         self.kwargs = kwargs
         self.id = uuid.uuid4()
 
-    def __call__(self, request):
+    def __call__(self, request: Any) -> Any:
         if self.args is None:
             args = ()
         else:
@@ -4047,16 +4123,16 @@ class Metric(Structure):
 
     def __init__(
         self,
-        func,
-        name,
-        n_metrics=1,
-        bad_metrics=np.inf,
-        evaluation_objects=None,
-        evaluators=None,
-        labels=None,
-        args=None,
-        kwargs=None,
-    ):
+        func: tp.Callable,
+        name: str,
+        n_metrics: int = 1,
+        bad_metrics: float | np.ndarray = np.inf,
+        evaluation_objects: Optional[object] = None,
+        evaluators: Optional[list[Evaluator]] = None,
+        labels: list[str] = None,
+        args: Any = None,
+        kwargs: Any = None
+    ) -> None:
         self.func = func
         self.name = name
 
@@ -4077,13 +4153,13 @@ class Metric(Structure):
         self.id = uuid.uuid4()
 
     @property
-    def n_total_metrics(self):
+    def n_total_metrics(self) -> int:
         """int: Total number of objectives."""
         n_eval_objects = len(self.evaluation_objects) if self.evaluation_objects else 1
         return n_eval_objects * self.n_metrics
 
     @property
-    def labels(self):
+    def labels(self) -> list[str]:
         """list: List of metric labels."""
         if self._labels is not None:
             return self._labels
@@ -4104,14 +4180,14 @@ class Metric(Structure):
         return labels
 
     @labels.setter
-    def labels(self, labels):
+    def labels(self, labels: list[str]) -> None:
         if labels is not None:
             if len(labels) != self.n_metrics:
                 raise CADETProcessError(f"Expected {self.n_metrics} labels.")
 
         self._labels = labels
 
-    def __call__(self, request):
+    def __call__(self, request: Any) -> np.ndarray:
         """
         Evaluate the metric function with the given request and predefined arguments.
 
@@ -4154,7 +4230,9 @@ class Objective(Metric):
     n_objectives = Metric.n_metrics
     minimize = Bool(default=True)
 
-    def __init__(self, *args, n_objectives=1, minimize=True, **kwargs):
+    def __init__(
+        self, *args: Any, n_objectives: int = 1, minimize: bool = True, **kwargs: Any
+    ) -> None:
         self.minimize = minimize
 
         super().__init__(*args, n_metrics=n_objectives, **kwargs)
@@ -4169,12 +4247,12 @@ class NonlinearConstraint(Metric):
 
     def __init__(
         self,
-        *args,
-        n_nonlinear_constraints=1,
-        bounds=0,
-        comparison_operator="le",
-        **kwargs,
-    ):
+        *args: Any,
+        n_nonlinear_constraints: int = 1,
+        bounds: int = 0,
+        comparison_operator: str = 'le',
+        **kwargs: Any
+    ) -> None:
         self.bounds = bounds
         self.comparison_operator = comparison_operator
 
@@ -4205,16 +4283,16 @@ class Callback(Structure):
 
     def __init__(
         self,
-        callback,
-        name,
-        evaluation_objects=None,
-        evaluators=None,
-        frequency=10,
-        callbacks_dir=None,
-        keep_progress=False,
-        args=None,
-        kwargs=None,
-    ):
+        callback: tp.Callable,
+        name: str,
+        evaluation_objects: Optional[list[object]] = None,
+        evaluators: Optional[list[Evaluator]] = None,
+        frequency: int = 10,
+        callbacks_dir: Optional[str] = None,
+        keep_progress: bool = False,
+        args: Any = None,
+        kwargs: Any = None
+    ) -> None:
         self.callback = callback
         self.name = name
 
@@ -4236,7 +4314,7 @@ class Callback(Structure):
 
         self.id = uuid.uuid4()
 
-    def cleanup(self, callbacks_dir, current_iteration):
+    def cleanup(self, callbacks_dir: str, current_iteration: int) -> None:
         if (
             not current_iteration % self.frequency == 0
             or current_iteration <= self.frequency
@@ -4259,7 +4337,7 @@ class Callback(Structure):
                 shutil.copy(file, new_directory)
             file.unlink()
 
-    def __call__(self, request, evaluation_object):
+    def __call__(self, request: Any, evaluation_object: Any) -> Any:
         if self.args is None:
             args = ()
         else:
@@ -4301,7 +4379,9 @@ class MetaScore(Metric):
     n_meta_scores = Metric.n_metrics
     minimize = Bool(default=True)
 
-    def __init__(self, *args, n_meta_scores=1, minimize=True, **kwargs):
+    def __init__(
+        self, *args: Any, n_meta_scores: int = 1, minimize: bool = True, **kwargs: Any
+    ) -> None:
         self.minimize = minimize
 
         super().__init__(*args, n_metrics=n_meta_scores, **kwargs)
@@ -4313,13 +4393,13 @@ class MultiCriteriaDecisionFunction(Structure):
     decision_function = Callable()
     name = String()
 
-    def __init__(self, decision_function, name):
+    def __init__(self, decision_function: tp.Callable, name: str) -> None:
         self.decision_function = decision_function
         self.name = name
 
         self.id = uuid.uuid4()
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
         return self.decision_function(*args, **kwargs)
 
     evaluate = __call__
@@ -4355,6 +4435,8 @@ def approximate_jac(
         `xk`.
     *args : args, optional
         Any other arguments that are to be passed to `f`.
+    **kwargs
+        Additional arguments that are to be passed to `f`.
 
     Returns
     -------

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -4,6 +4,7 @@ import math
 import os
 import random
 import shutil
+import typing as tp
 import uuid
 import warnings
 from functools import wraps
@@ -65,7 +66,8 @@ __all__ = ["OptimizationProblem", "OptimizationVariable"]
 
 @frozen_attributes
 class OptimizationProblem(Structure):
-    """Class for configuring optimization problems.
+    """
+    Class for configuring optimization problems.
 
     Stores information about
     - optimization variables
@@ -101,7 +103,6 @@ class OptimizationProblem(Structure):
         Meta score functions.
     multi_criteria_decision_functions : list
         Multi criteria decision functions.
-
     """
 
     name = String()
@@ -113,7 +114,8 @@ class OptimizationProblem(Structure):
         cache_directory=None,
         log_level="INFO",
     ):
-        """Initialize OptimizationProblem.
+        """
+        Initialize OptimizationProblem.
 
         Parameters
         ----------
@@ -126,7 +128,6 @@ class OptimizationProblem(Structure):
             Only has an effect if `use_diskcache` is True.
         log_level : {'DEBUG', INFO, WARN, ERROR, CRITICAL}, optional
             Log level. The default is 'INFO'.
-
         """
         self.name = name
         self.logger = log.get_logger(self.name, level=log_level)
@@ -255,7 +256,8 @@ class OptimizationProblem(Structure):
         return self._evaluation_objects_dict
 
     def add_evaluation_object(self, evaluation_object, name=None):
-        """Add evaluation object to the optimization problem.
+        """
+        Add evaluation object to the optimization problem.
 
         Parameters
         ----------
@@ -270,7 +272,6 @@ class OptimizationProblem(Structure):
             If evaluation object already exists in optimization problem.
             If evaluation object with same name already exists in optimization
             problem.
-
         """
         if name is None:
             name = str(evaluation_object)
@@ -361,7 +362,8 @@ class OptimizationProblem(Structure):
         significant_digits=None,
         pre_processing=None,
     ):
-        """Add optimization variable to the OptimizationProblem.
+        """
+        Add optimization variable to the OptimizationProblem.
 
         The function encapsulates the creation of OptimizationVariable objects
         in order to prevent invalid OptimizationVariables.
@@ -390,7 +392,7 @@ class OptimizationProblem(Structure):
         significant_digits : int, optional
             Number of significant figures to which variable can be rounded.
             If None, variable is not rounded. The default is None.
-        pre_processing : callable, optional
+        pre_processing : tp.Callable, optional
             Additional step to process the value before setting it. This function must
             accept a single argument (the value) and return the processed value.
 
@@ -404,7 +406,6 @@ class OptimizationProblem(Structure):
         evaluation_objects
         OptimizationVariable
         remove_variable
-
         """
         if name in self.variables_dict:
             raise CADETProcessError("Variable already exists")
@@ -456,7 +457,8 @@ class OptimizationProblem(Structure):
         return var
 
     def remove_variable(self, var_name):
-        """Remove optimization variable from the OptimizationProblem.
+        """
+        Remove optimization variable from the OptimizationProblem.
 
         Parameters
         ----------
@@ -471,7 +473,6 @@ class OptimizationProblem(Structure):
         See Also
         --------
         add_variable
-
         """
         try:
             var = self.variables_dict[var_name]
@@ -567,7 +568,8 @@ class OptimizationProblem(Structure):
     def add_variable_dependency(
         self, dependent_variable, independent_variables, transform
     ):
-        """Add dependency between two optimization variables.
+        """
+        Add dependency between two optimization variables.
 
         Parameters
         ----------
@@ -575,7 +577,7 @@ class OptimizationProblem(Structure):
             OptimizationVariable whose value will depend on other variables.
         independent_variables : {str, list}
             Independent variable name or list of independent variables names.
-        transform : callable
+        transform : tp.Callable
             Function to describe dependency.
             Must take all independent variables as arguments in the order as
             given by independent_variables.
@@ -590,7 +592,6 @@ class OptimizationProblem(Structure):
         --------
         OptimizationVariable
         add_variable
-
         """
         try:
             var = self.variables_dict[dependent_variable]
@@ -608,7 +609,8 @@ class OptimizationProblem(Structure):
     @ensures2d
     @untransforms
     def get_dependent_values(self, X_independent: npt.ArrayLike) -> np.ndarray:
-        """Determine values of dependent optimization variables.
+        """
+        Determine values of dependent optimization variables.
 
         Parameters
         ----------
@@ -624,7 +626,6 @@ class OptimizationProblem(Structure):
         -------
         np.ndarray
             Value of all optimization variables in untransformed space.
-
         """
         if X_independent.shape[1] != self.n_independent_variables:
             raise CADETProcessError(
@@ -645,7 +646,8 @@ class OptimizationProblem(Structure):
     @ensures2d
     @untransforms
     def get_independent_values(self, X: npt.ArrayLike) -> np.ndarray:
-        """Remove dependent values from x.
+        """
+        Remove dependent values from x.
 
         Parameters
         ----------
@@ -662,7 +664,6 @@ class OptimizationProblem(Structure):
         -------
         x_independent : np.ndarray
             Values of all independent optimization variables.
-
         """
         if X.shape[1] != self.n_variables:
             raise CADETProcessError(f"Expected {self.n_variables} value(s).")
@@ -683,7 +684,8 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def set_variables(self, x, evaluation_objects=-1):
-        """Set the values from the x-vector to the EvaluationObjects.
+        """
+        Set the values from the x-vector to the EvaluationObjects.
 
         Parameters
         ----------
@@ -711,14 +713,13 @@ class OptimizationProblem(Structure):
         --------
         OptimizationVariable
         evaluate
-
         """
         for variable, value in zip(self.variables, x):
             variable.set_value(value)
 
     def _evaluate_population(
         self,
-        target_functions: list[callable],
+        target_functions: list[tp.Callable],
         X: npt.ArrayLike,
         parallelization_backend: ParallelizationBackendBase | None = None,
         force: bool = False,
@@ -728,7 +729,7 @@ class OptimizationProblem(Structure):
 
         Parameters
         ----------
-        target_functions : list[callable]
+        target_functions : list[tp.Callable]
             List of evaluation targets (e.g. objectives).
         X : npt.ArrayLike
             Population to be evaluated in untransformed space.
@@ -769,7 +770,7 @@ class OptimizationProblem(Structure):
 
     def _evaluate_individual(
         self,
-        target_functions: list[callable],
+        target_functions: list[tp.Callable],
         x: npt.ArrayLike,
         force=False,
     ) -> np.ndarray:
@@ -780,7 +781,7 @@ class OptimizationProblem(Structure):
         ----------
         x : npt.ArrayLike
             Value of all optimization variables in untransformed space.
-        target_functions: list[callable],
+        target_functions: list[tp.Callable],
             Evaluation functions.
         force : bool
             If True, do not use cached results. The default is False.
@@ -795,7 +796,6 @@ class OptimizationProblem(Structure):
         evaluate_objectives
         evaluate_nonlinear_constraints
         _evaluate
-
         """
         x = np.asarray(x)
         results = np.empty((0,))
@@ -814,7 +814,8 @@ class OptimizationProblem(Structure):
         return results
 
     def _evaluate(self, x, func, force=False):
-        """Iterate over all evaluation objects and evaluate at x.
+        """
+        Iterate over all evaluation objects and evaluate at x.
 
         Parameters
         ----------
@@ -830,7 +831,6 @@ class OptimizationProblem(Structure):
         -------
         results : np.ndarray
             Results of the evaluation functions.
-
         """
         self.logger.debug(f"evaluate {str(func)} at {x}")
 
@@ -917,14 +917,15 @@ class OptimizationProblem(Structure):
         return {evaluator.name: evaluator for evaluator in self.evaluators}
 
     def add_evaluator(self, evaluator, name=None, args=None, kwargs=None):
-        """Add Evaluator to OptimizationProblem.
+        """
+        Add Evaluator to OptimizationProblem.
 
         Evaluators can be referenced by objective and constraint functions to
         perform preprocessing steps.
 
         Parameters
         ----------
-        evaluator : callable
+        evaluator : tp.Callable
             Evaluation function.
         name : str, optional
             Name of the evaluator.
@@ -939,7 +940,6 @@ class OptimizationProblem(Structure):
             If evaluator is not callable.
         CADETProcessError
             If evaluator with same name already exists.
-
         """
         if not callable(evaluator):
             raise TypeError("Expected callable evaluator.")
@@ -998,11 +998,12 @@ class OptimizationProblem(Structure):
         *args,
         **kwargs,
     ):
-        """Add objective function to optimization problem.
+        """
+        Add objective function to optimization problem.
 
         Parameters
         ----------
-        objective : callable or MetricBase
+        objective : tp.Callable or MetricBase
             Objective function.
         name : str, optional
             Name of the objective.
@@ -1038,7 +1039,6 @@ class OptimizationProblem(Structure):
         CADETProcessError
             If EvaluationObject is not found.
             If Evaluator is not found.
-
         """
         if not callable(objective):
             raise TypeError("Expected callable objective.")
@@ -1132,6 +1132,24 @@ class OptimizationProblem(Structure):
         )
 
     def evaluate_objectives_population(self, *args, **kwargs):
+        """
+        Evaluate objective functions for each individual in a population.
+
+        This method is deprecated and will be removed in a future version.
+        Use `evaluate_objectives` instead, which now supports the evaluation of nd arrays.
+
+        Parameters
+        ----------
+        *args : tuple
+            Variable length argument list.
+        **kwargs : dict
+            Arbitrary keyword arguments.
+
+        Notes
+        -----
+        This function issues a deprecation warning to indicate that it will be removed
+        in future versions. Use `evaluate_objectives` for similar functionality.
+        """
         warnings.warn(
             "This function is deprecated; use `evaluate_objectives` instead, which now "
             "directly supports the evaluation of nd arrays.",
@@ -1143,7 +1161,8 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def objective_jacobian(self, x, ensure_minimization=False, dx=1e-3):
-        """Compute jacobian of objective functions using finite differences.
+        """
+        Compute jacobian of objective functions using finite differences.
 
         Parameters
         ----------
@@ -1161,7 +1180,6 @@ class OptimizationProblem(Structure):
         --------
         objectives
         approximate_jac
-
         """
         jacobian = approximate_jac(
             x, self.evaluate_objectives, dx, ensure_minimization=ensure_minimization
@@ -1218,11 +1236,12 @@ class OptimizationProblem(Structure):
         *args,
         **kwargs,
     ):
-        """Add nonliner constraint function to optimization problem.
+        """
+        Add nonliner constraint function to optimization problem.
 
         Parameters
         ----------
-        nonlincon : callable
+        nonlincon : tp.Callable
             Nonlinear constraint function.
         name : str, optional
             Name of the nonlinear constraint.
@@ -1265,7 +1284,6 @@ class OptimizationProblem(Structure):
         CADETProcessError
             If EvaluationObject is not found.
             If Evaluator is not found.
-
         """
         if not callable(nonlincon):
             raise TypeError("Expected callable constraint function.")
@@ -1365,6 +1383,25 @@ class OptimizationProblem(Structure):
         )
 
     def evaluate_nonlinear_constraints_population(self, *args, **kwargs):
+        """
+        Evaluate nonlinear constraint functions for each individual in a population.
+
+        This method is deprecated and will be removed in a future version.
+        Use `evaluate_nonlinear_constraints` instead, which now supports the
+        evaluation of nd arrays.
+
+        Parameters
+        ----------
+        *args : tuple
+            Variable length argument list.
+        **kwargs : dict
+            Arbitrary keyword arguments.
+
+        Notes
+        -----
+        This function issues a deprecation warning to indicate that it will be removed
+        in future versions. Use `evaluate_nonlinear_constraints` for similar functionality.
+        """
         warnings.warn(
             "This function is deprecated; use `evaluate_nonlinear_constraints` "
             "instead, which now directly supports the evaluation of nd arrays.",
@@ -1429,6 +1466,26 @@ class OptimizationProblem(Structure):
         return G_transformed - bounds_transformed
 
     def evaluate_nonlinear_constraints_violation_population(self, *args, **kwargs):
+        """
+        Evaluate nonlinear constraint violation for each individual in a population.
+
+        This method is deprecated and will be removed in a future version.
+        Use `evaluate_nonlinear_constraints_violation` instead, which now supports
+        the evaluation of nd arrays.
+
+        Parameters
+        ----------
+        *args : tuple
+            Variable length argument list.
+        **kwargs : dict
+            Arbitrary keyword arguments.
+
+        Notes
+        -----
+        This function issues a deprecation warning to indicate that it will be removed
+        in future versions. Use `evaluate_nonlinear_constraints_violation` for similar
+        functionality.
+        """
         warnings.warn(
             "This function is deprecated; use "
             "`evaluate_nonlinear_constraints_violation` instead, which now directly "
@@ -1443,7 +1500,8 @@ class OptimizationProblem(Structure):
     def check_nonlinear_constraints(
         self, x: npt.ArrayLike, cv_nonlincon_tol: Optional[float | np.ndarray] = 0.0
     ) -> bool:
-        """Check if all nonlinear constraints are met.
+        """
+        Check if all nonlinear constraints are met.
 
         Parameters
         ----------
@@ -1482,7 +1540,8 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def nonlinear_constraint_jacobian(self, x, dx=1e-3):
-        """Compute jacobian of the nonlinear constraints at point x.
+        """
+        Compute jacobian of the nonlinear constraints at point x.
 
         Parameters
         ----------
@@ -1500,7 +1559,6 @@ class OptimizationProblem(Structure):
         --------
         nonlinear_constraint_fun
         approximate_jac
-
         """
         jacobian = approximate_jac(x, self.evaluate_nonlinear_constraints, dx)
 
@@ -1533,11 +1591,12 @@ class OptimizationProblem(Structure):
         *args,
         **kwargs,
     ):
-        """Add callback function for processing (intermediate) results.
+        """
+        Add callback function for processing (intermediate) results.
 
         Parameters
         ----------
-        callback : callable
+        callback : tp.Callable
             Callback function.
         name : str, optional
             Name of the callback.
@@ -1571,7 +1630,6 @@ class OptimizationProblem(Structure):
         CADETProcessError
             If EvaluationObject is not found.
             If Evaluator is not found.
-
         """
         if not callable(callback):
             raise TypeError("Expected callable callback.")
@@ -1689,6 +1747,24 @@ class OptimizationProblem(Structure):
         parallelization_backend.evaluate(evaluate_callbacks, population)
 
     def evaluate_callbacks_population(self, *args, **kwargs):
+        """
+        Evaluate callbacks functions for each individual in a population.
+
+        This method is deprecated and will be removed in a future version.
+        Use `evaluate_callbacks` instead, which now supports the evaluation of nd arrays.
+
+        Parameters
+        ----------
+        *args : tuple
+            Variable length argument list.
+        **kwargs : dict
+            Arbitrary keyword arguments.
+
+        Notes
+        -----
+        This function issues a deprecation warning to indicate that it will be removed
+        in future versions. Use `evaluate_callbacks` for similar functionality.
+        """
         warnings.warn(
             "This function is deprecated; use `evaluate_callbacks` instead, which now "
             "directly supports the evaluation of nd arrays.",
@@ -1730,11 +1806,12 @@ class OptimizationProblem(Structure):
         evaluation_objects=-1,
         requires=None,
     ):
-        """Add Meta score to the OptimizationProblem.
+        """
+        Add Meta score to the OptimizationProblem.
 
         Parameters
         ----------
-        meta_score : callable
+        meta_score : tp.Callable
             Objective function.
         name : str, optional
             Name of the meta score.
@@ -1762,7 +1839,6 @@ class OptimizationProblem(Structure):
         CADETProcessError
             If EvaluationObject is not found.
             If Evaluator is not found.
-
         """
         if not callable(meta_score):
             raise TypeError("Expected callable meta score.")
@@ -1848,6 +1924,24 @@ class OptimizationProblem(Structure):
         )
 
     def evaluate_meta_scores_population(self, *args, **kwargs):
+        """
+        Evaluate meta scores for each individual in a population.
+
+        This method is deprecated and will be removed in a future version.
+        Use `evaluate_meta_scores` instead, which now supports the evaluation of nd arrays.
+
+        Parameters
+        ----------
+        *args : tuple
+            Variable length argument list.
+        **kwargs : dict
+            Arbitrary keyword arguments.
+
+        Notes
+        -----
+        This function issues a deprecation warning to indicate that it will be removed
+        in future versions. Use `evaluate_meta_scores` for similar functionality.
+        """
         warnings.warn(
             "This function is deprecated; use `evaluate_meta_scores` instead, which now "
             "directly supports the evaluation of nd arrays.",
@@ -1872,11 +1966,12 @@ class OptimizationProblem(Structure):
         return len(self.multi_criteria_decision_functions)
 
     def add_multi_criteria_decision_function(self, decision_function, name=None):
-        """Add multi criteria decision function to OptimizationProblem.
+        """
+        Add multi criteria decision function to OptimizationProblem.
 
         Parameters
         ----------
-        decision_function : callable
+        decision_function : tp.Callable
             Multi criteria decision function.
         name : str, optional
             Name of the multi criteria decision function.
@@ -2033,7 +2128,8 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def evaluate_bounds(self, x):
-        """Calculate bound violation.
+        """
+        Calculate bound violation.
 
         Parameters
         ----------
@@ -2050,7 +2146,6 @@ class OptimizationProblem(Structure):
         check_bounds
         lower_bounds
         upper_bounds
-
         """
         # Calculate the residuals for lower bounds
         lower_residual = np.maximum(0, self.lower_bounds - x)
@@ -2068,7 +2163,8 @@ class OptimizationProblem(Structure):
     def check_bounds(
         self, x: npt.ArrayLike, cv_bounds_tol: Optional[float | np.ndarray] = 0.0
     ) -> bool:
-        """Check if all bound constraints are kept.
+        """
+        Check if all bound constraints are kept.
 
         Parameters
         ----------
@@ -2128,7 +2224,8 @@ class OptimizationProblem(Structure):
         return len(self.linear_constraints)
 
     def add_linear_constraint(self, opt_vars, lhs=1.0, b=0.0):
-        """Add linear inequality constraints.
+        """
+        Add linear inequality constraints.
 
         Parameters
         ----------
@@ -2151,7 +2248,6 @@ class OptimizationProblem(Structure):
         linear_constraints
         remove_linear_constraint
         linear_equality_constraints
-
         """
         if not isinstance(opt_vars, list):
             opt_vars = [opt_vars]
@@ -2175,7 +2271,8 @@ class OptimizationProblem(Structure):
         self._linear_constraints.append(lincon)
 
     def remove_linear_constraint(self, index):
-        """Remove linear inequality constraint.
+        """
+        Remove linear inequality constraint.
 
         Parameters
         ----------
@@ -2186,13 +2283,13 @@ class OptimizationProblem(Structure):
         --------
         add_linear_equality_constraint
         linear_equality_constraint
-
         """
         del self._linear_constraints[index]
 
     @property
     def A(self):
-        """np.ndarray: LHS Matrix of linear inequality constraints.
+        """
+        np.ndarray: LHS Matrix of linear inequality constraints.
 
         See Also
         --------
@@ -2202,7 +2299,6 @@ class OptimizationProblem(Structure):
         A_transformed
         A_independent
         A_independent_transformed
-
         """
         A = np.zeros((len(self.linear_constraints), len(self.variables)))
 
@@ -2215,14 +2311,14 @@ class OptimizationProblem(Structure):
 
     @property
     def A_transformed(self):
-        """np.ndarray: LHS Matrix of linear inequality constraints in transformed space.
+        """
+        np.ndarray: LHS Matrix of linear inequality constraints in transformed space.
 
         See Also
         --------
         A
         A_independent_transformed
         A_independent
-
         """
         A_t = self.A.copy()
         for a in A_t:
@@ -2247,33 +2343,34 @@ class OptimizationProblem(Structure):
 
     @property
     def A_independent(self):
-        """np.ndarray: LHS Matrix of linear inequality constraints for indep variables.
+        """
+        np.ndarray: LHS Matrix of linear inequality constraints for indep variables.
 
         See Also
         --------
         A
         A_transformed
         A_independent_transformed
-
         """
         return self.A[:, self.independent_variable_indices]
 
     @property
     def A_independent_transformed(self):
-        """np.ndarray: LHS of lin ineqs for indep variables in transformed space.
+        """
+        np.ndarray: LHS of lin ineqs for indep variables in transformed space.
 
         See Also
         --------
         A
         A_transformed
         A_independent
-
         """
         return self.A_transformed[:, self.independent_variable_indices]
 
     @property
     def b(self):
-        """np.ndarray: Vector form of linear constraints.
+        """
+        np.ndarray: Vector form of linear constraints.
 
         See Also
         --------
@@ -2281,7 +2378,6 @@ class OptimizationProblem(Structure):
         add_linear_constraint
         remove_linear_constraint
         b_transformed
-
         """
         b = [lincon["b"] for lincon in self.linear_constraints]
 
@@ -2334,7 +2430,8 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def evaluate_linear_constraints(self, x):
-        """Calculate value of linear inequality constraints at point x.
+        """
+        Calculate value of linear inequality constraints at point x.
 
         Parameters
         ----------
@@ -2351,7 +2448,6 @@ class OptimizationProblem(Structure):
         A
         b
         linear_constraints
-
         """
         values = np.array(x, ndmin=1)
 
@@ -2362,7 +2458,8 @@ class OptimizationProblem(Structure):
     def check_linear_constraints(
         self, x: npt.ArrayLike, cv_lincon_tol: Optional[float | np.ndarray] = 0.0
     ) -> bool:
-        """Check if linear inequality constraints are met at point x.
+        """
+        Check if linear inequality constraints are met at point x.
 
         Parameters
         ----------
@@ -2426,7 +2523,8 @@ class OptimizationProblem(Structure):
         return len(self.linear_equality_constraints)
 
     def add_linear_equality_constraint(self, opt_vars, lhs=1, beq=0, eps=0.0):
-        """Add linear equality constraints.
+        """
+        Add linear equality constraints.
 
         Parameters
         ----------
@@ -2449,7 +2547,6 @@ class OptimizationProblem(Structure):
         linear_equality_constraints
         remove_linear_equality_constraint
         linear_constraints
-
         """
         if not isinstance(opt_vars, list):
             opt_vars = [opt_vars]
@@ -2474,7 +2571,8 @@ class OptimizationProblem(Structure):
         self._linear_equality_constraints.append(lineqcon)
 
     def remove_linear_equality_constraint(self, index):
-        """Remove linear equality constraint.
+        """
+        Remove linear equality constraint.
 
         Parameters
         ----------
@@ -2485,20 +2583,19 @@ class OptimizationProblem(Structure):
         --------
         add_linear_equality_constraint
         linear_equality_constraint
-
         """
         del self._linear_equality_constraints[index]
 
     @property
     def Aeq(self):
-        """np.ndarray: LHS Matrix form of linear equality constraints.
+        """
+        np.ndarray: LHS Matrix form of linear equality constraints.
 
         See Also
         --------
         beq
         add_linear_equality_constraint
         remove_linear_equality_constraint
-
         """
         Aeq = np.zeros((len(self.linear_equality_constraints), len(self.variables)))
 
@@ -2511,7 +2608,8 @@ class OptimizationProblem(Structure):
 
     @property
     def Aeq_transformed(self):
-        """np.ndarray: LHS Matrix of linear equality constraints in transformed space.
+        """
+        np.ndarray: LHS Matrix of linear equality constraints in transformed space.
 
         See Also
         --------
@@ -2542,40 +2640,40 @@ class OptimizationProblem(Structure):
 
     @property
     def Aeq_independent(self):
-        """np.ndarray: LHS Matrix of linear inequality constraints for indep variables.
+        """
+        np.ndarray: LHS Matrix of linear inequality constraints for indep variables.
 
         See Also
         --------
         Aeq
         Aeq_transformed
         Aeq_independent_transformed
-
         """
         return self.Aeq[:, self.independent_variable_indices]
 
     @property
     def Aeq_independent_transformed(self):
-        """np.ndarray: LHS of lin ineqs for indep variables in transformed space.
+        """
+        np.ndarray: LHS of lin ineqs for indep variables in transformed space.
 
         See Also
         --------
         Aeq
         Aeq_transformed
         Aeq_independent
-
         """
         return self.Aeq_transformed[:, self.independent_variable_indices]
 
     @property
     def beq(self):
-        """np.ndarray: Vector form of linear equality constraints.
+        """
+        np.ndarray: Vector form of linear equality constraints.
 
         See Also
         --------
         Aeq
         add_linear_equality_constraint
         remove_linear_equality_constraint
-
         """
         beq = [lincon["beq"] for lincon in self.linear_equality_constraints]
 
@@ -2627,7 +2725,8 @@ class OptimizationProblem(Structure):
 
     @property
     def eps_lineq(self):
-        """np.array: Relaxation tolerance for linear equality constraints.
+        """
+        np.array: Relaxation tolerance for linear equality constraints.
 
         See Also
         --------
@@ -2640,7 +2739,8 @@ class OptimizationProblem(Structure):
     @untransforms
     @gets_dependent_values
     def evaluate_linear_equality_constraints(self, x):
-        """Calculate value of linear equality constraints at point x.
+        """
+        Calculate value of linear equality constraints at point x.
 
         Parameters
         ----------
@@ -2657,7 +2757,6 @@ class OptimizationProblem(Structure):
         Aeq
         beq
         linear_equality_constraints
-
         """
         values = np.array(x, ndmin=1)
 
@@ -2670,7 +2769,8 @@ class OptimizationProblem(Structure):
         x: npt.ArrayLike,
         cv_lineq_tol: Optional[float | np.ndarray] = 0.0,
     ) -> bool:
-        """Check if linear equality constraints are met at point x.
+        """
+        Check if linear equality constraints are met at point x.
 
         Parameters
         ----------
@@ -2710,7 +2810,8 @@ class OptimizationProblem(Structure):
 
     @ensures2d
     def transform(self, X_independent: npt.ArrayLike) -> np.ndarray:
-        """Transform independent optimization variables from untransformed parameter space.
+        """
+        Transform independent optimization variables from untransformed parameter space.
 
         Parameters
         ----------
@@ -2734,7 +2835,8 @@ class OptimizationProblem(Structure):
 
     @ensures2d
     def untransform(self, X_transformed: npt.ArrayLike) -> np.ndarray:
-        """Untransform the optimization variables from transformed parameter space.
+        """
+        Untransform the optimization variables from transformed parameter space.
 
         Parameters
         ----------
@@ -2787,7 +2889,7 @@ class OptimizationProblem(Structure):
         self._cache_directory = cache_directory
 
     def setup_cache(self, n_shards=1):
-        """Setup cache to store (intermediate) results."""
+        """Set up cache to store (intermediate) results."""
         self.cache = ResultsCache(self.use_diskcache, self.cache_directory, n_shards)
 
     def delete_cache(self, reinit=False):
@@ -2809,7 +2911,6 @@ class OptimizationProblem(Structure):
             Tag to be removed. The default is 'temp'.
         close : bool, optional
             If True, database will be closed after operation. The default is True.
-
         """
         self.cache.prune(tag, close)
 
@@ -2836,7 +2937,6 @@ class OptimizationProblem(Structure):
         -------
         problem
             hopsy.Problem
-
         """
 
         class CustomModel:
@@ -2911,7 +3011,8 @@ class OptimizationProblem(Structure):
         self,
         include_dependent_variables: Optional[bool] = True,
     ) -> list[float]:
-        """Compute chebychev center.
+        """
+        Compute chebychev center.
 
         The Chebyshev center is the center of the largest Euclidean ball that is fully
         contained within the polytope of the parameter space.
@@ -2944,7 +3045,8 @@ class OptimizationProblem(Structure):
         burn_in: Optional[int] = 100000,
         include_dependent_variables: Optional[bool] = True,
     ) -> np.ndarray:
-        """Create initial value within parameter space.
+        """
+        Create initial value within parameter space.
 
         Uses hopsy (Highly Optimized toolbox for Polytope Sampling) to retrieve
         uniformly distributed samples from the parameter space.
@@ -2972,7 +3074,6 @@ class OptimizationProblem(Structure):
         -------
         values : np.ndarray
             Initial values for starting the optimization.
-
         """
         burn_in = int(burn_in)
 
@@ -3189,7 +3290,8 @@ class OptimizationProblem(Structure):
         return pop
 
     @property
-    def parameters(self):
+    def parameters(self) -> dict:
+        """dict: Parameters of the optimization problem."""
         parameters = Dict()
 
         parameters.variables = {opt.name: opt.parameters for opt in self.variables}
@@ -3199,7 +3301,8 @@ class OptimizationProblem(Structure):
         return parameters
 
     def check_linear_constraints_transforms(self):
-        """Check that variables used in linear constraints only use linear transforms.
+        """
+        Check that variables used in linear constraints only use linear transforms.
 
         Returns
         -------
@@ -3229,7 +3332,8 @@ class OptimizationProblem(Structure):
         return flag
 
     def check_linear_constraints_dependency(self):
-        """Check that variables used in linear constraints are independent.
+        """
+        Check that variables used in linear constraints are independent.
 
         Returns
         -------
@@ -3259,7 +3363,8 @@ class OptimizationProblem(Structure):
         return flag
 
     def check_config(self, ignore_linear_constraints=False):
-        """Check if the OptimizationProblem is configured correctly.
+        """
+        Check if the OptimizationProblem is configured correctly.
 
         Parameters
         ----------
@@ -3270,7 +3375,6 @@ class OptimizationProblem(Structure):
         -------
         bool
             True if the OptimizationProblem is configured correctly, False otherwise.
-
         """
         flag = True
         if self.n_variables == 0:
@@ -3360,12 +3464,14 @@ class OptimizationProblem(Structure):
 
         return flag
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: Name of the optimization problem."""
         return self.name
 
 
 class OptimizationVariable:
-    """Class for setting the values for the optimization variables.
+    """
+    Class for setting the values for the optimization variables.
 
     Defines the attributes for optimization variables for creating an
     OptimizationVariable. Tries to get the attr of the evaluation_object.
@@ -3391,7 +3497,7 @@ class OptimizationVariable:
     significant_digits : int, optional
         Number of significant figures to which variable can be rounded.
         If None, variable is not rounded. The default is None.
-    pre_processing : callable, optional
+    pre_processing : tp.Callable, optional
         Additional step to process the value before setting it. This function must
         accept a single argument (the value) and return the processed value.
 
@@ -3576,7 +3682,8 @@ class OptimizationVariable:
         return check_nested(polynomial_parameters, self.parameter_path)
 
     @property
-    def indices(self):
+    def indices(self) -> None | list[int]:
+        """list[int]: List of parameter indices that are modified by optimization variable."""
         if self._indices is None:
             return
 
@@ -3713,13 +3820,14 @@ class OptimizationVariable:
         return self.transformer.untransform(x, *args, **kwargs)
 
     def add_dependency(self, dependencies, transform):
-        """Add dependency of Variable on other Variables.
+        """
+        Add dependency of Variable on other Variables.
 
         Parameters
         ----------
         dependencies : list
             List of OptimizationVariables to be added as dependencies.
-        transform: callable
+        transform: tp.Callable
             Transform function describing dependency on independent variables.
 
         Raises
@@ -3849,7 +3957,7 @@ class OptimizationVariable:
 
                 parameter_type = self._parameter_type(eval_obj)
                 if (
-                    parameter_type is not NumpyProxyArray 
+                    parameter_type is not NumpyProxyArray
                     and not isinstance(new_value, parameter_type)
                 ):
                     new_value = parameter_type(new_value.tolist())
@@ -3874,7 +3982,8 @@ class OptimizationVariable:
         """list: Transformed bounds of the parameter."""
         return [self.transform(self.lb), self.transform(self.ub)]
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: String representation."""
         if self.evaluation_objects is not None:
             string = (
                 f"{self.__class__.__name__}"
@@ -3923,7 +4032,8 @@ class Evaluator(Structure):
 
     evaluate = __call__
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: The name of the evaluator."""
         return self.name
 
 
@@ -4032,7 +4142,8 @@ class Metric(Structure):
 
     evaluate = __call__
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """Name of the metric."""
         return self.name
 
 
@@ -4071,7 +4182,8 @@ class NonlinearConstraint(Metric):
 
 
 class Callback(Structure):
-    """Wrapper class to evaluate callbacks.
+    """
+    Wrapper class to evaluate callbacks.
 
     Callable must implement function with the following signature:
         results : obj
@@ -4177,7 +4289,8 @@ class Callback(Structure):
 
     evaluate = __call__
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: Name of the callback."""
         return self.name
 
 
@@ -4211,18 +4324,26 @@ class MultiCriteriaDecisionFunction(Structure):
 
     evaluate = __call__
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: Name of the multi-criteria decision function."""
         return self.name
 
 
-def approximate_jac(xk, f, epsilon, args=(), **kwargs):
-    """Finite-difference approximation of the jacobian of a vector function
+def approximate_jac(
+        xk: npt.ArrayLike,
+        f: tp.Callable,
+        epsilon: npt.ArrayLike,
+        args: Any = (),
+        **kwargs: Any
+    ) -> np.ndarray:
+    r"""
+    Finite-difference approximation of the jacobian of a vector function.
 
     Parameters
     ----------
     xk : array_like
         The coordinate vector at which to determine the jacobian of `f`.
-    f : callable
+    f : tp.Callable
         The function of which to determine the jacobian (partial derivatives).
         Should take `xk` as first argument, other arguments to `f` can be
         supplied in ``*args``.  Should return a vector, the values of the
@@ -4232,7 +4353,7 @@ def approximate_jac(xk, f, epsilon, args=(), **kwargs):
         If a scalar, uses the same finite difference delta for all partial
         derivatives.  If an array, should contain one value per element of
         `xk`.
-    \\*args : args, optional
+    *args : args, optional
         Any other arguments that are to be passed to `f`.
 
     Returns
@@ -4248,7 +4369,6 @@ def approximate_jac(xk, f, epsilon, args=(), **kwargs):
                  f(xk[i] + epsilon[i]) - f(xk[i])
         f'[:,i] = ---------------------------------
                             epsilon[i]
-
     """
     f0 = np.array(f(*((xk,) + args)))
 

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -3466,7 +3466,7 @@ class OptimizationVariable:
         if parameter_path is not None:
             for eval_obj in self.evaluation_objects:
                 parameters = eval_obj.parameters.to_dict()  # Workaround addict issue #136
-                if not check_nested(eval_obj.parameters, parameter_path):
+                if not check_nested(parameters, parameter_path):
                     raise CADETProcessError("Not a valid Optimization variable")
         self._parameter_path = parameter_path
 

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -29,7 +29,8 @@ __all__ = ["OptimizerBase"]
 
 
 class OptimizerBase(Structure):
-    """BaseClass for optimization solver APIs.
+    """
+    BaseClass for optimization solver APIs.
 
     Holds the configuration of the individual solvers and gives an interface
     for calling the run method. The class has to convert the
@@ -144,7 +145,8 @@ class OptimizerBase(Structure):
         *args,
         **kwargs,
     ):
-        """Solve OptimizationProblem.
+        """
+        Solve OptimizationProblem.
 
         Parameters
         ----------
@@ -191,7 +193,6 @@ class OptimizerBase(Structure):
         OptimizationProblem
         OptimizationResults
         CADETProcess.optimization.ResultsCache
-
         """
         self._current_cache_entries = []
 
@@ -323,7 +324,8 @@ class OptimizerBase(Structure):
 
     @abstractmethod
     def _run(optimization_problem, x0=None, *args, **kwargs):
-        """Abstract Method for solving an optimization problem.
+        """
+        Abstract Method for solving an optimization problem.
 
         Parameters
         ----------
@@ -342,7 +344,6 @@ class OptimizerBase(Structure):
         ------
         CADETProcessError
             If solver doesn't terminate successfully
-
         """
         return
 
@@ -360,7 +361,6 @@ class OptimizerBase(Structure):
         flag : bool
             True if the optimization problem is supported and configured correctly,
             False otherwise.
-
         """
         flag = True
         if not optimization_problem.check_config(
@@ -421,7 +421,8 @@ class OptimizerBase(Structure):
         return flag
 
     def check_x0(self, optimization_problem, x0):
-        """Check the initial guess x0 for an optimization problem.
+        """
+        Check the initial guess x0 for an optimization problem.
 
         Parameters
         ----------
@@ -616,7 +617,8 @@ class OptimizerBase(Structure):
         current_generation,
         X_opt_transformed=None,
     ):
-        """Run post-processing of generation.
+        """
+        Run post-processing of generation.
 
         Notes
         -----
@@ -639,7 +641,6 @@ class OptimizerBase(Structure):
         X_opt_transformed : list, optional
             (Currently) best variable values in independent transformed space.
             If None, internal pareto front is used to determine best values.
-
         """
         F = self.optimization_problem.transform_maximization(
             F_minimized, scores="objectives"
@@ -684,6 +685,7 @@ class OptimizerBase(Structure):
         self._log_results(current_generation)
 
     def run_final_processing(self):
+        """Run post processing at the end of the optimization."""
         self.results.plot_figures(show=False)
         if self.optimization_problem.n_callbacks > 0:
             self._evaluate_callbacks(0, "final")
@@ -717,8 +719,9 @@ class OptimizerBase(Structure):
         return self.parallelization_backend._n_cores
 
     @n_cores.setter
-    def n_cores(self, n_cores):
+    def n_cores(self, n_cores: int):
         self.parallelization_backend.n_cores = n_cores
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: String representation."""
         return self.__class__.__name__

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -4,10 +4,11 @@ import time
 import warnings
 from abc import abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional, Sequence
 
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 
 from CADETProcess import CADETProcessError, log, settings
 from CADETProcess.dataStructure import (
@@ -125,7 +126,8 @@ class OptimizerBase(Structure):
         "similarity_tol",
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize OptimizerBase."""
         self.parallelization_backend = Joblib()
 
         super().__init__(*args, **kwargs)
@@ -133,18 +135,18 @@ class OptimizerBase(Structure):
     def optimize(
         self,
         optimization_problem: OptimizationProblem,
-        x0=None,
-        save_results=True,
-        results_directory=None,
-        use_checkpoint=False,
-        overwrite_results_directory=False,
-        exist_ok=True,
-        log_level="INFO",
-        reinit_cache=True,
-        delete_cache=True,
-        *args,
-        **kwargs,
-    ):
+        x0: Optional[list] = None,
+        save_results: Optional[bool] = True,
+        results_directory: Optional[str] = None,
+        use_checkpoint: Optional[bool] = False,
+        overwrite_results_directory: Optional[bool] = False,
+        exist_ok: Optional[bool] = True,
+        log_level: Optional[str] = "INFO",
+        reinit_cache: Optional[bool] = True,
+        delete_cache: bool = True,
+        *args: Any,
+        **kwargs: Any,
+    ) -> OptimizationResults:
         """
         Solve OptimizationProblem.
 
@@ -170,6 +172,8 @@ class OptimizerBase(Structure):
         log_level : str, optional
             log level. The default is "INFO".
         reinit_cache : bool, optional
+            If True, reinitialize the Cache. The default is True.
+        delete_cache : bool, optional
             If True, delete ResultsCache after finishing. The default is True.
         *args : TYPE
             Additional arguments for Optimizer.
@@ -323,7 +327,7 @@ class OptimizerBase(Structure):
         return results
 
     @abstractmethod
-    def _run(optimization_problem, x0=None, *args, **kwargs):
+    def _run(optimization_problem, x0: Optional[list] = None, *args: Any, **kwargs: Any) -> None:
         """
         Abstract Method for solving an optimization problem.
 
@@ -333,6 +337,10 @@ class OptimizerBase(Structure):
             Optimization problem to be solved.
         x0 : list, optional
             Initial population of independent variables in untransformed space.
+        *args : args, optional
+            Additional args that may be processed.
+        **kwargs : kwargs, optional
+            Additional kwargs that may be processed.
 
         Returns
         -------
@@ -347,7 +355,7 @@ class OptimizerBase(Structure):
         """
         return
 
-    def check_optimization_problem(self, optimization_problem):
+    def check_optimization_problem(self, optimization_problem: OptimizationProblem) -> bool:
         """
         Check if problem is configured correctly and supported by the optimizer.
 
@@ -420,7 +428,7 @@ class OptimizerBase(Structure):
 
         return flag
 
-    def check_x0(self, optimization_problem, x0):
+    def check_x0(self, optimization_problem: OptimizationProblem, x0: npt.ArrayLike) -> tuple:
         """
         Check the initial guess x0 for an optimization problem.
 
@@ -486,7 +494,14 @@ class OptimizerBase(Structure):
 
         return flag, x0
 
-    def _create_population(self, X_transformed, F, F_min, G, CV_nonlincon):
+    def _create_population(
+        self,
+        X_transformed: npt.ArrayLike,
+        F: npt.ArrayLike,
+        F_min: npt.ArrayLike,
+        G: npt.ArrayLike,
+        CV_nonlincon: npt.ArrayLike
+    ) -> Population:
         """Create new population from current generation for post procesing."""
         X_transformed = np.array(X_transformed, ndmin=2)
         F = np.array(F, ndmin=2)
@@ -538,7 +553,7 @@ class OptimizerBase(Structure):
 
         return population
 
-    def _create_pareto_front(self, X_opt_transformed):
+    def _create_pareto_front(self, X_opt_transformed: npt.ArrayLike) -> Population:
         """Create new pareto front from current generation for post procesing."""
         if X_opt_transformed is None:
             pareto_front = None
@@ -554,7 +569,7 @@ class OptimizerBase(Structure):
 
         return pareto_front
 
-    def _create_meta_front(self):
+    def _create_meta_front(self) -> Population:
         """Create new meta front from current generation for post procesing."""
         if self.optimization_problem.n_multi_criteria_decision_functions == 0:
             meta_front = None
@@ -573,7 +588,11 @@ class OptimizerBase(Structure):
 
         return meta_front
 
-    def _evaluate_callbacks(self, current_generation, sub_dir=None):
+    def _evaluate_callbacks(
+        self,
+        current_generation: int,
+        sub_dir: str = None
+    ) -> None:
         if sub_dir is not None:
             callbacks_dir = self.callbacks_dir / sub_dir
             callbacks_dir.mkdir(exist_ok=True, parents=True)
@@ -596,7 +615,7 @@ class OptimizerBase(Structure):
             parallelization_backend=self.parallelization_backend,
         )
 
-    def _log_results(self, current_generation):
+    def _log_results(self, current_generation: int) -> None:
         self.logger.info(f"Finished Generation {current_generation}.")
         for ind in self.results.meta_front:
             message = f"x: {ind.x}, f: {ind.f}"
@@ -610,13 +629,13 @@ class OptimizerBase(Structure):
 
     def run_post_processing(
         self,
-        X_transformed,
-        F_minimized,
-        G,
-        CV_nonlincon,
-        current_generation,
-        X_opt_transformed=None,
-    ):
+        X_transformed: Sequence[Sequence[float]],
+        F_minimized: Sequence[float | Sequence[float]],
+        G: Sequence[float | Sequence[float]],
+        CV_nonlincon: Sequence[float],
+        current_generation: int,
+        X_opt_transformed: Optional[Sequence[float]] = None
+    ) -> None:
         """
         Run post-processing of generation.
 
@@ -684,7 +703,7 @@ class OptimizerBase(Structure):
 
         self._log_results(current_generation)
 
-    def run_final_processing(self):
+    def run_final_processing(self) -> None:
         """Run post processing at the end of the optimization."""
         self.results.plot_figures(show=False)
         if self.optimization_problem.n_callbacks > 0:
@@ -692,7 +711,7 @@ class OptimizerBase(Structure):
         self.results.save_results("final")
 
     @property
-    def options(self):
+    def options(self) -> dict:
         """dict: Optimizer options."""
         return {
             opt: getattr(self, opt)
@@ -700,12 +719,12 @@ class OptimizerBase(Structure):
         }
 
     @property
-    def specific_options(self):
+    def specific_options(self) -> dict:
         """dict: Optimizer spcific options."""
         return {opt: getattr(self, opt) for opt in (self._specific_options)}
 
     @property
-    def n_cores(self):
+    def n_cores(self) -> int:
         """int: Proxy to the number of cores used by the parallelization backend.
 
         Note, this will always return the actual number of cores used, even if negative
@@ -714,12 +733,11 @@ class OptimizerBase(Structure):
         See Also
         --------
         parallelization_backend
-
         """
         return self.parallelization_backend._n_cores
 
     @n_cores.setter
-    def n_cores(self, n_cores: int):
+    def n_cores(self, n_cores: int) -> None:
         self.parallelization_backend.n_cores = n_cores
 
     def __str__(self) -> str:

--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -1,10 +1,13 @@
+import multiprocessing
 from abc import abstractmethod
 from collections.abc import Iterable
-import multiprocessing
 
-from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import Bool, Integer, RangedInteger, UnsignedInteger, Constant, String
-
+from CADETProcess.dataStructure import (
+    Constant,
+    RangedInteger,
+    Structure,
+    UnsignedInteger,
+)
 
 cpu_count = multiprocessing.cpu_count()
 
@@ -25,7 +28,7 @@ class ParallelizationBackendBase(Structure):
 
     n_cores = RangedInteger(lb=-cpu_count, ub=cpu_count, default=1)
 
-    _parameters = ['n_cores']
+    _parameters = ["n_cores"]
 
     @property
     def _n_cores(self):
@@ -107,6 +110,7 @@ class SequentialBackend(ParallelizationBackendBase):
 
 try:
     from joblib import Parallel, delayed
+
     __all__.append("Joblib")
 except ModuleNotFoundError:
     pass
@@ -126,7 +130,7 @@ class Joblib(ParallelizationBackendBase):
     """
 
     verbose = UnsignedInteger(default=0)
-    _parameters = ['verbose']
+    _parameters = ["verbose"]
 
     def evaluate(self, function: callable, population: Iterable) -> list:
         """Evaluate the function in parallalel for all individuals of the population.
@@ -152,6 +156,7 @@ class Joblib(ParallelizationBackendBase):
 
 try:
     import pathos
+
     __all__.append("Pathos")
 except ModuleNotFoundError:
     pass

--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -15,7 +15,8 @@ __all__ = ["ParallelizationBackendBase", "SequentialBackend"]
 
 
 class ParallelizationBackendBase(Structure):
-    """Base class for all parallelization backend adapters.
+    """
+    Base class for all parallelization backend adapters.
 
     Attributes
     ----------
@@ -23,7 +24,6 @@ class ParallelizationBackendBase(Structure):
         Number of cores to be used. If set to 0 or -1, all available cores are used.
         For values less than -1, (n_cpus + 1 + n_cores) are used.
         For example, for n_cores = -2, all CPUs but one are used.
-
     """
 
     n_cores = RangedInteger(lb=-cpu_count, ub=cpu_count, default=1)
@@ -42,7 +42,8 @@ class ParallelizationBackendBase(Structure):
 
     @abstractmethod
     def evaluate(self, function: callable, population: Iterable) -> list:
-        """Evaluate the function at all individuals in the population-list.
+        """
+        Evaluate the function at all individuals in the population-list.
 
         This method must be implemented by subclasses to evaluate the provided function
         at each individual in the given population. The evaluation can be performed
@@ -68,7 +69,8 @@ class ParallelizationBackendBase(Structure):
 
 
 class SequentialBackend(ParallelizationBackendBase):
-    """Sequential execution backend for evaluating the target function.
+    """
+    Sequential execution backend for evaluating the target function.
 
     This backend does not perform parallelization. It evaluates the function at each
     individual in the population sequentially, one by one.
@@ -78,13 +80,13 @@ class SequentialBackend(ParallelizationBackendBase):
     n_cores : int
         Number of cores to be used. This attribute is constant and always set to 1
         for the 'SequentialBackend'.
-
     """
 
     n_cores = Constant(value=1)
 
     def evaluate(self, function: callable, population: Iterable) -> list:
-        """Evaluate the function sequentially at all individuals in the population.
+        """
+        Evaluate the function sequentially at all individuals in the population.
 
         Since this is the 'SequentialBackend', the evaluation is done sequentially
         without any parallelization.
@@ -100,7 +102,6 @@ class SequentialBackend(ParallelizationBackendBase):
         -------
         list
             List of results of function evaluations.
-
         """
         results = []
         for ind in population:
@@ -117,7 +118,8 @@ except ModuleNotFoundError:
 
 
 class Joblib(ParallelizationBackendBase):
-    """Parallelization backend implementation using joblib.
+    """
+    Parallelization backend implementation using joblib.
 
     Attributes
     ----------
@@ -126,14 +128,14 @@ class Joblib(ParallelizationBackendBase):
         Above 50, the output is sent to stdout.
         The frequency of the messages increases with the verbosity level.
         If it's more than 10, all iterations are reported.
-
     """
 
     verbose = UnsignedInteger(default=0)
     _parameters = ["verbose"]
 
     def evaluate(self, function: callable, population: Iterable) -> list:
-        """Evaluate the function in parallalel for all individuals of the population.
+        """
+        Evaluate the function in parallalel for all individuals of the population.
 
         Parameters
         ----------
@@ -146,7 +148,6 @@ class Joblib(ParallelizationBackendBase):
         -------
         list
             List of results of function evaluations.
-
         """
         backend = Parallel(n_jobs=self.n_cores, verbose=self.verbose)
         results = backend(delayed(function)(x) for x in population)
@@ -166,7 +167,8 @@ class Pathos(ParallelizationBackendBase):
     """Parallelization backend using the pathos library."""
 
     def evaluate(self, function: callable, population: Iterable) -> list:
-        """Evaluate the function in parallalel for all individuals of the population.
+        """
+        Evaluate the function in parallalel for all individuals of the population.
 
         Parameters
         ----------
@@ -179,7 +181,6 @@ class Pathos(ParallelizationBackendBase):
         -------
         list
             List of results of function evaluations.
-
         """
         with pathos.pools.ProcessPool(ncpus=self.n_cores) as pool:
             results = pool.map(function, population)

--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -31,7 +31,7 @@ class ParallelizationBackendBase(Structure):
     _parameters = ["n_cores"]
 
     @property
-    def _n_cores(self):
+    def _n_cores(self) -> int:
         if self.n_cores == 0:
             return cpu_count
 
@@ -63,7 +63,7 @@ class ParallelizationBackendBase(Structure):
         """
         pass
 
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the class name as a string."""
         return self.__class__.__name__
 

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -1,21 +1,20 @@
-from pathlib import Path
-from typing import Optional
 import uuid
 import warnings
+from pathlib import Path
+from typing import Optional
 
-from addict import Dict
 import corner
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
-import matplotlib.pyplot as plt
+from addict import Dict
 from pymoo.visualization.scatter import Scatter
 
-from CADETProcess import CADETProcessError
-from CADETProcess import plotting
-from CADETProcess.optimization.individual import hash_array, Individual
+from CADETProcess import CADETProcessError, plotting
+from CADETProcess.optimization.individual import Individual, hash_array
 
 
-class Population():
+class Population:
     """Collection of Individuals evaluated during Optimization.
 
     Attributes
@@ -446,16 +445,18 @@ class Population():
             return space_fig_all, space_axs_all
 
     def plot_objectives(
-            self,
-            figs=None, axs=None,
-            include_meta=True,
-            plot_infeasible=True,
-            plot_individual=False,
-            autoscale=True,
-            color_feas='blue',
-            color_infeas='red',
-            show=True,
-            plot_directory=None):
+        self,
+        figs=None,
+        axs=None,
+        include_meta=True,
+        plot_infeasible=True,
+        plot_individual=False,
+        autoscale=True,
+        color_feas="blue",
+        color_infeas="red",
+        show=True,
+        plot_directory=None,
+    ):
         """Plot the objective function values for each design variable.
 
         Parameters
@@ -581,9 +582,9 @@ class Population():
             plot_directory = Path(plot_directory)
             if plot_individual:
                 for i, fig in enumerate(figs):
-                    fig.savefig(f'{plot_directory / "objectives"}_{i}.png')
+                    fig.savefig(f"{plot_directory / 'objectives'}_{i}.png")
             else:
-                figs[0].savefig(f'{plot_directory / "objectives"}.png')
+                figs[0].savefig(f"{plot_directory / 'objectives'}.png")
 
         if plot_individual:
             return figs, axs
@@ -618,15 +619,15 @@ class Population():
         return plot
 
     def plot_pareto(
-            self,
-            plot=None,
-            include_meta=True,
-            plot_infeasible=True,
-            color_feas="blue",
-            color_infeas="red",
-            show=True,
-            plot_directory=None,
-            ):
+        self,
+        plot=None,
+        include_meta=True,
+        plot_infeasible=True,
+        color_feas="blue",
+        color_infeas="red",
+        show=True,
+        plot_directory=None,
+    ):
         """Plot pairwise Pareto fronts for each generation in the optimization.
 
         The Pareto front represents the optimal solutions that cannot be improved in one
@@ -683,7 +684,7 @@ class Population():
 
         if plot_directory is not None:
             plot_directory = Path(plot_directory)
-            plot.save(f'{plot_directory / "pareto.png"}')
+            plot.save(f"{plot_directory / 'pareto.png'}")
 
         if not show:
             plt.close(plot.fig)
@@ -693,15 +694,15 @@ class Population():
         return plot
 
     def plot_pairwise(
-            self,
-            fig: Optional[plt.Figure] = None,
-            axs: Optional[npt.NDArray[plt.Axes]] = None,
-            n_bins: int = 20,
-            use_transformed=False,
-            autoscale: bool = True,
-            show=True,
-            plot_directory=None,
-            ) -> tuple[plt.Figure, np.ndarray]:
+        self,
+        fig: Optional[plt.Figure] = None,
+        axs: Optional[npt.NDArray[plt.Axes]] = None,
+        n_bins: int = 20,
+        use_transformed=False,
+        autoscale: bool = True,
+        show=True,
+        plot_directory=None,
+    ) -> tuple[plt.Figure, np.ndarray]:
         """
         Create a pairplot using Matplotlib.
 
@@ -739,12 +740,17 @@ class Population():
             labels = self.variable_names
 
         fig, axs = plot_pairwise(
-            x, labels, n_bins=n_bins, autoscale=autoscale, fig=fig, axs=axs,
+            x,
+            labels,
+            n_bins=n_bins,
+            autoscale=autoscale,
+            fig=fig,
+            axs=axs,
         )
 
         if plot_directory is not None:
             plot_directory = Path(plot_directory)
-            fig.savefig(f'{plot_directory / "pairwise.png"}')
+            fig.savefig(f"{plot_directory / 'pairwise.png'}")
 
         if not show:
             plt.close(fig)
@@ -805,7 +811,7 @@ class Population():
 
         if plot_directory is not None:
             plot_directory = Path(plot_directory)
-            fig.savefig(f'{plot_directory / "corner.png"}')
+            fig.savefig(f"{plot_directory / 'corner.png'}")
 
         if not show:
             plt.close(fig)
@@ -1067,10 +1073,7 @@ class ParetoFront(Population):
         ParetoFront
             ParetoFront created from data.
         """
-        front = cls(
-            similarity_tol=data.get("similarity_tol"),
-            id=data["id"]
-        )
+        front = cls(similarity_tol=data.get("similarity_tol"), id=data["id"])
         for individual_data in data["individuals"].values():
             individual = Individual.from_dict(individual_data)
             front.add_individual(individual)
@@ -1079,13 +1082,13 @@ class ParetoFront(Population):
 
 
 def plot_pairwise(
-        population: npt.ArrayLike,
-        variable_names: Optional[list[str]] = None,
-        n_bins: int = 20,
-        autoscale: bool = True,
-        fig: Optional[plt.Figure] = None,
-        axs: Optional[npt.NDArray[plt.Axes]] = None,
-        ) -> tuple[plt.Figure, npt.NDArray[plt.Axes]]:
+    population: npt.ArrayLike,
+    variable_names: Optional[list[str]] = None,
+    n_bins: int = 20,
+    autoscale: bool = True,
+    fig: Optional[plt.Figure] = None,
+    axs: Optional[npt.NDArray[plt.Axes]] = None,
+) -> tuple[plt.Figure, npt.NDArray[plt.Axes]]:
     """
     Create a pairwise scatter plot for all variables of a population.
 
@@ -1126,10 +1129,12 @@ def plot_pairwise(
 
     if fig is None and axs is None:
         fig, axs = plt.subplots(
-            n_variables, n_variables,
+            n_variables,
+            n_variables,
             figsize=(6 * n_variables, 5 * n_variables),
-            sharex="col", sharey="row",
-            squeeze=False
+            sharex="col",
+            sharey="row",
+            squeeze=False,
         )
 
     if axs.shape != (n_variables, n_variables):
@@ -1162,13 +1167,11 @@ def plot_pairwise(
                 # Determine binning strategy
                 if scale_i:
                     bins = np.geomspace(
-                        population[:, i].min(), population[:, i].max(), n_bins+1
+                        population[:, i].min(), population[:, i].max(), n_bins + 1
                     )
                 else:
                     bins = np.linspace(
-                        population[:, i].min(),
-                        population[:, i].max(),
-                        n_bins+1
+                        population[:, i].min(), population[:, i].max(), n_bins + 1
                     )
 
                 ax_hist.hist(
@@ -1177,7 +1180,7 @@ def plot_pairwise(
                     alpha=0.7,
                     color="blue",
                     edgecolor="black",
-                    align="mid"
+                    align="mid",
                 )
                 ax_hist.set_yticks([])  # Hide y-ticks for the histogram
             else:

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -1,7 +1,9 @@
+from __future__ import annotations
+
 import uuid
 import warnings
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import corner
 import matplotlib.pyplot as plt
@@ -15,7 +17,8 @@ from CADETProcess.optimization.individual import Individual, hash_array
 
 
 class Population:
-    """Collection of Individuals evaluated during Optimization.
+    """
+    Collection of Individuals evaluated during Optimization.
 
     Attributes
     ----------
@@ -26,11 +29,11 @@ class Population:
     --------
     CADETProcess.optimization.Individual
     ParetoFront
-
     """
 
     def __init__(self, id=None):
-        """Initialize the Population.
+        """
+        Initialize the Population.
 
         Parameters
         ----------
@@ -85,8 +88,8 @@ class Population:
         return self.individuals[0].n_m
 
     @property
-    def dimensions(self) -> tuple[int]:
-        """tuple: Individual dimensions (n_x, n_f, n_g, n_m)"""
+    def dimensions(self) -> tuple[int] | None:
+        """tuple: Individual dimensions (n_x, n_f, n_g, n_m)."""
         if self.n_individuals == 0:
             return None
 
@@ -135,7 +138,8 @@ class Population:
         individual: Individual,
         ignore_duplicate: bool | None = True,
     ):
-        """Add individual to population.
+        """
+        Add individual to population.
 
         Parameters
         ----------
@@ -151,7 +155,6 @@ class Population:
         CADETProcessError
             If the individual does not match the dimensions.
             If the individual already exists.
-
         """
         if not isinstance(individual, Individual):
             raise TypeError("Expected Individual")
@@ -168,7 +171,8 @@ class Population:
         self._individuals[individual.id] = individual
 
     def remove_individual(self, individual):
-        """Remove an individual from the population.
+        """
+        Remove an individual from the population.
 
         Parameters
         ----------
@@ -181,7 +185,6 @@ class Population:
             If the individual is not an instance of Individual.
         CADETProcessError
             If the individual is not in the population.
-
         """
         if not isinstance(individual, Individual):
             raise TypeError("Expected Individual")
@@ -191,7 +194,8 @@ class Population:
         self._individuals.pop(individual.id)
 
     def update(self, other):
-        """Update the population with individuals from another population.
+        """
+        Update the population with individuals from another population.
 
         Parameters
         ----------
@@ -204,7 +208,6 @@ class Population:
             If other is not an instance of Population.
         CADETProcessError
             If the dimensions do not match.
-
         """
         if not isinstance(other, Population):
             raise TypeError("Expected Population")
@@ -393,11 +396,16 @@ class Population:
 
     @property
     def is_feasilbe(self) -> bool:
-        """np.array: False if any constraint is not met. True otherwise."""
+        """
+        np.array: False if any constraint is not met.
+
+        True otherwise.
+        """
         return np.array([ind.is_feasible for ind in self.individuals])
 
     def setup_objectives_figure(self, include_meta=True, plot_individual=False):
-        """Set up figure and axes for plotting objectives.
+        """
+        Set up figure and axes for plotting objectives.
 
         Parameters
         ----------
@@ -457,7 +465,8 @@ class Population:
         show=True,
         plot_directory=None,
     ):
-        """Plot the objective function values for each design variable.
+        """
+        Plot the objective function values for each design variable.
 
         Parameters
         ----------
@@ -592,7 +601,8 @@ class Population:
             return figs[0], axs
 
     def setup_pareto(self, include_meta: bool = False):
-        """Set up base figure for plotting the Pareto front.
+        """
+        Set up base figure for plotting the Pareto front.
 
         Parameters
         ----------
@@ -628,7 +638,8 @@ class Population:
         show=True,
         plot_directory=None,
     ):
-        """Plot pairwise Pareto fronts for each generation in the optimization.
+        """
+        Plot pairwise Pareto fronts for each generation in the optimization.
 
         The Pareto front represents the optimal solutions that cannot be improved in one
         objective without sacrificing another. The method shows a pairwise Pareto plot,
@@ -758,7 +769,8 @@ class Population:
         return fig, axs
 
     def plot_corner(self, use_transformed=False, show=True, plot_directory=None):
-        """Create a corner plot of the independent variables.
+        """
+        Create a corner plot of the independent variables.
 
         Parameters
         ----------
@@ -817,7 +829,8 @@ class Population:
             plt.close(fig)
 
     def __contains__(self, other):
-        """Check if the population contains a specific individual.
+        """
+        Check if the population contains a specific individual.
 
         Parameters
         ----------
@@ -842,7 +855,8 @@ class Population:
             return False
 
     def __getitem__(self, x):
-        """Get an individual from the population using its hashable representation.
+        """
+        Get an individual from the population using its hashable representation.
 
         Parameters
         ----------
@@ -859,7 +873,8 @@ class Population:
         return self._individuals[key]
 
     def __len__(self):
-        """Get the number of individuals in the population.
+        """
+        Get the number of individuals in the population.
 
         Returns
         -------
@@ -869,7 +884,8 @@ class Population:
         return self.n_individuals
 
     def __iter__(self):
-        """Iterate over the individuals in the population.
+        """
+        Iterate over the individuals in the population.
 
         Returns
         -------
@@ -879,7 +895,8 @@ class Population:
         return iter(self.individuals)
 
     def to_dict(self):
-        """Convert Population to a dictionary.
+        """
+        Convert Population to a dictionary.
 
         Returns
         -------
@@ -896,7 +913,8 @@ class Population:
 
     @classmethod
     def from_dict(cls, data):
-        """Create a Population from a dictionary.
+        """
+        Create a Population from a dictionary.
 
         Parameters
         ----------
@@ -919,26 +937,43 @@ class Population:
 
 
 class ParetoFront(Population):
-    def __init__(self, similarity_tol=1e-1, *args, **kwargs):
+    """Class representing a Pareto front in a multi-objective optimization problem."""
+
+    def __init__(
+            self,
+            similarity_tol: float = 1e-1,
+            *args: Any,
+            **kwargs: Any
+    ) -> None:
+        """
+        Initialize a ParetoFront with a specified similarity tolerance.
+
+        Parameters
+        ----------
+        similarity_tol : float, optional
+            Tolerance for similarity between individuals. Default is 1e-1.
+        *args : tuple
+            Additional positional arguments for the parent class.
+        **kwargs : dict
+            Additional keyword arguments for the parent class.
+        """
         self.similarity_tol = similarity_tol
         super().__init__(*args, **kwargs)
 
-    def update_population(self, population: Population):
-        """Update the Pareto front with new population.
-
-        If any individual in the pareto front is dominated, it is removed.
+    def update_population(self, population: Population) -> tuple[list, bool]:
+        """
+        Update the Pareto front with a new population.
 
         Parameters
         ----------
         population : Population
-            Population to update the pareto front with.
+            The population used to update the Pareto front.
 
         Returns
         -------
-        new_members : list
-            New members added to the pareto front.
-        significant_improvement : bool
-            True if pareto front has improved significantly. False otherwise.
+        tuple[list, bool]
+            A tuple containing new members added to the Pareto front and a boolean indicating
+            if there was a significant improvement.
         """
         new_members = []
         significant = []
@@ -1019,14 +1054,14 @@ class ParetoFront(Population):
 
         return new_members, any(significant)
 
-    def remove_infeasible(self):
-        """Remove infeasible individuals from pareto front."""
+    def remove_infeasible(self) -> None:
+        """Remove infeasible individuals from the Pareto front."""
         for ind in self.individuals.copy():
             if not ind.is_feasible:
                 self.remove_individual(ind)
 
-    def remove_dominated(self):
-        """Remove dominated individuals from pareto front."""
+    def remove_dominated(self) -> None:
+        """Remove dominated individuals from the Pareto front."""
         for ind in self.individuals.copy():
             dominates_one = False
             to_remove = []
@@ -1045,13 +1080,15 @@ class ParetoFront(Population):
                 except CADETProcessError:
                     pass
 
-    def to_dict(self):
-        """Convert ParetoFront to a dictionary.
+    def to_dict(self) -> dict:
+        """
+        Convert the ParetoFront to a dictionary.
 
         Returns
         -------
         dict
-            ParetoFront as a dictionary with individuals stored as list of dictionaries.
+            A dictionary representation of the ParetoFront, including individuals and
+            similarity tolerance if set.
         """
         front = super().to_dict()
         if self.similarity_tol:
@@ -1060,18 +1097,19 @@ class ParetoFront(Population):
         return front
 
     @classmethod
-    def from_dict(cls, data):
-        """Create ParetoFront from dictionary.
+    def from_dict(cls, data: dict) -> ParetoFront:
+        """
+        Create a ParetoFront instance from a dictionary.
 
         Parameters
         ----------
         data : dict
-            Dictionary containing population data.
+            Dictionary containing the ParetoFront data.
 
         Returns
         -------
         ParetoFront
-            ParetoFront created from data.
+            An instance of ParetoFront created from the dictionary.
         """
         front = cls(similarity_tol=data.get("similarity_tol"), id=data["id"])
         for individual_data in data["individuals"].values():
@@ -1110,6 +1148,7 @@ def plot_pairwise(
     axs : Optional[npt.NDArray[plt.Axes]], default=None
         An optional array of Matplotlib Axes. If none is provided, new axes will be
         created.
+
     Returns
     -------
     tuple

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import uuid
 import warnings
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 import corner
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from addict import Dict
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 from pymoo.visualization.scatter import Scatter
 
 from CADETProcess import CADETProcessError, plotting
@@ -31,7 +33,7 @@ class Population:
     ParetoFront
     """
 
-    def __init__(self, id=None):
+    def __init__(self, id: Optional[str] = None) -> None:
         """
         Initialize the Population.
 
@@ -88,7 +90,7 @@ class Population:
         return self.individuals[0].n_m
 
     @property
-    def dimensions(self) -> tuple[int] | None:
+    def dimensions(self) -> tuple[int]:
         """tuple: Individual dimensions (n_x, n_f, n_g, n_m)."""
         if self.n_individuals == 0:
             return None
@@ -137,7 +139,7 @@ class Population:
         self,
         individual: Individual,
         ignore_duplicate: bool | None = True,
-    ):
+    ) -> None:
         """
         Add individual to population.
 
@@ -170,7 +172,7 @@ class Population:
 
         self._individuals[individual.id] = individual
 
-    def remove_individual(self, individual):
+    def remove_individual(self, individual: Individual) -> None:
         """
         Remove an individual from the population.
 
@@ -193,7 +195,7 @@ class Population:
             raise CADETProcessError("Individual is not in population.")
         self._individuals.pop(individual.id)
 
-    def update(self, other):
+    def update(self, other: Population) -> None:
         """
         Update the population with individuals from another population.
 
@@ -217,7 +219,7 @@ class Population:
 
         self._individuals.update(other._individuals)
 
-    def remove_similar(self):
+    def remove_similar(self) -> None:
         """Remove similar individuals from the population."""
         for ind in self.individuals.copy():
             to_remove = []
@@ -249,161 +251,161 @@ class Population:
 
     @property
     def x(self) -> np.ndarray:
-        """np.array: All evaluated points."""
+        """np.ndarray: All evaluated points."""
         return np.array([ind.x for ind in self.individuals])
 
     @property
     def x_transformed(self) -> np.ndarray:
-        """np.array: All evaluated points in independent transformed space."""
+        """np.ndarray: All evaluated points in independent transformed space."""
         return np.array([ind.x_transformed for ind in self.individuals])
 
     @property
     def cv_bounds(self) -> np.ndarray:
-        """np.array: All evaluated bound constraint violations."""
+        """np.ndarray: All evaluated bound constraint violations."""
         return np.array([ind.cv_bounds for ind in self.individuals])
 
     @property
     def cv_lincon(self) -> np.ndarray:
-        """np.array: All evaluated linear constraint violations."""
+        """np.ndarray: All evaluated linear constraint violations."""
         return np.array([ind.cv_lincon for ind in self.individuals])
 
     @property
     def cv_lineqcon(self) -> np.ndarray:
-        """np.array: All evaluated linear equality constraint violations."""
+        """np.ndarray: All evaluated linear equality constraint violations."""
         return np.array([ind.cv_lineqcon for ind in self.individuals])
 
     @property
     def f(self) -> np.ndarray:
-        """np.array: All evaluated objective function values."""
+        """np.ndarray: All evaluated objective function values."""
         return np.array([ind.f for ind in self.individuals])
 
     @property
     def f_minimized(self) -> np.ndarray:
-        """np.array: All evaluated objective function values, transformed to be minimized."""
+        """np.ndarray: All evaluated objective function values as if minimized."""
         return np.array([ind.f_min for ind in self.individuals])
 
     @property
     def f_best(self) -> np.ndarray:
-        """np.array: Best objective values."""
+        """np.ndarray: Best objective values."""
         f_best = np.min(self.f_minimized, axis=0)
         return np.multiply(self.objectives_minimization_factors, f_best)
 
     @property
     def f_min(self) -> np.ndarray:
-        """np.array: Minimum objective values."""
+        """np.ndarray: Minimum objective values."""
         return np.min(self.f, axis=0)
 
     @property
     def f_max(self) -> np.ndarray:
-        """np.array: Maximum objective values."""
+        """np.ndarray: Maximum objective values."""
         return np.max(self.f, axis=0)
 
     @property
     def f_avg(self) -> np.ndarray:
-        """np.array: Average objective values."""
+        """np.ndarray: Average objective values."""
         return np.mean(self.f, axis=0)
 
     @property
     def g(self) -> np.ndarray:
-        """np.array: All evaluated nonlinear constraint function values."""
+        """np.ndarray: All evaluated nonlinear constraint function values."""
         if self.dimensions[2] > 0:
             return np.array([ind.g for ind in self.individuals])
 
     @property
     def g_best(self) -> np.ndarray:
-        """np.array: Best nonlinear constraint values."""
+        """np.ndarray: Best nonlinear constraint values."""
         indices = np.argmin(self.cv_nonlincon, axis=0)
         return [self.g[ind, i] for i, ind in enumerate(indices)]
 
     @property
     def g_min(self) -> np.ndarray:
-        """np.array: Minimum nonlinear constraint values."""
+        """np.ndarray: Minimum nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.min(self.g, axis=0)
 
     @property
     def g_max(self) -> np.ndarray:
-        """np.array: Maximum nonlinear constraint values."""
+        """np.ndarray: Maximum nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.max(self.g, axis=0)
 
     @property
     def g_avg(self) -> np.ndarray:
-        """np.array: Average nonlinear constraint values."""
+        """np.ndarray: Average nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.mean(self.g, axis=0)
 
     @property
     def cv_nonlincon(self) -> np.ndarray:
-        """np.array: All evaluated nonlinear constraint violation values."""
+        """np.ndarray: All evaluated nonlinear constraint violation values."""
         if self.dimensions[2] > 0:
             return np.array([ind.cv_nonlincon for ind in self.individuals])
 
     @property
     def cv_nonlincon_min(self) -> np.ndarray:
-        """np.array: Minimum nonlinear constraint violation values."""
+        """np.ndarray: Minimum nonlinear constraint violation values."""
         if self.dimensions[2] > 0:
             return np.min(self.cv_nonlincon, axis=0)
 
     @property
     def cv_nonlincon_max(self) -> np.ndarray:
-        """np.array: Maximum nonlinearconstraint violation values."""
+        """np.ndarray: Maximum nonlinearconstraint violation values."""
         if self.dimensions[2] > 0:
             return np.max(self.cv_nonlincon, axis=0)
 
     @property
     def cv_nonlincon_avg(self) -> np.ndarray:
-        """np.array: Average nonlinear constraint violation values."""
+        """np.ndarray: Average nonlinear constraint violation values."""
         if self.dimensions[2] > 0:
             return np.mean(self.cv_nonlincon, axis=0)
 
     @property
     def m(self) -> np.ndarray:
-        """np.array: All evaluated meta scores."""
+        """np.ndarray: All evaluated meta scores."""
         if self.dimensions[3] > 0:
             return np.array([ind.m for ind in self.individuals])
 
     @property
     def m_minimized(self) -> np.ndarray:
-        """np.array: All evaluated meta scores, transformed to be minimized."""
+        """np.ndarray: All evaluated meta scores, transformed to be minimized."""
         if self.dimensions[3] > 0:
             return np.array([ind.m_min for ind in self.individuals])
 
     @property
     def m_best(self) -> np.ndarray:
-        """np.array: Best meta scores."""
+        """np.ndarray: Best meta scores."""
         if self.dimensions[3] > 0:
             m_best = np.min(self.m_minimized, axis=0)
             return np.multiply(self.meta_scores_minimization_factors, m_best)
 
     @property
     def m_min(self) -> np.ndarray:
-        """np.array: Minimum meta scores."""
+        """np.ndarray: Minimum meta scores."""
         if self.dimensions[3] > 0:
             return np.min(self.m, axis=0)
 
     @property
     def m_max(self) -> np.ndarray:
-        """np.array: Maximum meta scores."""
+        """np.ndarray: Maximum meta scores."""
         if self.dimensions[3] > 0:
             return np.max(self.m, axis=0)
 
     @property
     def m_avg(self) -> np.ndarray:
-        """np.array: Average meta scores."""
+        """np.ndarray: Average meta scores."""
         if self.dimensions[3] > 0:
             return np.mean(self.m, axis=0)
 
     @property
     def is_feasilbe(self) -> bool:
-        """
-        np.array: False if any constraint is not met.
-
-        True otherwise.
-        """
+        """np.ndarray: False if any constraint is not met. True otherwise."""
         return np.array([ind.is_feasible for ind in self.individuals])
 
-    def setup_objectives_figure(self, include_meta=True, plot_individual=False):
+    def setup_objectives_figure(
+        self,
+        include_meta: Optional[bool] = True,
+        plot_individual: Optional[bool] = False
+    ) -> tuple:
         """
         Set up figure and axes for plotting objectives.
 
@@ -454,17 +456,17 @@ class Population:
 
     def plot_objectives(
         self,
-        figs=None,
-        axs=None,
-        include_meta=True,
-        plot_infeasible=True,
-        plot_individual=False,
-        autoscale=True,
-        color_feas="blue",
-        color_infeas="red",
-        show=True,
-        plot_directory=None,
-    ):
+        figs: Optional[Figure | list[Figure]] = None,
+        axs: Optional[Axes | list[list[Axes]]] = None,
+        include_meta: bool = True,
+        plot_infeasible: bool = True,
+        plot_individual: bool = False,
+        autoscale: bool = True,
+        color_feas: str = 'blue',
+        color_infeas: str = 'red',
+        show: bool = True,
+        plot_directory: Optional[str | Path] = None
+    ) -> tuple[list[Figure], list[list[Axes]]]:
         """
         Plot the objective function values for each design variable.
 
@@ -600,7 +602,7 @@ class Population:
         else:
             return figs[0], axs
 
-    def setup_pareto(self, include_meta: bool = False):
+    def setup_pareto(self, include_meta: bool = False) -> Scatter:
         """
         Set up base figure for plotting the Pareto front.
 
@@ -630,14 +632,14 @@ class Population:
 
     def plot_pareto(
         self,
-        plot=None,
-        include_meta=True,
-        plot_infeasible=True,
-        color_feas="blue",
-        color_infeas="red",
-        show=True,
-        plot_directory=None,
-    ):
+        plot: Optional[Scatter] = None,
+        include_meta: bool = True,
+        plot_infeasible: bool = True,
+        color_feas: str = "blue",
+        color_infeas: str = "red",
+        show: bool = True,
+        plot_directory: Optional[str | Path] = None
+    ) -> Scatter:
         """
         Plot pairwise Pareto fronts for each generation in the optimization.
 
@@ -709,10 +711,10 @@ class Population:
         fig: Optional[plt.Figure] = None,
         axs: Optional[npt.NDArray[plt.Axes]] = None,
         n_bins: int = 20,
-        use_transformed=False,
+        use_transformed: bool = False,
         autoscale: bool = True,
-        show=True,
-        plot_directory=None,
+        show: bool = True,
+        plot_directory: Optional[str] = None,
     ) -> tuple[plt.Figure, np.ndarray]:
         """
         Create a pairplot using Matplotlib.
@@ -731,6 +733,8 @@ class Population:
             If True, use the transformed independent variables. The default is False.
         autoscale : bool, optional
             If True, automatically adjust the scaling of the axes. The default is True.
+        use_transformed : bool, optional
+            If True, transformed values will be plotted. The default is False.
         show : bool, optional
             If True, display the plot. The default is True.
         plot_directory : str, optional
@@ -768,7 +772,12 @@ class Population:
 
         return fig, axs
 
-    def plot_corner(self, use_transformed=False, show=True, plot_directory=None):
+    def plot_corner(
+        self,
+        use_transformed: bool = False,
+        show: bool = True,
+        plot_directory: Optional[str] = None
+    ) -> None:
         """
         Create a corner plot of the independent variables.
 
@@ -828,13 +837,13 @@ class Population:
         if not show:
             plt.close(fig)
 
-    def __contains__(self, other):
+    def __contains__(self, other: Individual | np.ndarray | list) -> bool:
         """
         Check if the population contains a specific individual.
 
         Parameters
         ----------
-        other : Individual, np.array, list
+        other : Individual | np.ndarray | list
             The individual or its hashable representation.
 
         Returns
@@ -854,13 +863,13 @@ class Population:
         else:
             return False
 
-    def __getitem__(self, x):
+    def __getitem__(self, x: np.ndarray | list) -> Individual:
         """
         Get an individual from the population using its hashable representation.
 
         Parameters
         ----------
-        x : np.array, list
+        x : np.ndarray | list
             The hashable representation of the individual.
 
         Returns
@@ -872,7 +881,7 @@ class Population:
 
         return self._individuals[key]
 
-    def __len__(self):
+    def __len__(self) -> int:
         """
         Get the number of individuals in the population.
 
@@ -883,7 +892,7 @@ class Population:
         """
         return self.n_individuals
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Individual]:
         """
         Iterate over the individuals in the population.
 
@@ -894,7 +903,7 @@ class Population:
         """
         return iter(self.individuals)
 
-    def to_dict(self):
+    def to_dict(self) -> Dict:
         """
         Convert Population to a dictionary.
 
@@ -912,7 +921,7 @@ class Population:
         return data
 
     @classmethod
-    def from_dict(cls, data):
+    def from_dict(cls, data: dict) -> Population:
         """
         Create a Population from a dictionary.
 
@@ -940,10 +949,10 @@ class ParetoFront(Population):
     """Class representing a Pareto front in a multi-objective optimization problem."""
 
     def __init__(
-            self,
-            similarity_tol: float = 1e-1,
-            *args: Any,
-            **kwargs: Any
+        self,
+        similarity_tol: float = 1e-1,
+        *args: Any,
+        **kwargs: Any,
     ) -> None:
         """
         Initialize a ParetoFront with a specified similarity tolerance.
@@ -1125,8 +1134,8 @@ def plot_pairwise(
     n_bins: int = 20,
     autoscale: bool = True,
     fig: Optional[plt.Figure] = None,
-    axs: Optional[npt.NDArray[plt.Axes]] = None,
-) -> tuple[plt.Figure, npt.NDArray[plt.Axes]]:
+    axs: Optional[np.ndarray[plt.Axes]] = None,
+) -> tuple[plt.Figure, np.ndarray[plt.Axes]]:
     """
     Create a pairwise scatter plot for all variables of a population.
 

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -1,25 +1,22 @@
-import time
 import warnings
 
 import numpy as np
-
-from pymoo.core.problem import Problem
-from pymoo.util.ref_dirs import get_reference_directions
-from pymoo.termination.default import DefaultMultiObjectiveTermination
-from pymoo.util.display.multi import MultiObjectiveOutput
-from pymoo.core.repair import Repair
 from pymoo.algorithms.moo.nsga2 import NSGA2
 from pymoo.algorithms.moo.unsga3 import UNSGA3
-from pymoo.core.evaluator import Evaluator
 from pymoo.core.population import Population
-from pymoo.problems.static import StaticProblem
+from pymoo.core.problem import Problem
+from pymoo.core.repair import Repair
+from pymoo.termination.default import DefaultMultiObjectiveTermination
+from pymoo.util.display.multi import MultiObjectiveOutput
+from pymoo.util.ref_dirs import get_reference_directions
 
-from CADETProcess.dataStructure import UnsignedInteger, UnsignedFloat
-from CADETProcess.optimization import OptimizerBase, OptimizationProblem
+from CADETProcess.dataStructure import UnsignedFloat, UnsignedInteger
+from CADETProcess.optimization import OptimizationProblem, OptimizerBase
 
 
 class PymooInterface(OptimizerBase):
     """Wrapper around pymoo."""
+
     is_population_based = True
 
     supports_multi_objective = True
@@ -46,7 +43,13 @@ class PymooInterface(OptimizerBase):
     n_max_iter = n_max_gen      # Alias for uniform interface
 
     _specific_options = [
-        'seed', 'pop_size', 'xtol', 'ftol', 'cvtol', 'n_max_gen', 'n_skip'
+        "seed",
+        "pop_size",
+        "xtol",
+        "ftol",
+        "cvtol",
+        "n_max_gen",
+        "n_skip",
     ]
 
     def _run(self, optimization_problem: OptimizationProblem, x0=None):
@@ -84,8 +87,7 @@ class PymooInterface(OptimizerBase):
 
         if len(pop) < pop_size:
             warnings.warn(
-                "Initial population smaller than popsize. "
-                "Creating missing entries."
+                "Initial population smaller than popsize. Creating missing entries."
             )
             n_remaining = pop_size - len(pop)
             remaining = optimization_problem.create_initial_values(
@@ -126,8 +128,11 @@ class PymooInterface(OptimizerBase):
         )
 
         algorithm.setup(
-            problem, termination=termination,
-            seed=self.seed, verbose=True, save_history=False,
+            problem,
+            termination=termination,
+            seed=self.seed,
+            verbose=True,
+            save_history=False,
             output=MultiObjectiveOutput(),
         )
 
@@ -168,16 +173,16 @@ class PymooInterface(OptimizerBase):
 
             # Post generation processing
             X_opt = algorithm.opt.get("X").tolist()
-            self.run_post_processing(X, F, G, CV, algorithm.n_gen-1, X_opt)
+            self.run_post_processing(X, F, G, CV, algorithm.n_gen - 1, X_opt)
 
         if algorithm.n_gen >= n_max_gen:
             success = True
             exit_flag = 1
-            exit_message = 'Max number of generations exceeded.'
+            exit_message = "Max number of generations exceeded."
         else:
             success = True
             exit_flag = 0
-            exit_message = 'Success'
+            exit_message = "Success"
 
         self.results.success = success
         self.results.exit_flag = exit_flag
@@ -187,21 +192,13 @@ class PymooInterface(OptimizerBase):
 
     def get_population_size(self, optimization_problem):
         if self.pop_size is None:
-            return min(
-                400, max(
-                    50*optimization_problem.n_independent_variables, 50
-                )
-            )
+            return min(400, max(50 * optimization_problem.n_independent_variables, 50))
         else:
             return self.pop_size
 
     def get_max_number_of_generations(self, optimization_problem):
         if self.n_max_gen is None:
-            return min(
-                100, max(
-                    10*optimization_problem.n_independent_variables, 40
-                )
-            )
+            return min(100, max(10 * optimization_problem.n_independent_variables, 40))
         else:
             return self.n_max_gen
 
@@ -210,14 +207,14 @@ class NSGA2(PymooInterface):
     _cls = NSGA2
 
     def __str__(self):
-        return 'NSGA2'
+        return "NSGA2"
 
 
 class U_NSGA3(PymooInterface):
     _cls = UNSGA3
 
     def __str__(self):
-        return 'UNSGA3'
+        return "UNSGA3"
 
 
 class PymooProblem(Problem):
@@ -231,7 +228,7 @@ class PymooProblem(Problem):
             n_ieq_constr=optimization_problem.n_nonlinear_constraints,
             xl=optimization_problem.lower_bounds_independent_transformed,
             xu=optimization_problem.upper_bounds_independent_transformed,
-            **kwargs
+            **kwargs,
         )
 
     def _evaluate(self, X, out, *args, **kwargs):
@@ -276,14 +273,14 @@ class RepairIndividuals(Repair):
         X_new = None
         for i, ind in enumerate(X):
             if not self.optimization_problem.check_individual(
-                    ind,
-                    untransform=True,
-                    get_dependent_values=True,
-                    cv_bounds_tol=self.optimizer.cv_bounds_tol,
-                    cv_lincon_tol=self.optimizer.cv_lincon_tol,
-                    cv_lineqcon_tol=self.optimizer.cv_lineqcon_tol,
-                    check_nonlinear_constraints=False,
-                    ):
+                ind,
+                untransform=True,
+                get_dependent_values=True,
+                cv_bounds_tol=self.optimizer.cv_bounds_tol,
+                cv_lincon_tol=self.optimizer.cv_lincon_tol,
+                cv_lineqcon_tol=self.optimizer.cv_lineqcon_tol,
+                check_nonlinear_constraints=False,
+            ):
                 if X_new is None:
                     X_new = self.optimization_problem.create_initial_values(
                         len(X), include_dependent_variables=False

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -53,7 +53,8 @@ class PymooInterface(OptimizerBase):
     ]
 
     def _run(self, optimization_problem: OptimizationProblem, x0=None):
-        """Solve optimization problem using functional pymoo implementation.
+        """
+        Solve optimization problem using functional pymoo implementation.
 
         Parameters
         ----------
@@ -72,7 +73,6 @@ class PymooInterface(OptimizerBase):
         --------
         evaluate_objectives
         options
-
         """
         pop_size = self.get_population_size(optimization_problem)
 
@@ -190,13 +190,50 @@ class PymooInterface(OptimizerBase):
 
         return self.results
 
-    def get_population_size(self, optimization_problem):
+    def get_population_size(
+            self,
+            optimization_problem: OptimizationProblem
+    ) -> int:
+        """
+        Determine the population size for an optimization problem.
+
+        This method calculates the population size based on the number of independent
+        variables in the optimization problem. If `pop_size` is not set, it defaults to
+        the minimum of 400 or the maximum of 50 times the number of independent variables
+        and 50.
+
+        Parameters
+        ----------
+        optimization_problem : OptimizationProblem
+            The optimization problem for which to determine the population size.
+
+        Returns
+        -------
+        int
+            The population size.
+        """
         if self.pop_size is None:
             return min(400, max(50 * optimization_problem.n_independent_variables, 50))
         else:
             return self.pop_size
 
-    def get_max_number_of_generations(self, optimization_problem):
+    def get_max_number_of_generations(
+            self,
+            optimization_problem: OptimizationProblem
+    ) -> int:
+        """
+        Determine the maximum number of generations for an optimization problem.
+
+        Parameters
+        ----------
+        optimization_problem : OptimizationProblem
+            The optimization problem for which to determine the maximum number of generations.
+
+        Returns
+        -------
+        int
+            The maximum number of generations.
+        """
         if self.n_max_gen is None:
             return min(100, max(10 * optimization_problem.n_independent_variables, 40))
         else:
@@ -204,20 +241,28 @@ class PymooInterface(OptimizerBase):
 
 
 class NSGA2(PymooInterface):
+    """NSGA2 Algorithm."""
+
     _cls = NSGA2
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: String representation."""
         return "NSGA2"
 
 
 class U_NSGA3(PymooInterface):
+    """U-NSGA3 Algorithm."""
+
     _cls = UNSGA3
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: String representation."""
         return "UNSGA3"
 
 
 class PymooProblem(Problem):
+    """Class to implement Pymoo Problem interface."""
+
     def __init__(self, optimization_problem, parallelization_backend, **kwargs):
         self.optimization_problem = optimization_problem
         self.parallelization_backend = parallelization_backend
@@ -263,6 +308,8 @@ class PymooProblem(Problem):
 
 
 class RepairIndividuals(Repair):
+    """Class to repair individuals."""
+
     def __init__(self, optimizer, optimization_problem, *args, **kwargs):
         self.optimizer = optimizer
         self.optimization_problem = optimization_problem

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -1,28 +1,31 @@
 import csv
-from functools import wraps
 import os
+import warnings
+from functools import wraps
 from pathlib import Path
 from typing import Literal, NoReturn
-import warnings
 
-from addict import Dict
-import matplotlib.colors as colors
 import matplotlib.cm as cmx
+import matplotlib.colors as colors
 import matplotlib.pyplot as plt
-cmap_feas = plt.get_cmap('winter_r')
-cmap_infeas = plt.get_cmap('autumn_r')
 import numpy as np
-
+from addict import Dict
 from cadet import H5
-from CADETProcess import plotting
-from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import (
-    Bool, Dictionary, NdArray, String, UnsignedInteger, UnsignedFloat
-)
 
-from CADETProcess import CADETProcessError
+from CADETProcess import CADETProcessError, plotting
+from CADETProcess.dataStructure import (
+    Bool,
+    Dictionary,
+    String,
+    Structure,
+    UnsignedFloat,
+    UnsignedInteger,
+)
+from CADETProcess.optimization import Individual, ParetoFront, Population
 from CADETProcess.sysinfo import system_information
-from CADETProcess.optimization import Individual, Population, ParetoFront
+
+cmap_feas = plt.get_cmap("winter_r")
+cmap_infeas = plt.get_cmap("autumn_r")
 
 
 class OptimizationResults(Structure):
@@ -61,6 +64,7 @@ class OptimizationResults(Structure):
         functions.
 
     """
+
     success = Bool(default=False)
     exit_flag = UnsignedInteger()
     exit_message = String()
@@ -69,11 +73,11 @@ class OptimizationResults(Structure):
     system_information = Dictionary()
 
     def __init__(
-            self,
-            optimization_problem,
-            optimizer,
-            similarity_tol: float = 0,
-            ):
+        self,
+        optimization_problem,
+        optimizer,
+        similarity_tol: float = 0,
+    ):
         self.optimization_problem = optimization_problem
         self.optimizer = optimizer
 
@@ -101,7 +105,7 @@ class OptimizationResults(Structure):
     def results_directory(self, results_directory: str | os.PathLike):
         if results_directory is not None:
             results_directory = Path(results_directory)
-            self.plot_directory = Path(results_directory / 'figures')
+            self.plot_directory = Path(results_directory / "figures")
             self.plot_directory.mkdir(exist_ok=True)
         else:
             self.plot_directory = None
@@ -184,9 +188,7 @@ class OptimizationResults(Structure):
         pareto_new : Population, optional
             New pareto front. If None, update existing front with latest population.
         """
-        pareto_front = ParetoFront(
-            similarity_tol=self._similarity_tol
-        )
+        pareto_front = ParetoFront(similarity_tol=self._similarity_tol)
 
         if pareto_new is not None:
             pareto_front.update_population(pareto_new)
@@ -393,49 +395,42 @@ class OptimizationResults(Structure):
             warnings.simplefilter("ignore")
 
             self.plot_convergence(
-                'objectives',
-                show=show,
-                plot_directory=self.plot_directory
+                "objectives", show=show, plot_directory=self.plot_directory
             )
             if self.optimization_problem.n_nonlinear_constraints > 0:
                 self.plot_convergence(
-                    'nonlinear_constraints',
+                    "nonlinear_constraints",
                     show=show,
-                    plot_directory=self.plot_directory
+                    plot_directory=self.plot_directory,
                 )
             if self.optimization_problem.n_meta_scores > 0:
                 self.plot_convergence(
-                    'meta_scores',
-                    show=show,
-                    plot_directory=self.plot_directory
+                    "meta_scores", show=show, plot_directory=self.plot_directory
                 )
-            self.plot_objectives(
-                show=show, plot_directory=self.plot_directory
-            )
+            self.plot_objectives(show=show, plot_directory=self.plot_directory)
             if self.optimization_problem.n_variables > 1 and len(self.x) > 1:
-                self.plot_corner(
-                    show=show, plot_directory=self.plot_directory
-                )
+                self.plot_corner(show=show, plot_directory=self.plot_directory)
 
-            self.plot_pairwise(
-                show=show, plot_directory=self.plot_directory
-            )
+            self.plot_pairwise(show=show, plot_directory=self.plot_directory)
 
             if self.optimization_problem.n_objectives > 1:
                 self.plot_pareto(
-                    show=show, plot_directory=self.plot_directory,
-                    plot_evolution=True, plot_pareto=False,
+                    show=show,
+                    plot_directory=self.plot_directory,
+                    plot_evolution=True,
+                    plot_pareto=False,
                 )
 
     def plot_objectives(
-            self,
-            include_meta=True,
-            plot_pareto=False,
-            plot_infeasible=True,
-            plot_individual=False,
-            autoscale=True,
-            show=True,
-            plot_directory=None):
+        self,
+        include_meta=True,
+        plot_pareto=False,
+        plot_infeasible=True,
+        plot_individual=False,
+        autoscale=True,
+        show=True,
+        plot_directory=None,
+    ):
         """Plot objective function values for all optimization generations.
 
         Parameters
@@ -495,7 +490,8 @@ class OptimizationResults(Structure):
                 _plot_directory = plot_directory
                 _show = show
             figs, axs = gen.plot_objectives(
-                figs, axs,
+                figs,
+                axs,
                 include_meta=include_meta,
                 plot_infeasible=plot_infeasible,
                 plot_individual=plot_individual,
@@ -503,17 +499,14 @@ class OptimizationResults(Structure):
                 color_feas=scalarMap_feas.to_rgba(i),
                 color_infeas=scalarMap_infeas.to_rgba(i),
                 show=_show,
-                plot_directory=_plot_directory
+                plot_directory=_plot_directory,
             )
 
         return figs, axs
 
     def plot_pareto(
-            self,
-            show=True,
-            plot_pareto=True,
-            plot_evolution=False,
-            plot_directory=None):
+        self, show=True, plot_pareto=True, plot_evolution=False, plot_directory=None
+    ):
         """Plot Pareto fronts for each generation in the optimization.
 
         The Pareto front represents the optimal solutions that cannot be improved in one
@@ -580,7 +573,7 @@ class OptimizationResults(Structure):
                 color_feas=scalarMap_feas.to_rgba(i),
                 color_infeas=scalarMap_infeas.to_rgba(i),
                 show=_show,
-                plot_directory=_plot_directory
+                plot_directory=_plot_directory,
             )
 
         return plot.fig, plot.ax
@@ -594,11 +587,11 @@ class OptimizationResults(Structure):
         return self.population_all.plot_pairwise(*args, **kwargs)
 
     def setup_convergence_figure(self, target, plot_individual=False):
-        if target == 'objectives':
+        if target == "objectives":
             n = self.optimization_problem.n_objectives
-        elif target == 'nonlinear_constraints':
+        elif target == "nonlinear_constraints":
             n = self.optimization_problem.n_nonlinear_constraints
-        elif target == 'meta_scores':
+        elif target == "meta_scores":
             n = self.optimization_problem.n_meta_scores
         else:
             raise CADETProcessError("Unknown target.")
@@ -608,7 +601,7 @@ class OptimizationResults(Structure):
 
         fig_all, axs_all = plt.subplots(
             ncols=n,
-            figsize=(n*6 + 2, 6),
+            figsize=(n * 6 + 2, 6),
             squeeze=False,
         )
         axs_all = axs_all.reshape((-1,))
@@ -631,14 +624,16 @@ class OptimizationResults(Structure):
             return fig_all, axs_all
 
     def plot_convergence(
-            self,
-            target='objectives',
-            figs=None, axs=None,
-            plot_individual=False,
-            plot_avg=True,
-            autoscale=True,
-            show=True,
-            plot_directory=None):
+        self,
+        target="objectives",
+        figs=None,
+        axs=None,
+        plot_individual=False,
+        plot_avg=True,
+        autoscale=True,
+        show=True,
+        plot_directory=None,
+    ):
         """Plot the convergence of optimization metrics over evaluations.
 
         Parameters
@@ -677,17 +672,17 @@ class OptimizationResults(Structure):
             figs = [figs]
 
         layout = plotting.Layout()
-        layout.x_label = '$n_{Evaluations}$'
+        layout.x_label = "$n_{Evaluations}$"
 
-        if target == 'objectives':
+        if target == "objectives":
             funcs = self.optimization_problem.objectives
             values_min = self.f_best_history
             values_avg = self.f_avg_history
-        elif target == 'nonlinear_constraints':
+        elif target == "nonlinear_constraints":
             funcs = self.optimization_problem.nonlinear_constraints
             values_min = self.g_best_history
             values_avg = self.g_avg_history
-        elif target == 'meta_scores':
+        elif target == "meta_scores":
             funcs = self.optimization_problem.meta_scores
             values_min = self.m_best_history
             values_avg = self.m_avg_history
@@ -700,7 +695,7 @@ class OptimizationResults(Structure):
         counter = 0
         for func in funcs:
             start = counter
-            stop = counter+func.n_metrics
+            stop = counter + func.n_metrics
             v_func_min = values_min[:, start:stop]
             v_func_avg = values_avg[:, start:stop]
 
@@ -718,33 +713,29 @@ class OptimizationResults(Structure):
                         lines[1].set_ydata(v_line_avg)
                 else:
                     if plot_avg and self.population_last.n_individuals > 1:
-                        label = 'best'
+                        label = "best"
                     else:
-                        label=None
+                        label = None
 
                     ax.plot(
-                        self.n_evals_history,
-                        v_line_min,
-                        '--',
-                        color='k',
-                        label=label
+                        self.n_evals_history, v_line_min, "--", color="k", label=label
                     )
                     if plot_avg and self.population_last.n_individuals > 1:
                         ax.plot(
                             self.n_evals_history,
                             v_line_avg,
-                            '-',
-                            color='k',
+                            "-",
+                            color="k",
                             alpha=0.5,
-                            label='avg'
+                            label="avg",
                         )
 
-                layout.x_lim = (0, np.max(self.n_evals_history)+1)
+                layout.x_lim = (0, np.max(self.n_evals_history) + 1)
 
                 try:
                     label = func.labels[i_metric]
                 except AttributeError:
-                    label = f'{func}_{i_metric}'
+                    label = f"{func}_{i_metric}"
 
                 if plot_avg and self.population_last.n_individuals > 1:
                     y_min = np.nanmin(v_line_min)
@@ -756,7 +747,7 @@ class OptimizationResults(Structure):
                 layout.y_label = label
                 if autoscale and y_min > 0:
                     if y_max / y_min > 100.0:
-                        ax.set_yscale('log')
+                        ax.set_yscale("log")
                         layout.y_label = f"$log_{{10}}$({label})"
 
                 try:
@@ -783,15 +774,11 @@ class OptimizationResults(Structure):
             plot_directory = Path(plot_directory)
             if plot_individual:
                 for i, fig in enumerate(figs):
-                    figname = f'convergence_{target}_{i}'
-                    fig.savefig(
-                        f'{plot_directory / figname}.png'
-                    )
+                    figname = f"convergence_{target}_{i}"
+                    fig.savefig(f"{plot_directory / figname}.png")
             else:
-                figname = f'convergence_{target}'
-                figs[0].savefig(
-                    f'{plot_directory / figname}.png'
-                )
+                figname = f"convergence_{target}"
+                figs[0].savefig(f"{plot_directory / figname}.png")
 
         if plot_individual:
             return figs, axs
@@ -808,15 +795,15 @@ class OptimizationResults(Structure):
             Results file name without file extension.
         """
         if self.results_directory is not None:
-            self._update_csv(self.population_last, 'results_all', mode='a')
-            self._update_csv(self.population_last, 'results_last', mode='w')
-            self._update_csv(self.pareto_front, 'results_pareto', mode='w')
+            self._update_csv(self.population_last, "results_all", mode="a")
+            self._update_csv(self.population_last, "results_last", mode="w")
+            self._update_csv(self.pareto_front, "results_pareto", mode="w")
             if self.optimization_problem.n_meta_scores > 0:
-                self._update_csv(self.meta_front, 'results_meta', mode='w')
+                self._update_csv(self.meta_front, "results_meta", mode="w")
 
             results = H5()
             results.root = Dict(self.to_dict())
-            results.filename = self.results_directory / f'{file_name}.h5'
+            results.filename = self.results_directory / f"{file_name}.h5"
             results.save()
 
     def load_results(self, file_name: str) -> NoReturn:
@@ -877,29 +864,29 @@ class OptimizationResults(Structure):
         data : dict
             Serialized data.
         """
-        self._optimizer_state = data['optimizer_state']
-        self._population_all = Population(id=data['population_all_id'])
-        self._similarity_tol = data.get('similarity_tol')
+        self._optimizer_state = data["optimizer_state"]
+        self._population_all = Population(id=data["population_all_id"])
+        self._similarity_tol = data.get("similarity_tol")
 
-        for pop_dict in data['populations'].values():
+        for pop_dict in data["populations"].values():
             pop = Population.from_dict(pop_dict)
             self.update(pop)
 
         self._pareto_fronts = [
-            ParetoFront.from_dict(d) for d in data['pareto_fronts'].values()
+            ParetoFront.from_dict(d) for d in data["pareto_fronts"].values()
         ]
         if self._meta_fronts is not None:
             self._meta_fronts = [
-                ParetoFront.from_dict(d) for d in data['meta_fronts'].values()
+                ParetoFront.from_dict(d) for d in data["meta_fronts"].values()
             ]
 
     def setup_csv(self):
         """Create csv files for optimization results."""
-        self._setup_csv('results_all')
-        self._setup_csv('results_last')
-        self._setup_csv('results_pareto')
+        self._setup_csv("results_all")
+        self._setup_csv("results_last")
+        self._setup_csv("results_pareto")
         if self.optimization_problem.n_meta_scores > 0:
-            self._setup_csv('results_meta')
+            self._setup_csv("results_meta")
 
     def _setup_csv(self, file_name: str):
         """
@@ -913,7 +900,7 @@ class OptimizationResults(Structure):
         header = [
             "id",
             *self.optimization_problem.variable_names,
-            *self.optimization_problem.objective_labels
+            *self.optimization_problem.objective_labels,
         ]
 
         if self.optimization_problem.n_nonlinear_constraints > 0:
@@ -921,19 +908,16 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_meta_scores > 0:
             header += [*self.optimization_problem.meta_score_labels]
 
-        with open(
-                f'{self.results_directory / file_name}.csv', 'w'
-        ) as csvfile:
-
+        with open(f"{self.results_directory / file_name}.csv", "w") as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(header)
 
     def _update_csv(
-            self,
-            population: Population,
-            file_name: str,
-            mode: Literal["w", "b"],
-            ):
+        self,
+        population: Population,
+        file_name: str,
+        mode: Literal["w", "b"],
+    ):
         """
         Update csv file with latest population.
 
@@ -951,22 +935,15 @@ class OptimizationResults(Structure):
         --------
         setup_csv
         """
-        if mode == 'w':
+        if mode == "w":
             self._setup_csv(file_name)
-            mode = 'a'
+            mode = "a"
 
-        with open(
-                f'{self.results_directory / file_name}.csv', mode
-        ) as csvfile:
-
+        with open(f"{self.results_directory / file_name}.csv", mode) as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
 
             for ind in population:
-                row = [
-                    ind.id,
-                    *ind.x.tolist(),
-                    *ind.f.tolist()
-                ]
+                row = [ind.id, *ind.x.tolist(), *ind.f.tolist()]
                 if ind.g is not None:
                     row += ind.g.tolist()
                 if ind.m is not None:

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
+
 import csv
 import os
 import warnings
 from functools import wraps
 from pathlib import Path
-from typing import Any, Literal, NoReturn
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import matplotlib.cm as cmx
 import matplotlib.colors as colors
@@ -11,6 +13,8 @@ import matplotlib.pyplot as plt
 import numpy as np
 from addict import Dict
 from cadet import H5
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from CADETProcess import CADETProcessError, plotting
 from CADETProcess.dataStructure import (
@@ -23,6 +27,9 @@ from CADETProcess.dataStructure import (
 )
 from CADETProcess.optimization import Individual, ParetoFront, Population
 from CADETProcess.sysinfo import system_information
+
+if TYPE_CHECKING:
+    from CADETProcess.optimization import OptimizationProblem, OptimizerBase
 
 cmap_feas = plt.get_cmap("winter_r")
 cmap_infeas = plt.get_cmap("autumn_r")
@@ -74,10 +81,11 @@ class OptimizationResults(Structure):
 
     def __init__(
         self,
-        optimization_problem,
-        optimizer,
+        optimization_problem: OptimizationProblem,
+        optimizer: OptimizerBase,
         similarity_tol: float = 0,
-    ):
+    ) -> None:
+        """Initialize OptimizationResults object."""
         self.optimization_problem = optimization_problem
         self.optimizer = optimizer
 
@@ -103,7 +111,7 @@ class OptimizationResults(Structure):
         return self._results_directory
 
     @results_directory.setter
-    def results_directory(self, results_directory: str | os.PathLike):
+    def results_directory(self, results_directory: str | os.PathLike) -> None:
         if results_directory is not None:
             results_directory = Path(results_directory)
             self.plot_directory = Path(results_directory / "figures")
@@ -167,7 +175,7 @@ class OptimizationResults(Structure):
         else:
             return self._meta_fronts[-1]
 
-    def update(self, new: Individual | Population):
+    def update(self, new: Individual | Population) -> None:
         """
         Update Results.
 
@@ -191,7 +199,7 @@ class OptimizationResults(Structure):
         self._populations.append(population)
         self.population_all.update(population)
 
-    def update_pareto(self, pareto_new: Population | None = None):
+    def update_pareto(self, pareto_new: Population | None = None) -> None:
         """
         Update pareto front with new population.
 
@@ -213,7 +221,7 @@ class OptimizationResults(Structure):
             pareto_front.remove_similar()
         self._pareto_fronts.append(pareto_front)
 
-    def update_meta(self, meta_front: Population):
+    def update_meta(self, meta_front: Population) -> None:
         """
         Update meta front with new population.
 
@@ -238,47 +246,47 @@ class OptimizationResults(Structure):
 
     @property
     def x(self) -> np.ndarray:
-        """np.array: Optimal points in untransformed space."""
+        """np.ndarray: Optimal points in untransformed space."""
         return self.meta_front.x
 
     @property
     def x_transformed(self) -> np.ndarray:
-        """np.array: Optimal points in transformed space."""
+        """np.ndarray: Optimal points in transformed space."""
         return self.meta_front.x_transformed
 
     @property
     def cv_bounds(self) -> np.ndarray:
-        """np.array: Bound constraint violation of optimal points."""
+        """np.ndarray: Bound constraint violation of optimal points."""
         return self.meta_front.cv_bounds
 
     @property
     def cv_lincon(self) -> np.ndarray:
-        """np.array: Linear constraint violation of optimal points."""
+        """np.ndarray: Linear constraint violation of optimal points."""
         return self.meta_front.cv_lincon
 
     @property
     def cv_lineqcon(self) -> np.ndarray:
-        """np.array: Linear equality constraint violation of optimal points."""
+        """np.ndarray: Linear equality constraint violation of optimal points."""
         return self.meta_front.cv_lineqcon
 
     @property
     def f(self) -> np.ndarray:
-        """np.array: Objective function values of optimal points."""
+        """np.ndarray: Objective function values of optimal points."""
         return self.meta_front.f
 
     @property
     def g(self) -> np.ndarray:
-        """np.array: Nonlinear constraint function values of optimal points."""
+        """np.ndarray: Nonlinear constraint function values of optimal points."""
         return self.meta_front.g
 
     @property
     def cv_nonlincon(self) -> np.ndarray:
-        """np.array: Nonlinear constraint violation values of optimal points."""
+        """np.ndarray: Nonlinear constraint violation values of optimal points."""
         return self.meta_front.cv_nonlincon
 
     @property
     def m(self) -> np.ndarray:
-        """np.array: Meta scores of optimal points."""
+        """np.ndarray: Meta scores of optimal points."""
         return self.meta_front.m
 
     @property
@@ -289,32 +297,32 @@ class OptimizationResults(Structure):
 
     @property
     def f_best_history(self) -> np.ndarray:
-        """np.array: Best objective values per generation."""
+        """np.ndarray: Best objective values per generation."""
         return np.array([pop.f_best for pop in self.meta_fronts])
 
     @property
     def f_min_history(self) -> np.ndarray:
-        """np.array: Minimum objective values per generation."""
+        """np.ndarray: Minimum objective values per generation."""
         return np.array([pop.f_min for pop in self.meta_fronts])
 
     @property
     def f_max_history(self) -> np.ndarray:
-        """np.array: Maximum objective values per generation."""
+        """np.ndarray: Maximum objective values per generation."""
         return np.array([pop.f_max for pop in self.meta_fronts])
 
     @property
     def f_avg_history(self) -> np.ndarray:
-        """np.array: Average objective values per generation."""
+        """np.ndarray: Average objective values per generation."""
         return np.array([pop.f_avg for pop in self.meta_fronts])
 
     @property
     def g_best_history(self) -> np.ndarray:
-        """np.array: Best nonlinear constraint per generation."""
+        """np.ndarray: Best nonlinear constraint per generation."""
         return np.array([pop.g_best for pop in self.meta_fronts])
 
     @property
     def g_min_history(self) -> np.ndarray:
-        """np.array: Minimum nonlinear constraint values per generation."""
+        """np.ndarray: Minimum nonlinear constraint values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
@@ -322,7 +330,7 @@ class OptimizationResults(Structure):
 
     @property
     def g_max_history(self) -> np.ndarray:
-        """np.array: Maximum nonlinear constraint values per generation."""
+        """np.ndarray: Maximum nonlinear constraint values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
@@ -330,7 +338,7 @@ class OptimizationResults(Structure):
 
     @property
     def g_avg_history(self) -> np.ndarray:
-        """np.array: Average nonlinear constraint values per generation."""
+        """np.ndarray: Average nonlinear constraint values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
@@ -338,7 +346,7 @@ class OptimizationResults(Structure):
 
     @property
     def cv_nonlincon_min_history(self) -> np.ndarray:
-        """np.array: Minimum nonlinear constraint violation values per generation."""
+        """np.ndarray: Minimum nonlinear constraint violation values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
@@ -346,7 +354,7 @@ class OptimizationResults(Structure):
 
     @property
     def cv_nonlincon_max_history(self) -> np.ndarray:
-        """np.array: Maximum nonlinear constraint violation values per generation."""
+        """np.ndarray: Maximum nonlinear constraint violation values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
@@ -354,7 +362,7 @@ class OptimizationResults(Structure):
 
     @property
     def cv_nonlincon_avg_history(self) -> np.ndarray:
-        """np.array: Average nonlinear constraint violation values per generation."""
+        """np.ndarray: Average nonlinear constraint violation values per generation."""
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
@@ -362,12 +370,12 @@ class OptimizationResults(Structure):
 
     @property
     def m_best_history(self) -> np.ndarray:
-        """np.array: Best meta scores per generation."""
+        """np.ndarray: Best meta scores per generation."""
         return np.array([pop.m_best for pop in self.meta_fronts])
 
     @property
     def m_min_history(self) -> np.ndarray:
-        """np.array: Minimum meta scores per generation."""
+        """np.ndarray: Minimum meta scores per generation."""
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
@@ -375,7 +383,7 @@ class OptimizationResults(Structure):
 
     @property
     def m_max_history(self) -> np.ndarray:
-        """np.array: Maximum meta scores per generation."""
+        """np.ndarray: Maximum meta scores per generation."""
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
@@ -383,13 +391,13 @@ class OptimizationResults(Structure):
 
     @property
     def m_avg_history(self) -> np.ndarray:
-        """np.array: Average meta scores per generation."""
+        """np.ndarray: Average meta scores per generation."""
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
             return np.array([pop.m_avg for pop in self.meta_fronts])
 
-    def plot_figures(self, show=True):
+    def plot_figures(self, show: bool = True) -> None:
         """
         Plot result figures.
 
@@ -436,14 +444,14 @@ class OptimizationResults(Structure):
 
     def plot_objectives(
         self,
-        include_meta=True,
-        plot_pareto=False,
-        plot_infeasible=True,
-        plot_individual=False,
-        autoscale=True,
-        show=True,
-        plot_directory=None,
-    ):
+        include_meta: bool = True,
+        plot_pareto: bool = False,
+        plot_infeasible: bool = True,
+        plot_individual: bool = False,
+        autoscale: bool = True,
+        show: bool = True,
+        plot_directory: Optional[str | Path] = None
+    ) -> None:
         """
         Plot objective function values for all optimization generations.
 
@@ -518,8 +526,12 @@ class OptimizationResults(Structure):
         return figs, axs
 
     def plot_pareto(
-        self, show=True, plot_pareto=True, plot_evolution=False, plot_directory=None
-    ):
+        self,
+        show: bool = True,
+        plot_pareto: bool = True,
+        plot_evolution: bool = False,
+        plot_directory: Optional[str | Path] = None
+    ) -> None:
         """
         Plot Pareto fronts for each generation in the optimization.
 
@@ -667,24 +679,22 @@ class OptimizationResults(Structure):
 
     def plot_convergence(
         self,
-        target="objectives",
-        figs=None,
-        axs=None,
-        plot_individual=False,
-        plot_avg=True,
-        autoscale=True,
-        show=True,
-        plot_directory=None,
-    ):
+        target: Literal["objectives", "nonlinear_constraints", "meta_scores"] = "objectives",
+        figs: Optional[Figure] = None,
+        axs: Optional[Axes] = None,
+        plot_individual: bool = False,
+        plot_avg: bool = True,
+        autoscale: bool = True,
+        show: bool = True,
+        plot_directory: bool = None
+    ) -> tuple[list[Figure] | Figure, list[Axes]]:
         """
         Plot the convergence of optimization metrics over evaluations.
 
         Parameters
         ----------
-        target : str, optional
-            The target metrics to plot: 'objectives', 'nonlinear_constraints',
-            or 'meta_scores'.
-            The default is 'objectives'.
+        target : Literal["objectives", "nonlinear_constraints", "meta_scores"],
+            The target metrics to plot. The default is "objectives".
         figs : plt.Figure or list of plt.Figure, optional
             Figure(s) to plot the objectives on.
         axs : plt.Axes or list of plt.Axes, optional
@@ -693,6 +703,9 @@ class OptimizationResults(Structure):
         plot_individual : bool, optional
             If True, create individual figure vor each metric.
             The default is False.
+        plot_avg : bool, optional
+            If True, plot add trajectory of average value per generation.
+            The default is True.
         autoscale : bool, optional
             If True, autoscale the y-axis. The default is True.
         show : bool, optional
@@ -827,7 +840,7 @@ class OptimizationResults(Structure):
         else:
             return figs[0], axs
 
-    def save_results(self, file_name: str):
+    def save_results(self, file_name: str) -> None:
         """
         Save results to H5 file.
 
@@ -848,7 +861,7 @@ class OptimizationResults(Structure):
             results.filename = self.results_directory / f"{file_name}.h5"
             results.save()
 
-    def load_results(self, file_name: str) -> NoReturn:
+    def load_results(self, file_name: str) -> None:
         """
         Update optimization results from an HDF5 checkpoint file.
 
@@ -898,7 +911,7 @@ class OptimizationResults(Structure):
 
         return data
 
-    def update_from_dict(self, data: dict):
+    def update_from_dict(self, data: dict) -> None:
         """
         Update internal state from dictionary.
 
@@ -923,7 +936,7 @@ class OptimizationResults(Structure):
                 ParetoFront.from_dict(d) for d in data["meta_fronts"].values()
             ]
 
-    def setup_csv(self):
+    def setup_csv(self) -> None:
         """Create csv files for optimization results."""
         self._setup_csv("results_all")
         self._setup_csv("results_last")
@@ -931,7 +944,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_meta_scores > 0:
             self._setup_csv("results_meta")
 
-    def _setup_csv(self, file_name: str):
+    def _setup_csv(self, file_name: str) -> None:
         """
         Create csv file for optimization results.
 
@@ -960,7 +973,7 @@ class OptimizationResults(Structure):
         population: Population,
         file_name: str,
         mode: Literal["w", "b"],
-    ):
+    ) -> None:
         """
         Update csv file with latest population.
 

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -10,7 +10,8 @@ from CADETProcess.optimization import OptimizationProblem, OptimizerBase
 
 
 class SciPyInterface(OptimizerBase):
-    """Wrapper around scipy's optimization suite.
+    """
+    Wrapper around scipy's optimization suite.
 
     Defines the bounds and all constraints, saved in a constraint_object. Also
     the jacobian matrix is defined for several solvers.
@@ -42,7 +43,6 @@ class SciPyInterface(OptimizerBase):
     CADETProcess.optimization.OptimizationProblem.evaluate_objectives
     options
     scipy.optimize.minimize
-
     """
 
     finite_diff_rel_step = UnsignedFloat()
@@ -50,7 +50,8 @@ class SciPyInterface(OptimizerBase):
     jac = Switch(valid=["2-point", "3-point", "cs"], default="2-point")
 
     def _run(self, optimization_problem: OptimizationProblem, x0=None):
-        """Solve the optimization problem using any of the scipy methods.
+        """
+        Solve the optimization problem using any of the scipy methods.
 
         Returns
         -------
@@ -69,7 +70,6 @@ class SciPyInterface(OptimizerBase):
         CADETProcess.optimization.OptimizationProblem.evaluate_objectives
         options
         scipy.optimize.minimize
-
         """
         self.n_evals = 0
 
@@ -85,7 +85,8 @@ class SciPyInterface(OptimizerBase):
             )[0]
 
         def callback_function(x, state=None):
-            """Internal callback to report progress after evaluation.
+            """
+            Report progress after evaluation.
 
             Notes
             -----
@@ -153,9 +154,9 @@ class SciPyInterface(OptimizerBase):
         self.results.exit_flag = scipy_results.status
         self.results.exit_message = scipy_results.message
 
-    def get_bounds(self, optimization_problem):
-        """Returns the optimized bounds of a given optimization_problem as a
-        Bound object.
+    def get_bounds(self, optimization_problem) -> optimize.Bounds:
+        """
+        Return the optimized bounds of a given optimization_problem as a Bound object.
 
         Optimizes the bounds of the optimization_problem by calling the method
         optimize.Bounds. Keep_feasible is set to True.
@@ -171,8 +172,9 @@ class SciPyInterface(OptimizerBase):
             keep_feasible=True,
         )
 
-    def get_constraint_objects(self, optimization_problem):
-        """Return constraints as objets.
+    def get_constraint_objects(self, optimization_problem) -> list:
+        """
+        Return constraints as objets.
 
         Returns
         -------
@@ -195,7 +197,8 @@ class SciPyInterface(OptimizerBase):
         return [con for con in constraints if con is not None]
 
     def get_lincon_obj(self, optimization_problem):
-        """Return the linear constraints as an object.
+        """
+        Return the linear constraints as an object.
 
         Returns
         -------
@@ -220,7 +223,8 @@ class SciPyInterface(OptimizerBase):
         )
 
     def get_lineqcon_obj(self, optimization_problem):
-        """Return the linear equality constraints as an object.
+        """
+        Return the linear equality constraints as an object.
 
         Returns
         -------
@@ -245,7 +249,8 @@ class SciPyInterface(OptimizerBase):
         )
 
     def get_nonlincon_obj(self, optimization_problem):
-        """Return the optimized nonlinear constraints as an object.
+        """
+        Return the optimized nonlinear constraints as an object.
 
         Returns
         -------
@@ -263,7 +268,8 @@ class SciPyInterface(OptimizerBase):
         opt = optimization_problem
 
         def makeConstraint(i):
-            """Create optimize.NonlinearConstraint object.
+            """
+            Create optimize.NonlinearConstraint object.
 
             Parameters
             ----------
@@ -300,11 +306,13 @@ class SciPyInterface(OptimizerBase):
         return constraints
 
     def __str__(self):
+        """str: String representation."""
         return self.__class__.__name__
 
 
 class TrustConstr(SciPyInterface):
-    """Wrapper for the trust-constr optimization method from the scipy optimization suite.
+    """
+    Wrapper for the trust-constr optimization method from the scipy optimization suite.
 
     It defines the solver options in the 'options' variable as a dictionary.
 
@@ -392,7 +400,6 @@ class TrustConstr(SciPyInterface):
         - 3 for more complete progress report.
     disp : Bool, optional
         If True, then verbose will be set to 1 if it was 0. Default is False.
-
     """
 
     supports_linear_constraints = True
@@ -440,11 +447,13 @@ class TrustConstr(SciPyInterface):
     ]
 
     def __str__(self):
+        """str: String representation."""
         return "trust-constr"
 
 
 class COBYLA(SciPyInterface):
-    """Wrapper for the COBYLA optimization method from the scipy optimization suite.
+    """
+    Wrapper for the COBYLA optimization method from the scipy optimization suite.
 
     It defines the solver options in the 'options' variable as a dictionary.
 
@@ -467,7 +476,6 @@ class COBYLA(SciPyInterface):
         Maximum number of function evaluations.
     catol : float, default 2e-4
         Absolute tolerance for constraint violations.
-
     """
 
     supports_linear_constraints = True
@@ -490,7 +498,8 @@ class COBYLA(SciPyInterface):
 
 
 class NelderMead(SciPyInterface):
-    """Wrapper for the Nelder-Mead optimization method from the scipy optimization suite.
+    """
+    Wrapper for the Nelder-Mead optimization method from the scipy optimization suite.
 
     Supports:
         - Bounds.
@@ -539,12 +548,14 @@ class NelderMead(SciPyInterface):
         "disp",
     ]
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: String representation."""
         return "Nelder-Mead"
 
 
 class SLSQP(SciPyInterface):
-    """Wrapper for the SLSQP optimization method from the scipy optimization suite.
+    """
+    Wrapper for the SLSQP optimization method from the scipy optimization suite.
 
     It defines the solver options in the 'options' variable as a dictionary.
 

--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -1,6 +1,8 @@
 import warnings
+from typing import Optional
 
 import numpy as np
+import numpy.typing as npt
 from scipy import optimize
 from scipy.optimize import OptimizeWarning
 
@@ -43,18 +45,19 @@ class SciPyInterface(OptimizerBase):
     CADETProcess.optimization.OptimizationProblem.evaluate_objectives
     options
     scipy.optimize.minimize
+
     """
 
     finite_diff_rel_step = UnsignedFloat()
     tol = UnsignedFloat()
     jac = Switch(valid=["2-point", "3-point", "cs"], default="2-point")
 
-    def _run(self, optimization_problem: OptimizationProblem, x0=None):
+    def _run(self, optimization_problem: OptimizationProblem, x0: Optional[list] = None) -> None:
         """
         Solve the optimization problem using any of the scipy methods.
 
-        Returns
-        -------
+        Parameters
+        ----------
         results : OptimizationResults
             Optimization results including optimization_problem and solver
             configuration.
@@ -76,7 +79,7 @@ class SciPyInterface(OptimizerBase):
         if optimization_problem.n_objectives > 1:
             raise CADETProcessError("Can only handle single objective.")
 
-        def objective_function(x):
+        def objective_function(x: npt.ArrayLike) -> np.ndarray:
             return optimization_problem.evaluate_objectives(
                 x,
                 untransform=True,
@@ -84,7 +87,7 @@ class SciPyInterface(OptimizerBase):
                 ensure_minimization=True,
             )[0]
 
-        def callback_function(x, state=None):
+        def callback_function(x: npt.ArrayLike, state: dict = None) -> bool:
             """
             Report progress after evaluation.
 
@@ -154,7 +157,7 @@ class SciPyInterface(OptimizerBase):
         self.results.exit_flag = scipy_results.status
         self.results.exit_message = scipy_results.message
 
-    def get_bounds(self, optimization_problem) -> optimize.Bounds:
+    def get_bounds(self, optimization_problem: OptimizationProblem) -> optimize.Bounds:
         """
         Return the optimized bounds of a given optimization_problem as a Bound object.
 
@@ -172,7 +175,7 @@ class SciPyInterface(OptimizerBase):
             keep_feasible=True,
         )
 
-    def get_constraint_objects(self, optimization_problem) -> list:
+    def get_constraint_objects(self, optimization_problem: OptimizationProblem) -> list:
         """
         Return constraints as objets.
 
@@ -196,7 +199,9 @@ class SciPyInterface(OptimizerBase):
 
         return [con for con in constraints if con is not None]
 
-    def get_lincon_obj(self, optimization_problem):
+    def get_lincon_obj(
+        self, optimization_problem: OptimizationProblem
+    ) -> optimize.LinearConstraint:
         """
         Return the linear constraints as an object.
 
@@ -222,7 +227,9 @@ class SciPyInterface(OptimizerBase):
             optimization_problem.A_independent_transformed, lb, ub, keep_feasible=True
         )
 
-    def get_lineqcon_obj(self, optimization_problem):
+    def get_lineqcon_obj(
+        self, optimization_problem: OptimizationProblem
+    ) -> optimize.LinearConstraint:
         """
         Return the linear equality constraints as an object.
 
@@ -248,7 +255,7 @@ class SciPyInterface(OptimizerBase):
             optimization_problem.Aeq_independent_transformed, lb, ub, keep_feasible=True
         )
 
-    def get_nonlincon_obj(self, optimization_problem):
+    def get_nonlincon_obj(self, optimization_problem: OptimizationProblem) -> list:
         """
         Return the optimized nonlinear constraints as an object.
 
@@ -267,7 +274,7 @@ class SciPyInterface(OptimizerBase):
 
         opt = optimization_problem
 
-        def makeConstraint(i):
+        def makeConstraint(i: int) -> optimize.NonlinearConstraint:
             """
             Create optimize.NonlinearConstraint object.
 
@@ -305,7 +312,7 @@ class SciPyInterface(OptimizerBase):
 
         return constraints
 
-    def __str__(self):
+    def __str__(self) -> str:
         """str: String representation."""
         return self.__class__.__name__
 
@@ -446,7 +453,7 @@ class TrustConstr(SciPyInterface):
         "disp",
     ]
 
-    def __str__(self):
+    def __str__(self) -> str:
         """str: String representation."""
         return "trust-constr"
 

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -46,9 +46,8 @@ it's no longer required for setting up as optimization problem.
 import numpy as np
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure
+from CADETProcess.dataStructure import SizedNdArray, Structure
 from CADETProcess.metric import MetricBase
-from CADETProcess.dataStructure import SizedNdArray
 from CADETProcess.processModel import ComponentSystem
 
 
@@ -90,21 +89,34 @@ class Performance(Structure):
     """
 
     _performance_keys = [
-        'mass', 'concentration', 'purity', 'recovery',
-        'productivity', 'eluent_consumption', 'mass_balance_difference'
+        "mass",
+        "concentration",
+        "purity",
+        "recovery",
+        "productivity",
+        "eluent_consumption",
+        "mass_balance_difference",
     ]
 
-    mass = SizedNdArray(size=('n_comp'))
-    concentration = SizedNdArray(size=('n_comp'))
-    purity = SizedNdArray(size=('n_comp'))
-    recovery = SizedNdArray(size=('n_comp'))
-    productivity = SizedNdArray(size=('n_comp'))
-    eluent_consumption = SizedNdArray(size=('n_comp'))
-    mass_balance_difference = SizedNdArray(size=('n_comp'))
+    mass = SizedNdArray(size=("n_comp"))
+    concentration = SizedNdArray(size=("n_comp"))
+    purity = SizedNdArray(size=("n_comp"))
+    recovery = SizedNdArray(size=("n_comp"))
+    productivity = SizedNdArray(size=("n_comp"))
+    eluent_consumption = SizedNdArray(size=("n_comp"))
+    mass_balance_difference = SizedNdArray(size=("n_comp"))
 
     def __init__(
-            self, mass, concentration, purity, recovery,
-            productivity, eluent_consumption, mass_balance_difference, component_system=None):
+        self,
+        mass,
+        concentration,
+        purity,
+        recovery,
+        productivity,
+        eluent_consumption,
+        mass_balance_difference,
+        component_system=None,
+    ):
         """Initialize Performance.
 
         Parameters
@@ -145,29 +157,29 @@ class Performance(Structure):
 
     def to_dict(self):
         """Return a dictionary representation of the object."""
-        return {key: getattr(self, key).tolist()
-                for key in self._performance_keys}
+        return {key: getattr(self, key).tolist() for key in self._performance_keys}
 
     def __getitem__(self, item):
         """Get an attribute of the object by its name."""
         if item not in self._performance_keys:
-            raise AttributeError('Not a valid performance parameter')
+            raise AttributeError("Not a valid performance parameter")
 
         return getattr(self, item)
 
     def __repr__(self):
         """String representation of the object."""
-        return \
-            f'{self.__class__.__name__}(mass={np.array_repr(self.mass)}, '\
-            f'concentration={np.array_repr(self.concentration)}, '\
-            f'purity={np.array_repr(self.purity)}, '\
-            f'recovery={np.array_repr(self.recovery)}, '\
-            f'productivity={np.array_repr(self.productivity)}, '\
-            f'eluent_consumption={np.array_repr(self.eluent_consumption)} '\
-            f'mass_balance_difference={np.array_repr(self.mass_balance_difference)})'
+        return (
+            f"{self.__class__.__name__}(mass={np.array_repr(self.mass)}, "
+            f"concentration={np.array_repr(self.concentration)}, "
+            f"purity={np.array_repr(self.purity)}, "
+            f"recovery={np.array_repr(self.recovery)}, "
+            f"productivity={np.array_repr(self.productivity)}, "
+            f"eluent_consumption={np.array_repr(self.eluent_consumption)} "
+            f"mass_balance_difference={np.array_repr(self.mass_balance_difference)})"
+        )
 
 
-class RankedPerformance():
+class RankedPerformance:
     """Class for calculating a weighted average of the Performance
 
     See Also
@@ -181,7 +193,7 @@ class RankedPerformance():
 
     def __init__(self, performance, ranking=1.0):
         if not isinstance(performance, Performance):
-            raise TypeError('Expected Performance')
+            raise TypeError("Expected Performance")
 
         self._performance = performance
 
@@ -200,34 +212,33 @@ class RankedPerformance():
         if isinstance(ranking, (float, int)):
             ranking = self.performance.n_comp * [ranking]
         elif len(ranking) != self.performance.n_comp:
-            raise CADETProcessError('Number of components does not match.')
+            raise CADETProcessError("Number of components does not match.")
 
         self._ranking = ranking
 
     def to_dict(self):
-        return {
-            key: float(getattr(self, key)) for key in self._performance_keys
-        }
+        return {key: float(getattr(self, key)) for key in self._performance_keys}
 
     def __getattr__(self, item):
         if item not in self._performance_keys:
             raise AttributeError
-        return sum(self._performance[item]*self.ranking)/sum(self.ranking)
+        return sum(self._performance[item] * self.ranking) / sum(self.ranking)
 
     def __getitem__(self, item):
         if item not in self._performance_keys:
-            raise AttributeError('Not a valid performance parameter')
+            raise AttributeError("Not a valid performance parameter")
         return getattr(self, item)
 
     def __repr__(self):
-        return \
-            f'{self.__class__.__name__}(mass={np.array_repr(self.mass)}, '\
-            f'concentration={np.array_repr(self.concentration)}, '\
-            f'purity={np.array_repr(self.purity)}, '\
-            f'recovery={np.array_repr(self.recovery)}, '\
-            f'productivity={np.array_repr(self.productivity)}, '\
-            f'eluent_consumption={np.array_repr(self.eluent_consumption)} ' \
-            f'mass_balance_difference={np.array_repr(self.mass_balance_difference)})'
+        return (
+            f"{self.__class__.__name__}(mass={np.array_repr(self.mass)}, "
+            f"concentration={np.array_repr(self.concentration)}, "
+            f"purity={np.array_repr(self.purity)}, "
+            f"recovery={np.array_repr(self.recovery)}, "
+            f"productivity={np.array_repr(self.productivity)}, "
+            f"eluent_consumption={np.array_repr(self.eluent_consumption)} "
+            f"mass_balance_difference={np.array_repr(self.mass_balance_difference)})"
+        )
 
 
 class PerformanceIndicator(MetricBase):
@@ -390,10 +401,11 @@ class PerformanceProduct(PerformanceIndicator):
     """
 
     def _evaluate(self, performance):
-        return \
-            performance.productivity \
-            * performance.recovery \
+        return (
+            performance.productivity
+            * performance.recovery
             * performance.eluent_consumption
+        )
 
 
 class MassBalanceDifference(PerformanceIndicator):

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -41,7 +41,9 @@ Notes
 Performance Indicators might be deprecated in future since with new evaluation chains
 it's no longer required for setting up as optimization problem.
 
-"""
+"""  # noqa
+
+from typing import Any
 
 import numpy as np
 
@@ -52,7 +54,8 @@ from CADETProcess.processModel import ComponentSystem
 
 
 class Performance(Structure):
-    """Class for storing the performance parameters after fractionation.
+    """
+    Class for storing the performance parameters after fractionation.
 
     Attributes
     ----------
@@ -85,7 +88,6 @@ class Performance(Structure):
     --------
     CADETProcess.fractionation
     RankedPerformance
-
     """
 
     _performance_keys = [
@@ -117,7 +119,8 @@ class Performance(Structure):
         mass_balance_difference,
         component_system=None,
     ):
-        """Initialize Performance.
+        """
+        Initialize Performance.
 
         Parameters
         ----------
@@ -155,11 +158,11 @@ class Performance(Structure):
         """int: Number of components in the system."""
         return self.component_system.n_comp
 
-    def to_dict(self):
-        """Return a dictionary representation of the object."""
+    def to_dict(self) -> dict:
+        """Return dictionary representation of the object."""
         return {key: getattr(self, key).tolist() for key in self._performance_keys}
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> Any:
         """Get an attribute of the object by its name."""
         if item not in self._performance_keys:
             raise AttributeError("Not a valid performance parameter")
@@ -167,7 +170,7 @@ class Performance(Structure):
         return getattr(self, item)
 
     def __repr__(self):
-        """String representation of the object."""
+        """str: String representation of the object."""
         return (
             f"{self.__class__.__name__}(mass={np.array_repr(self.mass)}, "
             f"concentration={np.array_repr(self.concentration)}, "
@@ -180,13 +183,13 @@ class Performance(Structure):
 
 
 class RankedPerformance:
-    """Class for calculating a weighted average of the Performance
+    """
+    Class for calculating a weighted average of the Performance.
 
     See Also
     --------
     Performance
     ranked_objective_decorator
-
     """
 
     _performance_keys = Performance._performance_keys
@@ -200,11 +203,13 @@ class RankedPerformance:
         self.ranking = ranking
 
     @property
-    def performance(self):
+    def performance(self) -> Performance:
+        """Performance: Performance object."""
         return self._performance
 
     @property
-    def ranking(self):
+    def ranking(self) -> list[float]:
+        """list[float]: Relative weighting factors for multi component evaluation."""
         return self._ranking
 
     @ranking.setter
@@ -216,20 +221,24 @@ class RankedPerformance:
 
         self._ranking = ranking
 
-    def to_dict(self):
+    def to_dict(self) -> Any:
+        """Return dictionary representation of the object."""
         return {key: float(getattr(self, key)) for key in self._performance_keys}
 
-    def __getattr__(self, item):
+    def __getattr__(self, item: str) -> float:
+        """Retrieve a performance attribute by its name, weighted by ranking."""
         if item not in self._performance_keys:
             raise AttributeError
         return sum(self._performance[item] * self.ranking) / sum(self.ranking)
 
-    def __getitem__(self, item):
+    def __getitem__(self, item) -> Any:
+        """Retrieve an attribute of the object by its name using indexing syntax."""
         if item not in self._performance_keys:
             raise AttributeError("Not a valid performance parameter")
         return getattr(self, item)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: Sting representation of the object."""
         return (
             f"{self.__class__.__name__}(mass={np.array_repr(self.mass)}, "
             f"concentration={np.array_repr(self.concentration)}, "
@@ -242,7 +251,8 @@ class RankedPerformance:
 
 
 class PerformanceIndicator(MetricBase):
-    """Base class for performance indicators used in optimization and fractionation.
+    """
+    Base class for performance indicators used in optimization and fractionation.
 
     See Also
     --------
@@ -250,7 +260,8 @@ class PerformanceIndicator(MetricBase):
     """
 
     def __init__(self, ranking=None):
-        """Initialize PerformanceIndicator.
+        """
+        Initialize PerformanceIndicator.
 
         Parameters
         ----------
@@ -261,6 +272,7 @@ class PerformanceIndicator(MetricBase):
 
     @property
     def ranking(self):
+        """list[float]: Relative weighting factors for multi component evaluation."""
         return self._ranking
 
     @ranking.setter
@@ -268,11 +280,13 @@ class PerformanceIndicator(MetricBase):
         self._ranking = ranking
 
     @property
-    def bad_metrics(self):
+    def bad_metrics(self) -> int:
+        """int: Bad metrics to use when evaluation fails."""
         return 0
 
     def evaluate(self, performance):
-        """Evaluate the performance indicator for the given performance data.
+        """
+        Evaluate the performance indicator for the given performance data.
 
         Parameters
         ----------
@@ -305,18 +319,18 @@ class PerformanceIndicator(MetricBase):
 
     __call__ = evaluate
 
-    def __str__(self):
-        """String representation of the class."""
+    def __str__(self) -> str:
+        """str: String representation of the class."""
         return self.__class__.__name__
 
 
 class Mass(PerformanceIndicator):
-    """Performance indicator based on the mass of each component in the system.
+    """
+    Performance indicator based on the mass of each component in the system.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -324,12 +338,12 @@ class Mass(PerformanceIndicator):
 
 
 class Recovery(PerformanceIndicator):
-    """Performance indicator based on the recovery of each component in the system.
+    """
+    Performance indicator based on the recovery of each component in the system.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -337,12 +351,12 @@ class Recovery(PerformanceIndicator):
 
 
 class Productivity(PerformanceIndicator):
-    """Performance indicator based on the productivity of each component in the system.
+    """
+    Performance indicator based on the productivity of each component in the system.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -350,12 +364,12 @@ class Productivity(PerformanceIndicator):
 
 
 class EluentConsumption(PerformanceIndicator):
-    """Performance indicator based on the specific eluent consumption of each component.
+    """
+    Performance indicator based on the specific eluent consumption of each component.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -363,12 +377,12 @@ class EluentConsumption(PerformanceIndicator):
 
 
 class Purity(PerformanceIndicator):
-    """Performance indicator based on the purity of each component in the system.
+    """
+    Performance indicator based on the purity of each component in the system.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -376,12 +390,12 @@ class Purity(PerformanceIndicator):
 
 
 class Concentration(PerformanceIndicator):
-    """Performance indicator based on the concentration of each component in the system.
+    """
+    Performance indicator based on the concentration of each component in the system.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -389,7 +403,8 @@ class Concentration(PerformanceIndicator):
 
 
 class PerformanceProduct(PerformanceIndicator):
-    """Performance indicator based on the product of several performance indicators.
+    """
+    Performance indicator based on the product of several performance indicators.
 
     See Also
     --------
@@ -397,7 +412,6 @@ class PerformanceProduct(PerformanceIndicator):
     Recovery
     EluentConsumption
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):
@@ -409,12 +423,12 @@ class PerformanceProduct(PerformanceIndicator):
 
 
 class MassBalanceDifference(PerformanceIndicator):
-    """Performance indicator based on the mass balance of each component in the system.
+    """
+    Performance indicator based on the mass balance of each component in the system.
 
     See Also
     --------
     PerformanceIndicator
-
     """
 
     def _evaluate(self, performance):

--- a/CADETProcess/plotting.py
+++ b/CADETProcess/plotting.py
@@ -73,15 +73,19 @@ Hlines
     HLines
     add_hlines
 
-"""
+"""  # noqa
 
 import sys
 from functools import wraps
+from typing import Any, Optional
 
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np
+import numpy.typing as npt
 from matplotlib import cycler
+from matplotlib.axes import Axes
+from matplotlib.figure import Figure
 
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import (
@@ -145,8 +149,9 @@ figure_styles = {
 }
 
 
-def set_figure_style(style="medium"):
-    """Define the sytle of a plot.
+def set_figure_style(style: Optional[str] = "medium"):
+    """
+    Define the sytle of a plot.
 
     Can set the sytle of a plot for small, medium and large plots. The
     figuresize of the figure, the linewitdth and color of the lines and the
@@ -154,7 +159,7 @@ def set_figure_style(style="medium"):
 
     Parameters
     ----------
-    style : str
+    style : str, optional
         Style of a figure plot, default set to small.
 
     Raises
@@ -205,7 +210,6 @@ def get_fig_size(n_rows=1, n_cols=1, style=None):
     -------
     fig_size : tuple
         Size of the figure (width, height)
-
     """
     if style is None:
         style = this.style
@@ -218,26 +222,30 @@ def get_fig_size(n_rows=1, n_cols=1, style=None):
     return fig_size
 
 
-def setup_figure(n_rows=1, n_cols=1, style=None, squeeze=True):
+def setup_figure(
+    n_rows: Optional[int] = 1,
+    n_cols: Optional[int] = 1,
+    style: Optional[str] = None,
+    squeeze: Optional[bool] = True
+) -> tuple[Figure, Axes]:
     """
-    Setup a figure.
+    Set up a matplotlib figure with specified dimensions and style.
 
     Parameters
     ----------
     n_rows : int, optional
-        Number of rows in the figure. The default is 1.
+        Number of rows in the figure, by default 1.
     n_cols : int, optional
-        Number of columns in the figure. The default is 1.
+        Number of columns in the figure, by default 1.
     style : str, optional
-        Style to use for the figure. The default is None.
+        Style to use for the figure. Uses a predefined style if None.
     squeeze : bool, optional
-        If True, extra dimensions are squeezed out from the returned array of Axes.
-        The default is True.
+        If True, extra dimensions are removed from the returned Axes array, by default True.
 
     Returns
     -------
-    fig : Figure
-    ax : Axes or array of Axes
+    tuple[Figure, Axes]
+        A tuple containing the Figure object and an Axes object or an array of Axes objects.
     """
     if style is None:
         style = this.style
@@ -254,6 +262,8 @@ def setup_figure(n_rows=1, n_cols=1, style=None, squeeze=True):
 
 
 class SecondaryAxis(Structure):
+    """Parameters for secondary axis."""
+
     components = List()
     y_label = String()
     y_lim = Tuple()
@@ -261,6 +271,8 @@ class SecondaryAxis(Structure):
 
 
 class Layout(Structure):
+    """General figure layout."""
+
     style = String()
     title = String()
     x_label = String()
@@ -271,7 +283,29 @@ class Layout(Structure):
     y_lim = Tuple()
 
 
-def set_layout(ax, layout, show_legend=True, ax_secondary=None, secondary_layout=None):
+def set_layout(
+    ax: Axes,
+    layout: Layout,
+    show_legend: bool = True,
+    ax_secondary: Optional[SecondaryAxis] = None,
+    secondary_layout: Optional[Layout] = None
+) -> None:
+    """
+    Configure the layout of a matplotlib Axes object.
+
+    Parameters
+    ----------
+    ax : Axes
+        The primary matplotlib Axes object to configure.
+    layout : Layout
+        Layout object containing axis labels, limits, title, and ticks.
+    show_legend : bool, optional
+        Whether to display the legend. Default is True.
+    ax_secondary : Optional[SecondaryAxis], optional
+        The secondary Axes object, if applicable.
+    secondary_layout : Optional[Layout], optional
+        Layout object for the secondary axis, if applicable.
+    """
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
 
@@ -303,23 +337,67 @@ def set_layout(ax, layout, show_legend=True, ax_secondary=None, secondary_layout
 
 
 class Tick(Structure):
+    """Parameters for Axes ticks."""
+
     location: Tuple()
     label: String()
 
 
-def set_yticks(ax, y_ticks):
-    locs = np.array([y_tick["loc"] for y_tick in y_ticks])
-    labels = [y_tick["label"] for y_tick in y_ticks]
+def set_yticks(ax: Axes, y_ticks: list[Tick]) -> None:
+    """
+    Set the y-ticks on a matplotlib Axes object.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib Axes object to set the y-ticks on.
+    y_ticks : list[Tick]
+        List of Tick objects containing location and label for each y-tick.
+    """
+    locs = np.array([y_tick.location for y_tick in y_ticks])
+    labels = [y_tick.label for y_tick in y_ticks]
     ax.set_yticks(locs, labels)
 
 
-def set_xticks(ax, x_ticks):
-    locs = np.array([x_tick["loc"] for x_tick in x_ticks])
-    labels = [x_tick["label"] for x_tick in x_ticks]
+def set_xticks(ax: Axes, x_ticks: list[Tick]) -> None:
+    """
+    Set the x-ticks on a matplotlib Axes object with rotation.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib Axes object to set the x-ticks on.
+    x_ticks : list[Tick]
+        List of Tick objects containing location and label for each x-tick.
+    """
+    locs = np.array([x_tick.location for x_tick in x_ticks])
+    labels = [x_tick.label for x_tick in x_ticks]
     plt.xticks(locs, labels, rotation=72, horizontalalignment="center")
 
 
-def add_text(ax, text, position=(0.05, 0.9), tb_props=None, **kwargs):
+def add_text(
+    ax: Axes,
+    text: str,
+    position: tuple[float, float] = (0.05, 0.9),
+    tb_props: Optional[Any] = None,
+    **kwargs: Optional[dict],
+) -> None:
+    """
+    Add text to a matplotlib Axes object.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib Axes object to add text to.
+    text : str
+        The text to be added.
+    position : tuple[float], optional
+        The position of the text, default is (0.05, 0.9).
+    tb_props : Optional[Any], optional
+        Properties to update the textbox with.
+    **kwargs : Optional[dict]
+        Additional keyword arguments for text customization.
+    """
     if tb_props is not None:
         textbox_props.update(tb_props)
 
@@ -333,9 +411,27 @@ def add_text(ax, text, position=(0.05, 0.9), tb_props=None, **kwargs):
     )
 
 
-def add_overlay(ax, y_overlay, x_overlay=None, **plot_args):
-    if not isinstance(y_overlay, list):
-        y_overlay = [y_overlay]
+def add_overlay(
+    ax: Axes,
+    y_overlay: npt.ArrayLike,
+    x_overlay: Optional[npt.ArrayLike] = None,
+    **plot_args: Optional[dict]
+) -> None:
+    """
+    Add overlay plot(s) to a matplotlib Axes object.
+
+    Parameters
+    ----------
+    ax : Axes
+        The matplotlib Axes object to which the overlay is added.
+    y_overlay : npt.ArrayLike
+        The y-data for the overlay plot(s).
+    x_overlay : Optional[list], optional
+        The x-data for the overlay plot(s). If None, uses x-data from the first line in ax.
+    **plot_args : Optional[dict]
+        Additional keyword arguments for customizing the plot.
+    """
+    y_overlay = np.array(y_overlay)
 
     if x_overlay is None:
         x_overlay = ax.lines[0].get_xdata()
@@ -346,13 +442,19 @@ def add_overlay(ax, y_overlay, x_overlay=None, **plot_args):
 
 
 class Annotation(Structure):
+    """Parameters for text annotations."""
+
     text = String()
     xy = Tuple()
     xytext = Tuple()
     arrowstyle = "-|>"
 
 
-def add_annotations(ax, annotations):
+def add_annotations(
+        ax: Axes,
+        annotations: list[Annotation]
+        ) -> None:
+    """Add list of annotations to axis ax."""
     for annotation in annotations:
         ax.annotate(
             annotation.text,
@@ -367,6 +469,8 @@ def add_annotations(ax, annotations):
 
 
 class FillRegion(Structure):
+    """Parameters for fill region."""
+
     color_index = Integer()
     start = UnsignedFloat()
     end = UnsignedFloat()
@@ -376,7 +480,12 @@ class FillRegion(Structure):
     text = String()
 
 
-def add_fill_regions(ax, fill_regions, x_lim=None):
+def add_fill_regions(
+        ax: Axes,
+        fill_regions: list[FillRegion],
+        x_lim: Optional[npt.ArrayLike] = None
+        ) -> None:
+    """Add FillRegion to axes."""
     for fill in fill_regions:
         color = color_list[fill.color_index]
         ax.fill_between(
@@ -403,38 +512,51 @@ def add_fill_regions(ax, fill_regions, x_lim=None):
 
 
 class HLines(Structure):
+    """Parameters for plotting horizontal lines."""
+
     y = UnsignedFloat()
     x_min = UnsignedFloat()
     x_max = UnsignedFloat()
 
 
-def add_hlines(ax, hlines):
+def add_hlines(ax: Axes, hlines: list[HLines]) -> None:
+    """Add hlines to matplotlib Axes."""
     for line in hlines:
         ax.hlines(line.y, line.x_min, line.x_max)
 
 
 def create_and_save_figure(func):
+    """Wrap plot functions to provide some general utility."""
     @wraps(func)
     def wrapper(
-        *args,
-        fig=None,
-        ax=None,
-        show=True,
-        file_name=None,
-        style="medium",
-        **kwargs,
-    ):
-        """Wrapper around plot function.
+            *args: Any,
+            fig: Optional[Figure] = None,
+            ax: Optional[Axes] = None,
+            show: bool = True,
+            file_name: Optional[str] = None,
+            style: str = 'medium',
+            **kwargs: Any
+            ) -> tuple:
+        """
+        Wrap plot functions to provide some general utility.
 
         Parameters
         ----------
+        *args :
+            Parameters wrapped around.
         fig : Figure, optional
+            Figure object.
         ax : Axes, optional
            Axes to plot on. If None, a new standard figure will be created.
         show : bool, optional
             If True, show plot. The default is False.
         file_name : str, optional
             Path for saving figure. If None, figure is not saved.
+        style : str, optional
+            Style for figure. Default i 'medium'.
+        **kwargs :
+            Additional parameters wrapped around.
+
         """
         if ax is None:
             fig, ax = setup_figure(style=style)

--- a/CADETProcess/plotting.py
+++ b/CADETProcess/plotting.py
@@ -149,7 +149,7 @@ figure_styles = {
 }
 
 
-def set_figure_style(style: Optional[str] = "medium"):
+def set_figure_style(style: Optional[str] = 'medium') -> None:
     """
     Define the sytle of a plot.
 
@@ -193,7 +193,11 @@ def set_figure_style(style: Optional[str] = "medium"):
 set_figure_style()
 
 
-def get_fig_size(n_rows=1, n_cols=1, style=None):
+def get_fig_size(
+    n_rows: Optional[int] = 1,
+    n_cols: Optional[int] = 1,
+    style: Optional[str] = None
+) -> tuple[float, float]:
     """
     Get figure size for figures with multiple Axes.
 
@@ -288,7 +292,7 @@ def set_layout(
     layout: Layout,
     show_legend: bool = True,
     ax_secondary: Optional[SecondaryAxis] = None,
-    secondary_layout: Optional[Layout] = None
+    secondary_layout: Optional[Layout] = None,
 ) -> None:
     """
     Configure the layout of a matplotlib Axes object.
@@ -525,7 +529,7 @@ def add_hlines(ax: Axes, hlines: list[HLines]) -> None:
         ax.hlines(line.y, line.x_min, line.x_max)
 
 
-def create_and_save_figure(func):
+def create_and_save_figure(func: Callable) -> Callable:
     """Wrap plot functions to provide some general utility."""
     @wraps(func)
     def wrapper(
@@ -535,7 +539,7 @@ def create_and_save_figure(func):
             show: bool = True,
             file_name: Optional[str] = None,
             style: str = 'medium',
-            **kwargs: Any
+            **kwargs: Any,
             ) -> tuple:
         """
         Wrap plot functions to provide some general utility.

--- a/CADETProcess/plotting.py
+++ b/CADETProcess/plotting.py
@@ -75,75 +75,77 @@ Hlines
 
 """
 
-from functools import wraps
 import sys
+from functools import wraps
 
-import numpy as np
 import matplotlib
 import matplotlib.pyplot as plt
+import numpy as np
 from matplotlib import cycler
 
 from CADETProcess import CADETProcessError
-
-from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    Integer, List, String, Tuple, Callable, UnsignedFloat
+    Callable,
+    Integer,
+    List,
+    String,
+    Structure,
+    Tuple,
+    UnsignedFloat,
 )
-
 
 this = sys.modules[__name__]
 
-style = 'medium'
+style = "medium"
 
 color_dict = {
-    'blue': matplotlib.colors.to_rgb('#000099'),
-    'red':  matplotlib.colors.to_rgb('#990000'),
-    'green': matplotlib.colors.to_rgb('#009900'),
-    'orange': matplotlib.colors.to_rgb('#D79B00'),
-    'purple': matplotlib.colors.to_rgb('#896999'),
-    'grey':  matplotlib.colors.to_rgb('#444444'),
-         }
+    "blue": matplotlib.colors.to_rgb("#000099"),
+    "red": matplotlib.colors.to_rgb("#990000"),
+    "green": matplotlib.colors.to_rgb("#009900"),
+    "orange": matplotlib.colors.to_rgb("#D79B00"),
+    "purple": matplotlib.colors.to_rgb("#896999"),
+    "grey": matplotlib.colors.to_rgb("#444444"),
+}
 color_list = list(color_dict.values())
 chromapy_cycler = cycler(color=color_list)
 
-linestyle_cycler = cycler('linestyle', ['--', ':', '-.'])
+linestyle_cycler = cycler("linestyle", ["--", ":", "-."])
 
-textbox_props = dict(facecolor='white', alpha=1)
+textbox_props = dict(facecolor="white", alpha=1)
 
 
 figure_styles = {
-    'small': {
-        'width': 5,
-        'height': 3,
-        'linewidth': 2,
-        'font_small': 8,
-        'font_medium': 10,
-        'font_large': 12,
-        'color_cycler': chromapy_cycler,
-
+    "small": {
+        "width": 5,
+        "height": 3,
+        "linewidth": 2,
+        "font_small": 8,
+        "font_medium": 10,
+        "font_large": 12,
+        "color_cycler": chromapy_cycler,
     },
-    'medium': {
-        'width': 10,
-        'height': 6,
-        'linewidth': 4,
-        'font_small': 20,
-        'font_medium': 24,
-        'font_large': 28,
-        'color_cycler': chromapy_cycler,
+    "medium": {
+        "width": 10,
+        "height": 6,
+        "linewidth": 4,
+        "font_small": 20,
+        "font_medium": 24,
+        "font_large": 28,
+        "color_cycler": chromapy_cycler,
     },
-    'large': {
-        'width': 15,
-        'height': 9,
-        'linewidth': 6,
-        'font_small': 25,
-        'font_medium': 30,
-        'font_large': 40,
-        'color_cycler': chromapy_cycler,
+    "large": {
+        "width": 15,
+        "height": 9,
+        "linewidth": 6,
+        "font_small": 25,
+        "font_medium": 30,
+        "font_large": 40,
+        "color_cycler": chromapy_cycler,
     },
 }
 
 
-def set_figure_style(style='medium'):
+def set_figure_style(style="medium"):
     """Define the sytle of a plot.
 
     Can set the sytle of a plot for small, medium and large plots. The
@@ -161,26 +163,26 @@ def set_figure_style(style='medium'):
         If no valid style has been chosen as parameter.
     """
     if style not in figure_styles:
-        raise CADETProcessError('Not a valid style')
+        raise CADETProcessError("Not a valid style")
 
-    width = figure_styles[style]['width']
-    height = figure_styles[style]['height']
-    linewidth = figure_styles[style]['linewidth']
-    font_small = figure_styles[style]['font_small']
-    font_medium = figure_styles[style]['font_medium']
-    font_large = figure_styles[style]['font_large']
-    color_cycler = figure_styles[style]['color_cycler']
+    width = figure_styles[style]["width"]
+    height = figure_styles[style]["height"]
+    linewidth = figure_styles[style]["linewidth"]
+    font_small = figure_styles[style]["font_small"]
+    font_medium = figure_styles[style]["font_medium"]
+    font_large = figure_styles[style]["font_large"]
+    color_cycler = figure_styles[style]["color_cycler"]
 
-    plt.rcParams['figure.figsize'] = (width, height)
-    plt.rcParams['lines.linewidth'] = linewidth
-    plt.rcParams['font.size'] = font_small          # controls default text sizes
-    plt.rcParams['axes.titlesize'] = font_small     # fontsize of the axes title
-    plt.rcParams['axes.labelsize'] = font_medium    # fontsize of the x and y labels
-    plt.rcParams['xtick.labelsize'] = font_small    # fontsize of the tick labels
-    plt.rcParams['ytick.labelsize'] = font_small    # fontsize of the tick labels
-    plt.rcParams['legend.fontsize'] = font_small    # legend fontsize
-    plt.rcParams['figure.titlesize'] = font_large   # fontsize of the figure title
-    plt.rcParams['axes.prop_cycle'] = color_cycler
+    plt.rcParams["figure.figsize"] = (width, height)
+    plt.rcParams["lines.linewidth"] = linewidth
+    plt.rcParams["font.size"] = font_small  # controls default text sizes
+    plt.rcParams["axes.titlesize"] = font_small  # fontsize of the axes title
+    plt.rcParams["axes.labelsize"] = font_medium  # fontsize of the x and y labels
+    plt.rcParams["xtick.labelsize"] = font_small  # fontsize of the tick labels
+    plt.rcParams["ytick.labelsize"] = font_small  # fontsize of the tick labels
+    plt.rcParams["legend.fontsize"] = font_small  # legend fontsize
+    plt.rcParams["figure.titlesize"] = font_large  # fontsize of the figure title
+    plt.rcParams["axes.prop_cycle"] = color_cycler
 
 
 set_figure_style()
@@ -208,8 +210,8 @@ def get_fig_size(n_rows=1, n_cols=1, style=None):
     if style is None:
         style = this.style
 
-    width = figure_styles[style]['width']
-    height = figure_styles[style]['height']
+    width = figure_styles[style]["width"]
+    height = figure_styles[style]["height"]
 
     fig_size = (n_cols * width + 2, n_rows * height + 2)
 
@@ -243,10 +245,7 @@ def setup_figure(n_rows=1, n_cols=1, style=None, squeeze=True):
 
     fig_size = get_fig_size(n_rows, n_cols)
     fig, axs = plt.subplots(
-        nrows=n_rows,
-        ncols=n_cols,
-        squeeze=squeeze,
-        figsize=fig_size
+        nrows=n_rows, ncols=n_cols, squeeze=squeeze, figsize=fig_size
     )
 
     fig.tight_layout()
@@ -272,15 +271,9 @@ class Layout(Structure):
     y_lim = Tuple()
 
 
-def set_layout(
-        ax,
-        layout,
-        show_legend=True,
-        ax_secondary=None,
-        secondary_layout=None):
-
-    ax.spines['top'].set_visible(False)
-    ax.spines['right'].set_visible(False)
+def set_layout(ax, layout, show_legend=True, ax_secondary=None, secondary_layout=None):
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
 
     ax.set_xlabel(layout.x_label)
     ax.set_ylabel(layout.y_label)
@@ -300,8 +293,7 @@ def set_layout(
         ax_secondary.set_ylim(secondary_layout.y_lim)
 
         if show_legend:
-            lines_secondary, labels_secondary = \
-                ax_secondary.get_legend_handles_labels()
+            lines_secondary, labels_secondary = ax_secondary.get_legend_handles_labels()
             ax_secondary.legend(
                 lines_secondary + lines, labels_secondary + labels, loc=0
             )
@@ -316,15 +308,15 @@ class Tick(Structure):
 
 
 def set_yticks(ax, y_ticks):
-    locs = np.array([y_tick['loc'] for y_tick in y_ticks])
-    labels = [y_tick['label'] for y_tick in y_ticks]
+    locs = np.array([y_tick["loc"] for y_tick in y_ticks])
+    labels = [y_tick["label"] for y_tick in y_ticks]
     ax.set_yticks(locs, labels)
 
 
 def set_xticks(ax, x_ticks):
-    locs = np.array([x_tick['loc'] for x_tick in x_ticks])
-    labels = [x_tick['label'] for x_tick in x_ticks]
-    plt.xticks(locs, labels, rotation=72, horizontalalignment='center')
+    locs = np.array([x_tick["loc"] for x_tick in x_ticks])
+    labels = [x_tick["label"] for x_tick in x_ticks]
+    plt.xticks(locs, labels, rotation=72, horizontalalignment="center")
 
 
 def add_text(ax, text, position=(0.05, 0.9), tb_props=None, **kwargs):
@@ -332,8 +324,12 @@ def add_text(ax, text, position=(0.05, 0.9), tb_props=None, **kwargs):
         textbox_props.update(tb_props)
 
     ax.text(
-        *position, text, transform=ax.transAxes, verticalalignment='top',
-        bbox=textbox_props, **kwargs
+        *position,
+        text,
+        transform=ax.transAxes,
+        verticalalignment="top",
+        bbox=textbox_props,
+        **kwargs,
     )
 
 
@@ -353,7 +349,7 @@ class Annotation(Structure):
     text = String()
     xy = Tuple()
     xytext = Tuple()
-    arrowstyle = '-|>'
+    arrowstyle = "-|>"
 
 
 def add_annotations(ax, annotations):
@@ -361,12 +357,12 @@ def add_annotations(ax, annotations):
         ax.annotate(
             annotation.text,
             xy=annotation.xy,
-            xycoords='data',
+            xycoords="data",
             xytext=annotation.xytext,
-            textcoords='offset points',
+            textcoords="offset points",
             arrowprops={
-                'arrowstyle': annotation.arrowstyle
-            }
+                "arrowstyle": annotation.arrowstyle,
+            },
         )
 
 
@@ -385,20 +381,24 @@ def add_fill_regions(ax, fill_regions, x_lim=None):
         color = color_list[fill.color_index]
         ax.fill_between(
             [fill.start, fill.end],
-            fill.y_max, alpha=0.3, color=color
+            fill.y_max,
+            alpha=0.3,
+            color=color,
         )
 
         if fill.text is not None:
             if x_lim is None or fill.start < x_lim[0]:
-                x_position = (x_lim[0] + fill.end)/2
+                x_position = (x_lim[0] + fill.end) / 2
             else:
-                x_position = (fill.start + fill.end)/2
+                x_position = (fill.start + fill.end) / 2
             y_position = 0.5 * fill.y_max
 
             ax.text(
-                x_position, y_position, fill.text,
-                horizontalalignment='center',
-                verticalalignment='center'
+                x_position,
+                y_position,
+                fill.text,
+                horizontalalignment="center",
+                verticalalignment="center",
             )
 
 
@@ -416,11 +416,14 @@ def add_hlines(ax, hlines):
 def create_and_save_figure(func):
     @wraps(func)
     def wrapper(
-            *args,
-            fig=None,
-            ax=None,
-            show=True, file_name=None, style='medium',
-            **kwargs):
+        *args,
+        fig=None,
+        ax=None,
+        show=True,
+        file_name=None,
+        style="medium",
+        **kwargs,
+    ):
         """Wrapper around plot function.
 
         Parameters

--- a/CADETProcess/processModel/__init__.py
+++ b/CADETProcess/processModel/__init__.py
@@ -111,7 +111,7 @@ Process
 """
 
 from . import componentSystem
-from .componentSystem import  *
+from .componentSystem import *
 
 from . import reaction
 from .reaction import *

--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional
+
 import numpy as np
 
 from CADETProcess import CADETProcessError
@@ -47,7 +49,8 @@ __all__ = [
 
 @frozen_attributes
 class BindingBaseClass(Structure):
-    """Abstract base class for parameters of binding models.
+    """
+    Abstract base class for parameters of binding models.
 
     Attributes
     ----------
@@ -70,7 +73,6 @@ class BindingBaseClass(Structure):
         The default is True.
     parameters : dict
         dict with parameter values.
-
     """
 
     name = String()
@@ -84,18 +86,37 @@ class BindingBaseClass(Structure):
 
     _parameters = ["is_kinetic"]
 
-    def __init__(self, component_system, name=None, *args, **kwargs):
+    def __init__(
+        self,
+        component_system: ComponentSystem,
+        name: Optional[str] = None,
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
+        """
+        Initialize binding model.
+
+        Parameters
+        ----------
+        component_system: ComponentSystem
+            Component system of the binding model.
+        name: str
+            Name of the binding model.
+
+        """
         self.component_system = component_system
         self.name = name
 
         super().__init__(*args, **kwargs)
 
     @property
-    def model(self):
+    def model(self) -> str:
+        """str: Name of the binding model."""
         return self.__class__.__name__
 
     @property
-    def component_system(self):
+    def component_system(self) -> ComponentSystem:
+        """ComponentSystem: Component system of the binding model."""
         return self._component_system
 
     @component_system.setter
@@ -105,11 +126,13 @@ class BindingBaseClass(Structure):
         self._component_system = component_system
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
+        """int: Number of components."""
         return self.component_system.n_comp
 
     @property
-    def bound_states(self):
+    def bound_states(self) -> list[int]:
+        """list[int]: Number of bound states per component."""
         bound_states = self._bound_states
         for i in self.non_binding_component_indices:
             bound_states[i] = 0
@@ -124,24 +147,27 @@ class BindingBaseClass(Structure):
         self._bound_states = bound_states
 
     @property
-    def n_bound_states(self):
+    def n_bound_states(self) -> int:
+        """int: Number of bound states."""
         return sum(self.bound_states)
 
-    def __repr__(self):
+    def __repr__(self) -> str:
+        """str: String representation of the binding model."""
         return f"{self.__class__.__name__}(\
             component_system={self.component_system}, name={self.name})')"
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: String representation of the binding model."""
         if self.name is None:
             return self.__class__.__name__
         return self.name
 
 
 class NoBinding(BindingBaseClass):
-    """Dummy class for units that do not experience binging behavior.
+    """
+    Dummy class for units that do not experience binging behavior.
 
     The number of components is set to zero for this class.
-
     """
 
     def __init__(self, *args, **kwargs):
@@ -149,7 +175,8 @@ class NoBinding(BindingBaseClass):
 
 
 class Linear(BindingBaseClass):
-    """Parameters for Linear binding model.
+    """
+    Linear binding model.
 
     Attributes
     ----------
@@ -157,7 +184,6 @@ class Linear(BindingBaseClass):
         Adsorption rate constants. Length depends on `n_comp`.
     desorption_rate : list of unsigned floats.
         Desorption rate constants. Length depends on `n_comp`.
-
     """
 
     adsorption_rate = SizedUnsignedList(size="n_comp")
@@ -170,7 +196,8 @@ class Linear(BindingBaseClass):
 
 
 class Langmuir(BindingBaseClass):
-    """Parameters for Multi Component Langmuir binding model.
+    """
+    Multi Component Langmuir binding model.
 
     Attributes
     ----------
@@ -180,7 +207,6 @@ class Langmuir(BindingBaseClass):
         Desorption rate constants. Length depends on `n_comp`.
     capacity : list of unsigned floats.
         Maximum adsorption capacities. Length depends on `n_comp`.
-
     """
 
     adsorption_rate = SizedUnsignedList(size="n_comp")
@@ -195,8 +221,10 @@ class Langmuir(BindingBaseClass):
 
 
 class LangmuirLDF(BindingBaseClass):
-    """Parameters for Multi Component Langmuir binding model using a linear driving
-    force approximation based on the equilibrium concentration q* for given c.
+    """
+    Multi Component Langmuir binding model with linear driving force approximation.
+
+    Note, this variant is based on the equilibrium concentration q* for given c.
 
     Attributes
     ----------
@@ -206,7 +234,6 @@ class LangmuirLDF(BindingBaseClass):
         Desorption rate constants. Length depends on `n_comp`.
     capacity : list of unsigned floats.
         Maximum adsorption capacities. Length depends on `n_comp`.
-
     """
 
     equilibrium_constant = SizedUnsignedList(size="n_comp")
@@ -221,8 +248,10 @@ class LangmuirLDF(BindingBaseClass):
 
 
 class LangmuirLDFLiquidPhase(BindingBaseClass):
-    """Parameters for Multi Component Langmuir binding model using a linear driving
-    force approximation based on the equilibrium concentration c* for given q.
+    """
+    Multi Component Langmuir binding model with linear driving force approximation.
+
+    Note, this variant is based on the equilibrium concentration c* for given q.
 
     Attributes
     ----------
@@ -232,7 +261,6 @@ class LangmuirLDFLiquidPhase(BindingBaseClass):
         Desorption rate constants. Length depends on `n_comp`.
     capacity : list of unsigned floats.
         Maximum adsorption capacities. Length depends on `n_comp`.
-
     """
 
     equilibrium_constant = SizedUnsignedList(size="n_comp")
@@ -247,7 +275,8 @@ class LangmuirLDFLiquidPhase(BindingBaseClass):
 
 
 class BiLangmuir(BindingBaseClass):
-    """Parameters for Multi Component Bi-Langmuir binding model.
+    """
+    Multi Component Bi-Langmuir binding model.
 
     Attributes
     ----------
@@ -260,7 +289,6 @@ class BiLangmuir(BindingBaseClass):
     capacity : list of unsigned floats.
         Maximum adsorption capacities in state-major ordering.
         Length depends on `n_bound_states`.
-
     """
 
     n_binding_sites = UnsignedInteger(default=2)
@@ -282,7 +310,8 @@ class BiLangmuir(BindingBaseClass):
 
 
 class BiLangmuirLDF(BindingBaseClass):
-    """Parameters for Multi Component Bi-Langmuir binding model.
+    """
+    Multi Component Bi-Langmuir binding model.
 
     Attributes
     ----------
@@ -295,7 +324,6 @@ class BiLangmuirLDF(BindingBaseClass):
     capacity : list of unsigned floats.
         Maximum adsorption capacities in state-major ordering.
         Length depends on `n_bound_states`.
-
     """
 
     n_binding_sites = UnsignedInteger(default=2)
@@ -317,7 +345,8 @@ class BiLangmuirLDF(BindingBaseClass):
 
 
 class FreundlichLDF(BindingBaseClass):
-    """Parameters for the Freundlich isotherm model.
+    """
+    Freundlich isotherm model.
 
     Attributes
     ----------
@@ -327,7 +356,6 @@ class FreundlichLDF(BindingBaseClass):
         Freundlich coefficient for each component. Length depends on `n_comp`.
     exponent : list of unsigned floats.
         Freundlich exponent for each component. Length depends on `n_comp`.
-
     """
 
     driving_force_coefficient = SizedUnsignedList(size="n_comp")
@@ -342,7 +370,8 @@ class FreundlichLDF(BindingBaseClass):
 
 
 class StericMassAction(BindingBaseClass):
-    r"""Parameters for Steric Mass Action Law binding model.
+    r"""
+    Steric Mass Action Law binding model.
 
     Attributes
     ----------
@@ -368,7 +397,6 @@ class StericMassAction(BindingBaseClass):
     reference_solid_phase_conc : unsigned float.
         Reference liquid phase concentration.
         The default is 1.0
-
     """
 
     adsorption_rate = SizedUnsignedList(size="n_comp")
@@ -390,7 +418,8 @@ class StericMassAction(BindingBaseClass):
     ]
 
     @property
-    def adsorption_rate_untransformed(self):
+    def adsorption_rate_untransformed(self) -> list[float] | None:
+        """list[float]: Untransformed adsorption rate."""
         if self.adsorption_rate is None:
             return None
 
@@ -410,7 +439,8 @@ class StericMassAction(BindingBaseClass):
         ).tolist()
 
     @property
-    def desorption_rate_untransformed(self):
+    def desorption_rate_untransformed(self) -> list[float] | None:
+        """list[float]: Untransformed desorption rate."""
         if self.desorption_rate is None:
             return None
 
@@ -431,7 +461,8 @@ class StericMassAction(BindingBaseClass):
 
 
 class AntiLangmuir(BindingBaseClass):
-    """Multi Component Anti-Langmuir adsorption isotherm.
+    """
+    Multi Component Anti-Langmuir adsorption isotherm.
 
     Attributes
     ----------
@@ -443,7 +474,6 @@ class AntiLangmuir(BindingBaseClass):
         Maximum adsorption capacities. Length depends on `n_comp`.
     antilangmuir : list of {-1, 1}.
         Anti-Langmuir coefficients. Length depends on `n_comp`.
-
     """
 
     adsorption_rate = SizedUnsignedList(size="n_comp")
@@ -455,7 +485,8 @@ class AntiLangmuir(BindingBaseClass):
 
 
 class Spreading(BindingBaseClass):
-    """Multi Component Spreading adsorption isotherm.
+    """
+    Multi Component Spreading adsorption isotherm.
 
     Attributes
     ----------
@@ -474,7 +505,6 @@ class Spreading(BindingBaseClass):
     exchange_from_2_1 : list of unsigned floats.
         Exchange rates from the second to the first bound state.
         Length depends on `n_comp`.
-
     """
 
     n_binding_sites = RangedInteger(lb=2, ub=2, default=2)
@@ -495,7 +525,8 @@ class Spreading(BindingBaseClass):
 
 
 class MobilePhaseModulator(BindingBaseClass):
-    """Mobile Phase Modulator adsorption isotherm.
+    """
+    Mobile Phase Modulator adsorption isotherm.
 
     Attributes
     ----------
@@ -535,7 +566,8 @@ class MobilePhaseModulator(BindingBaseClass):
 
 
 class ExtendedMobilePhaseModulator(BindingBaseClass):
-    """Mobile Phase Modulator adsorption isotherm.
+    """
+    Mobile Phase Modulator adsorption isotherm.
 
     Attributes
     ----------
@@ -557,7 +589,6 @@ class ExtendedMobilePhaseModulator(BindingBaseClass):
         1 is linear binding,
         2 is modified Langmuir binding.
         Length depends on `n_comp`.
-
     """
 
     adsorption_rate = SizedUnsignedList(size="n_comp")
@@ -580,7 +611,8 @@ class ExtendedMobilePhaseModulator(BindingBaseClass):
 
 
 class SelfAssociation(BindingBaseClass):
-    r"""Self Association adsorption isotherm.
+    r"""
+    Self Association adsorption isotherm.
 
     Attributes
     ----------
@@ -603,7 +635,6 @@ class SelfAssociation(BindingBaseClass):
     reference_solid_phase_conc : unsigned float.
         Reference liquid phase concentration (optional)
         The default = 1.0
-
     """
 
     adsorption_rate = SizedUnsignedList(size="n_comp")
@@ -628,7 +659,8 @@ class SelfAssociation(BindingBaseClass):
 
 
 class BiStericMassAction(BindingBaseClass):
-    """Bi Steric Mass Action adsorption isotherm.
+    """
+    Bi Steric Mass Action adsorption isotherm.
 
     Attributes
     ----------
@@ -658,7 +690,6 @@ class BiStericMassAction(BindingBaseClass):
         Reference solid phase concentration for each binding site type or one
         value for all types.
         The default is 1.0
-
     """
 
     n_binding_sites = UnsignedInteger(default=2)
@@ -688,7 +719,8 @@ class BiStericMassAction(BindingBaseClass):
 
 
 class MultistateStericMassAction(BindingBaseClass):
-    r"""Multistate Steric Mass Action adsorption isotherm.
+    r"""
+    Multistate Steric Mass Action adsorption isotherm.
 
     Attributes
     ----------
@@ -721,7 +753,6 @@ class MultistateStericMassAction(BindingBaseClass):
     reference_solid_phase_conc : unsigned float, optional
         Reference solid phase concentration.
         The default = 1.0
-
     """
 
     bound_states = SizedUnsignedIntegerList(
@@ -758,7 +789,8 @@ class MultistateStericMassAction(BindingBaseClass):
 
 
 class SimplifiedMultistateStericMassAction(BindingBaseClass):
-    """Simplified multistate Steric Mass Action adsorption isotherm.
+    """
+    Simplified multistate Steric Mass Action adsorption isotherm.
 
     Attributes
     ----------
@@ -819,7 +851,6 @@ class SimplifiedMultistateStericMassAction(BindingBaseClass):
         Reference liquid phase concentration (optional, default value = 1.0).
     reference_solid_phase_conc : list of unsigned floats.
         Reference solid phase concentration (optional, default value = 1.0).
-
     """
 
     bound_states = SizedUnsignedIntegerList(
@@ -866,7 +897,8 @@ class SimplifiedMultistateStericMassAction(BindingBaseClass):
 
 
 class Saska(BindingBaseClass):
-    """Quadratic Isotherm.
+    """
+    Quadratic Isotherm.
 
     Attributes
     ----------
@@ -874,7 +906,6 @@ class Saska(BindingBaseClass):
         The Henry coefficient. Length depends on `n_comp`.
     quadratic_factor : list of unsigned floats.
         Quadratic factors. Length depends on `n_comp`.
-
     """
 
     henry_const = SizedUnsignedList(size="n_comp")
@@ -887,7 +918,8 @@ class Saska(BindingBaseClass):
 
 
 class GeneralizedIonExchange(BindingBaseClass):
-    r"""Generalized Ion Exchange isotherm model.
+    r"""
+    Generalized Ion Exchange isotherm model.
 
     Attributes
     ----------
@@ -958,7 +990,6 @@ class GeneralizedIonExchange(BindingBaseClass):
         Reference liquid phase concentration (optional, default value = 1.0).
     reference_solid_phase_conc : unsigned float.
         Reference liquid phase concentration (optional, default value = 1.0).
-
     """
 
     non_binding_component_indices = [1]
@@ -1030,7 +1061,8 @@ class GeneralizedIonExchange(BindingBaseClass):
 
 
 class HICConstantWaterActivity(BindingBaseClass):
-    """HIC based on Constant Water Activity adsorption isotherm.
+    """
+    HIC based on Constant Water Activity adsorption isotherm.
 
     Attributes
     ----------
@@ -1070,7 +1102,8 @@ class HICConstantWaterActivity(BindingBaseClass):
 
 
 class HICWaterOnHydrophobicSurfaces(BindingBaseClass):
-    """HIC isotherm by Wang et al. based on their 2016 paper.
+    """
+    HIC isotherm by Wang et al. based on their 2016 paper.
 
     Attributes
     ----------
@@ -1110,7 +1143,8 @@ class HICWaterOnHydrophobicSurfaces(BindingBaseClass):
 
 
 class MultiComponentColloidal(BindingBaseClass):
-    """Colloidal isotherm from Xu and Lenhoff 2009.
+    """
+    Colloidal isotherm from Xu and Lenhoff 2009.
 
     Attributes
     ----------
@@ -1152,7 +1186,6 @@ class MultiComponentColloidal(BindingBaseClass):
         Linear threshold.
     use_ph : Boolean.
         Include pH or not.
-
     """
 
     bound_states = SizedUnsignedIntegerList(

--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -1,45 +1,47 @@
-from warnings import warn
-
 import numpy as np
 
 from CADETProcess import CADETProcessError
-
-from CADETProcess.dataStructure import frozen_attributes
-from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    Bool, String,
-    RangedInteger, UnsignedInteger, UnsignedFloat, SizedFloatList,
-    SizedRangedIntegerList, SizedUnsignedIntegerList,
+    Bool,
+    DependentlyModulatedUnsignedList,
+    RangedInteger,
+    SizedFloatList,
+    SizedRangedIntegerList,
+    SizedUnsignedIntegerList,
     SizedUnsignedList,
-    DependentlyModulatedUnsignedList
+    String,
+    Structure,
+    UnsignedFloat,
+    UnsignedInteger,
+    frozen_attributes,
 )
 
 from .componentSystem import ComponentSystem
 
 __all__ = [
-    'BindingBaseClass',
-    'NoBinding',
-    'Linear',
-    'Langmuir',
-    'LangmuirLDF',
-    'LangmuirLDFLiquidPhase',
-    'BiLangmuir',
-    'BiLangmuirLDF',
-    'FreundlichLDF',
-    'StericMassAction',
-    'AntiLangmuir',
-    'Spreading',
-    'MobilePhaseModulator',
-    'ExtendedMobilePhaseModulator',
-    'SelfAssociation',
-    'BiStericMassAction',
-    'MultistateStericMassAction',
-    'SimplifiedMultistateStericMassAction',
-    'Saska',
-    'GeneralizedIonExchange',
-    'HICConstantWaterActivity',
-    'HICWaterOnHydrophobicSurfaces',
-    'MultiComponentColloidal',
+    "BindingBaseClass",
+    "NoBinding",
+    "Linear",
+    "Langmuir",
+    "LangmuirLDF",
+    "LangmuirLDFLiquidPhase",
+    "BiLangmuir",
+    "BiLangmuirLDF",
+    "FreundlichLDF",
+    "StericMassAction",
+    "AntiLangmuir",
+    "Spreading",
+    "MobilePhaseModulator",
+    "ExtendedMobilePhaseModulator",
+    "SelfAssociation",
+    "BiStericMassAction",
+    "MultistateStericMassAction",
+    "SimplifiedMultistateStericMassAction",
+    "Saska",
+    "GeneralizedIonExchange",
+    "HICConstantWaterActivity",
+    "HICWaterOnHydrophobicSurfaces",
+    "MultiComponentColloidal",
 ]
 
 
@@ -76,11 +78,11 @@ class BindingBaseClass(Structure):
 
     n_binding_sites = RangedInteger(lb=1, ub=1, default=1)
     _bound_states = SizedRangedIntegerList(
-        size=('n_binding_sites', 'n_comp'), lb=0, ub=1, default=1
+        size=("n_binding_sites", "n_comp"), lb=0, ub=1, default=1
     )
     non_binding_component_indices = []
 
-    _parameters = ['is_kinetic']
+    _parameters = ["is_kinetic"]
 
     def __init__(self, component_system, name=None, *args, **kwargs):
         self.component_system = component_system
@@ -99,7 +101,7 @@ class BindingBaseClass(Structure):
     @component_system.setter
     def component_system(self, component_system):
         if not isinstance(component_system, ComponentSystem):
-            raise TypeError('Expected ComponentSystem')
+            raise TypeError("Expected ComponentSystem")
         self._component_system = component_system
 
     @property
@@ -117,9 +119,7 @@ class BindingBaseClass(Structure):
     def bound_states(self, bound_states):
         indices = self.non_binding_component_indices
         if any(bound_states[i] > 0 for i in indices):
-            raise CADETProcessError(
-                "Cannot set bound state for non-binding component."
-            )
+            raise CADETProcessError("Cannot set bound state for non-binding component.")
 
         self._bound_states = bound_states
 
@@ -145,7 +145,7 @@ class NoBinding(BindingBaseClass):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(ComponentSystem(), name='NoBinding')
+        super().__init__(ComponentSystem(), name="NoBinding")
 
 
 class Linear(BindingBaseClass):
@@ -160,12 +160,12 @@ class Linear(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
+        "adsorption_rate",
+        "desorption_rate",
     ]
 
 
@@ -183,14 +183,14 @@ class Langmuir(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
-    capacity = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
+    capacity = SizedUnsignedList(size="n_comp")
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
+        "adsorption_rate",
+        "desorption_rate",
+        "capacity",
     ]
 
 
@@ -209,14 +209,14 @@ class LangmuirLDF(BindingBaseClass):
 
     """
 
-    equilibrium_constant = SizedUnsignedList(size='n_comp')
-    driving_force_coefficient = SizedUnsignedList(size='n_comp')
-    capacity = SizedUnsignedList(size='n_comp')
+    equilibrium_constant = SizedUnsignedList(size="n_comp")
+    driving_force_coefficient = SizedUnsignedList(size="n_comp")
+    capacity = SizedUnsignedList(size="n_comp")
 
     _parameters = [
-        'equilibrium_constant',
-        'driving_force_coefficient',
-        'capacity',
+        "equilibrium_constant",
+        "driving_force_coefficient",
+        "capacity",
     ]
 
 
@@ -235,14 +235,14 @@ class LangmuirLDFLiquidPhase(BindingBaseClass):
 
     """
 
-    equilibrium_constant = SizedUnsignedList(size='n_comp')
-    driving_force_coefficient = SizedUnsignedList(size='n_comp')
-    capacity = SizedUnsignedList(size='n_comp')
+    equilibrium_constant = SizedUnsignedList(size="n_comp")
+    driving_force_coefficient = SizedUnsignedList(size="n_comp")
+    capacity = SizedUnsignedList(size="n_comp")
 
     _parameters = [
-        'equilibrium_constant',
-        'driving_force_coefficient',
-        'capacity',
+        "equilibrium_constant",
+        "driving_force_coefficient",
+        "capacity",
     ]
 
 
@@ -265,14 +265,14 @@ class BiLangmuir(BindingBaseClass):
 
     n_binding_sites = UnsignedInteger(default=2)
 
-    adsorption_rate = SizedUnsignedList(size='n_bound_states')
-    desorption_rate = SizedUnsignedList(size='n_bound_states')
-    capacity = SizedUnsignedList(size='n_bound_states')
+    adsorption_rate = SizedUnsignedList(size="n_bound_states")
+    desorption_rate = SizedUnsignedList(size="n_bound_states")
+    capacity = SizedUnsignedList(size="n_bound_states")
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
+        "adsorption_rate",
+        "desorption_rate",
+        "capacity",
     ]
 
     def __init__(self, *args, n_binding_sites=2, **kwargs):
@@ -300,14 +300,14 @@ class BiLangmuirLDF(BindingBaseClass):
 
     n_binding_sites = UnsignedInteger(default=2)
 
-    equilibrium_constant = SizedUnsignedList(size='n_bound_states')
-    driving_force_coefficient = SizedUnsignedList(size='n_bound_states')
-    capacity = SizedUnsignedList(size='n_bound_states')
+    equilibrium_constant = SizedUnsignedList(size="n_bound_states")
+    driving_force_coefficient = SizedUnsignedList(size="n_bound_states")
+    capacity = SizedUnsignedList(size="n_bound_states")
 
     _parameters = [
-        'equilibrium_constant',
-        'driving_force_coefficient',
-        'capacity',
+        "equilibrium_constant",
+        "driving_force_coefficient",
+        "capacity",
     ]
 
     def __init__(self, *args, n_binding_sites=2, **kwargs):
@@ -330,14 +330,14 @@ class FreundlichLDF(BindingBaseClass):
 
     """
 
-    driving_force_coefficient = SizedUnsignedList(size='n_comp')
-    freundlich_coefficient = SizedUnsignedList(size='n_comp')
-    exponent = SizedUnsignedList(size='n_comp')
+    driving_force_coefficient = SizedUnsignedList(size="n_comp")
+    freundlich_coefficient = SizedUnsignedList(size="n_comp")
+    exponent = SizedUnsignedList(size="n_comp")
 
     _parameters = [
-        'driving_force_coefficient',
-        'freundlich_coefficient',
-        'exponent',
+        "driving_force_coefficient",
+        "freundlich_coefficient",
+        "exponent",
     ]
 
 
@@ -371,22 +371,22 @@ class StericMassAction(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
-    characteristic_charge = SizedUnsignedList(size='n_comp')
-    steric_factor = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
+    characteristic_charge = SizedUnsignedList(size="n_comp")
+    steric_factor = SizedUnsignedList(size="n_comp")
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1.0)
     reference_solid_phase_conc = UnsignedFloat(default=1.0)
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
-        'reference_liquid_phase_conc',
-        'reference_solid_phase_conc'
+        "adsorption_rate",
+        "desorption_rate",
+        "characteristic_charge",
+        "steric_factor",
+        "capacity",
+        "reference_liquid_phase_conc",
+        "reference_solid_phase_conc",
     ]
 
     @property
@@ -395,20 +395,19 @@ class StericMassAction(BindingBaseClass):
             return None
 
         nu = np.array(self.characteristic_charge)
-        return \
-            self.adsorption_rate * \
-            self.reference_solid_phase_conc**(-nu)
+        return self.adsorption_rate * self.reference_solid_phase_conc ** (-nu)
 
     @adsorption_rate_untransformed.setter
     def adsorption_rate_untransformed(self, adsorption_rate_untransformed):
         if self.characteristic_charge is None:
-            raise ValueError("Please set nu before setting an untransformed rate constant.")
+            raise ValueError(
+                "Please set nu before setting an untransformed rate constant."
+            )
 
         nu = np.array(self.characteristic_charge)
         self.adsorption_rate = (
-            (adsorption_rate_untransformed
-             / self.reference_solid_phase_conc ** (-nu)
-             ).tolist())
+            adsorption_rate_untransformed / self.reference_solid_phase_conc ** (-nu)
+        ).tolist()
 
     @property
     def desorption_rate_untransformed(self):
@@ -416,20 +415,19 @@ class StericMassAction(BindingBaseClass):
             return None
 
         nu = np.array(self.characteristic_charge)
-        return \
-            self.desorption_rate * \
-            self.reference_liquid_phase_conc**(-nu)
+        return self.desorption_rate * self.reference_liquid_phase_conc ** (-nu)
 
     @desorption_rate_untransformed.setter
     def desorption_rate_untransformed(self, desorption_rate_untransformed):
         if self.characteristic_charge is None:
-            raise ValueError("Please set nu before setting a transformed rate constant.")
+            raise ValueError(
+                "Please set nu before setting a transformed rate constant."
+            )
 
         nu = np.array(self.characteristic_charge)
         self.desorption_rate = (
-            (desorption_rate_untransformed
-             / self.reference_liquid_phase_conc ** (-nu)
-             ).tolist())
+            desorption_rate_untransformed / self.reference_liquid_phase_conc ** (-nu)
+        ).tolist()
 
 
 class AntiLangmuir(BindingBaseClass):
@@ -448,17 +446,12 @@ class AntiLangmuir(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
-    capacity = SizedUnsignedList(size='n_comp')
-    antilangmuir = SizedFloatList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
+    capacity = SizedUnsignedList(size="n_comp")
+    antilangmuir = SizedFloatList(size="n_comp")
 
-    _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'antilangmuir'
-    ]
+    _parameters = ["adsorption_rate", "desorption_rate", "capacity", "antilangmuir"]
 
 
 class Spreading(BindingBaseClass):
@@ -486,18 +479,18 @@ class Spreading(BindingBaseClass):
 
     n_binding_sites = RangedInteger(lb=2, ub=2, default=2)
 
-    adsorption_rate = SizedUnsignedList(size='n_total_bound')
-    desorption_rate = SizedUnsignedList(size='n_total_bound')
-    capacity = SizedUnsignedList(size='n_total_bound')
-    exchange_from_1_2 = SizedUnsignedList(size='n_comp')
-    exchange_from_2_1 = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_total_bound")
+    desorption_rate = SizedUnsignedList(size="n_total_bound")
+    capacity = SizedUnsignedList(size="n_total_bound")
+    exchange_from_1_2 = SizedUnsignedList(size="n_comp")
+    exchange_from_2_1 = SizedUnsignedList(size="n_comp")
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'exchange_from_1_2',
-        'exchange_from_2_1'
+        "adsorption_rate",
+        "desorption_rate",
+        "capacity",
+        "exchange_from_1_2",
+        "exchange_from_2_1",
     ]
 
 
@@ -522,22 +515,22 @@ class MobilePhaseModulator(BindingBaseClass):
         Concentration of c0 at which to switch to linear model approximation.
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
-    capacity = SizedUnsignedList(size='n_comp')
-    ion_exchange_characteristic = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
+    capacity = SizedUnsignedList(size="n_comp")
+    ion_exchange_characteristic = SizedUnsignedList(size="n_comp")
     beta = ion_exchange_characteristic
-    hydrophobicity = SizedFloatList(size='n_comp')
+    hydrophobicity = SizedFloatList(size="n_comp")
     gamma = hydrophobicity
     linear_threshold = UnsignedFloat(default=1e-8)
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'ion_exchange_characteristic',
-        'hydrophobicity',
-        'linear_threshold',
+        "adsorption_rate",
+        "desorption_rate",
+        "capacity",
+        "ion_exchange_characteristic",
+        "hydrophobicity",
+        "linear_threshold",
     ]
 
 
@@ -567,22 +560,22 @@ class ExtendedMobilePhaseModulator(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
-    capacity = SizedUnsignedList(size='n_comp')
-    ion_exchange_characteristic = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
+    capacity = SizedUnsignedList(size="n_comp")
+    ion_exchange_characteristic = SizedUnsignedList(size="n_comp")
     beta = ion_exchange_characteristic
-    hydrophobicity = SizedFloatList(size='n_comp')
+    hydrophobicity = SizedFloatList(size="n_comp")
     gamma = hydrophobicity
-    component_mode = SizedUnsignedIntegerList(size='n_comp', ub=2)
+    component_mode = SizedUnsignedIntegerList(size="n_comp", ub=2)
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'capacity',
-        'ion_exchange_characteristic',
-        'hydrophobicity',
-        'component_mode',
+        "adsorption_rate",
+        "desorption_rate",
+        "capacity",
+        "ion_exchange_characteristic",
+        "hydrophobicity",
+        "component_mode",
     ]
 
 
@@ -613,24 +606,24 @@ class SelfAssociation(BindingBaseClass):
 
     """
 
-    adsorption_rate = SizedUnsignedList(size='n_comp')
-    adsorption_rate_dimerization = SizedUnsignedList(size='n_comp')
-    desorption_rate = SizedUnsignedList(size='n_comp')
-    characteristic_charge = SizedUnsignedList(size='n_comp')
-    steric_factor = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_comp")
+    adsorption_rate_dimerization = SizedUnsignedList(size="n_comp")
+    desorption_rate = SizedUnsignedList(size="n_comp")
+    characteristic_charge = SizedUnsignedList(size="n_comp")
+    steric_factor = SizedUnsignedList(size="n_comp")
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1.0)
     reference_solid_phase_conc = UnsignedFloat(default=1.0)
 
     _parameters = [
-        'adsorption_rate',
-        'adsorption_rate_dimerization',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
-        'reference_liquid_phase_conc',
-        'reference_solid_phase_conc'
+        "adsorption_rate",
+        "adsorption_rate_dimerization",
+        "desorption_rate",
+        "characteristic_charge",
+        "steric_factor",
+        "capacity",
+        "reference_liquid_phase_conc",
+        "reference_solid_phase_conc",
     ]
 
 
@@ -670,23 +663,23 @@ class BiStericMassAction(BindingBaseClass):
 
     n_binding_sites = UnsignedInteger(default=2)
 
-    adsorption_rate = SizedUnsignedList(size='n_bound_states')
-    adsorption_rate_dimerization = SizedUnsignedList(size='n_bound_states')
-    desorption_rate = SizedUnsignedList(size='n_bound_states')
-    characteristic_charge = SizedUnsignedList(size='n_bound_states')
-    steric_factor = SizedUnsignedList(size='n_bound_states')
-    capacity = SizedUnsignedList(size='n_binding_sites')
-    reference_liquid_phase_conc = SizedUnsignedList(size='n_binding_sites', default=1)
-    reference_solid_phase_conc = SizedUnsignedList(size='n_binding_sites', default=1)
+    adsorption_rate = SizedUnsignedList(size="n_bound_states")
+    adsorption_rate_dimerization = SizedUnsignedList(size="n_bound_states")
+    desorption_rate = SizedUnsignedList(size="n_bound_states")
+    characteristic_charge = SizedUnsignedList(size="n_bound_states")
+    steric_factor = SizedUnsignedList(size="n_bound_states")
+    capacity = SizedUnsignedList(size="n_binding_sites")
+    reference_liquid_phase_conc = SizedUnsignedList(size="n_binding_sites", default=1)
+    reference_solid_phase_conc = SizedUnsignedList(size="n_binding_sites", default=1)
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'capacity',
-        'reference_liquid_phase_conc',
-        'reference_solid_phase_conc'
+        "adsorption_rate",
+        "desorption_rate",
+        "characteristic_charge",
+        "steric_factor",
+        "capacity",
+        "reference_liquid_phase_conc",
+        "reference_solid_phase_conc",
     ]
 
     def __init__(self, *args, n_states=2, **kwargs):
@@ -732,27 +725,27 @@ class MultistateStericMassAction(BindingBaseClass):
     """
 
     bound_states = SizedUnsignedIntegerList(
-        size=('n_binding_sites', 'n_comp'), default=1
+        size=("n_binding_sites", "n_comp"), default=1
     )
 
-    adsorption_rate = SizedUnsignedList(size='n_bound_states')
-    desorption_rate = SizedUnsignedList(size='n_bound_states')
-    characteristic_charge = SizedUnsignedList(size='n_bound_states')
-    steric_factor = SizedUnsignedList(size='n_bound_states')
-    conversion_rate = SizedUnsignedList(size='_conversion_entries')
+    adsorption_rate = SizedUnsignedList(size="n_bound_states")
+    desorption_rate = SizedUnsignedList(size="n_bound_states")
+    characteristic_charge = SizedUnsignedList(size="n_bound_states")
+    steric_factor = SizedUnsignedList(size="n_bound_states")
+    conversion_rate = SizedUnsignedList(size="_conversion_entries")
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge',
-        'steric_factor',
-        'conversion_rate',
-        'capacity',
-        'reference_liquid_phase_conc',
-        'reference_solid_phase_conc'
+        "adsorption_rate",
+        "desorption_rate",
+        "characteristic_charge",
+        "steric_factor",
+        "conversion_rate",
+        "capacity",
+        "reference_liquid_phase_conc",
+        "reference_solid_phase_conc",
     ]
 
     @property
@@ -830,45 +823,45 @@ class SimplifiedMultistateStericMassAction(BindingBaseClass):
     """
 
     bound_states = SizedUnsignedIntegerList(
-        size=('n_binding_sites', 'n_comp'), default=1
+        size=("n_binding_sites", "n_comp"), default=1
     )
 
-    adsorption_rate = SizedUnsignedList(size='n_bound_states')
-    desorption_rate = SizedUnsignedList(size='n_bound_states')
-    characteristic_charge_first = SizedUnsignedList(size='n_comp')
-    characteristic_charge_last = SizedUnsignedList(size='n_comp')
-    quadratic_modifiers_charge = SizedUnsignedList(size='n_comp')
-    steric_factor_first = SizedUnsignedList(size='n_comp')
-    steric_factor_last = SizedUnsignedList(size='n_comp')
-    quadratic_modifiers_steric = SizedUnsignedList(size='n_comp')
+    adsorption_rate = SizedUnsignedList(size="n_bound_states")
+    desorption_rate = SizedUnsignedList(size="n_bound_states")
+    characteristic_charge_first = SizedUnsignedList(size="n_comp")
+    characteristic_charge_last = SizedUnsignedList(size="n_comp")
+    quadratic_modifiers_charge = SizedUnsignedList(size="n_comp")
+    steric_factor_first = SizedUnsignedList(size="n_comp")
+    steric_factor_last = SizedUnsignedList(size="n_comp")
+    quadratic_modifiers_steric = SizedUnsignedList(size="n_comp")
     capacity = UnsignedFloat()
-    exchange_from_weak_stronger = SizedUnsignedList(size='n_comp')
-    linear_exchange_ws = SizedUnsignedList(size='n_comp')
-    quadratic_exchange_ws = SizedUnsignedList(size='n_comp')
-    exchange_from_stronger_weak = SizedUnsignedList(size='n_comp')
-    linear_exchange_sw = SizedUnsignedList(size='n_comp')
-    quadratic_exchange_sw = SizedUnsignedList(size='n_comp')
+    exchange_from_weak_stronger = SizedUnsignedList(size="n_comp")
+    linear_exchange_ws = SizedUnsignedList(size="n_comp")
+    quadratic_exchange_ws = SizedUnsignedList(size="n_comp")
+    exchange_from_stronger_weak = SizedUnsignedList(size="n_comp")
+    linear_exchange_sw = SizedUnsignedList(size="n_comp")
+    quadratic_exchange_sw = SizedUnsignedList(size="n_comp")
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'characteristic_charge_first',
-        'characteristic_charge_last',
-        'quadratic_modifiers_charge',
-        'steric_factor_first',
-        'steric_factor_last',
-        'quadratic_modifiers_steric',
-        'capacity',
-        'exchange_from_weak_stronger',
-        'linear_exchange_ws',
-        'quadratic_exchange_ws',
-        'exchange_from_stronger_weak',
-        'linear_exchange_sw',
-        'quadratic_exchange_sw',
-        'reference_liquid_phase_conc',
-        'reference_solid_phase_conc'
+        "adsorption_rate",
+        "desorption_rate",
+        "characteristic_charge_first",
+        "characteristic_charge_last",
+        "quadratic_modifiers_charge",
+        "steric_factor_first",
+        "steric_factor_last",
+        "quadratic_modifiers_steric",
+        "capacity",
+        "exchange_from_weak_stronger",
+        "linear_exchange_ws",
+        "quadratic_exchange_ws",
+        "exchange_from_stronger_weak",
+        "linear_exchange_sw",
+        "quadratic_exchange_sw",
+        "reference_liquid_phase_conc",
+        "reference_solid_phase_conc",
     ]
 
 
@@ -884,12 +877,12 @@ class Saska(BindingBaseClass):
 
     """
 
-    henry_const = SizedUnsignedList(size='n_comp')
-    quadratic_factor = SizedUnsignedList(size=('n_comp', 'n_comp'))
+    henry_const = SizedUnsignedList(size="n_comp")
+    quadratic_factor = SizedUnsignedList(size=("n_comp", "n_comp"))
 
     _parameters = [
-        'henry_const',
-        'quadratic_factor',
+        "henry_const",
+        "quadratic_factor",
     ]
 
 
@@ -970,52 +963,58 @@ class GeneralizedIonExchange(BindingBaseClass):
 
     non_binding_component_indices = [1]
 
-    adsorption_rate = SizedFloatList(size='n_comp')
-    adsorption_rate_linear = SizedFloatList(size='n_comp')
-    adsorption_rate_quadratic = SizedFloatList(size='n_comp', default=0)
-    adsorption_rate_cubic = SizedFloatList(size='n_comp', default=0)
-    adsorption_rate_salt = SizedFloatList(size='n_comp', default=0)
-    adsorption_rate_protein = SizedFloatList(size='n_comp', default=0)
-    desorption_rate = SizedFloatList(size='n_comp')
-    desorption_rate_linear = SizedFloatList(size='n_comp', default=0)
-    desorption_rate_quadratic = SizedFloatList(size='n_comp', default=0)
-    desorption_rate_cubic = SizedFloatList(size='n_comp', default=0)
-    desorption_rate_salt = SizedFloatList(size='n_comp', default=0)
-    desorption_rate_protein = SizedFloatList(size='n_comp', default=0)
+    adsorption_rate = SizedFloatList(size="n_comp")
+    adsorption_rate_linear = SizedFloatList(size="n_comp")
+    adsorption_rate_quadratic = SizedFloatList(size="n_comp", default=0)
+    adsorption_rate_cubic = SizedFloatList(size="n_comp", default=0)
+    adsorption_rate_salt = SizedFloatList(size="n_comp", default=0)
+    adsorption_rate_protein = SizedFloatList(size="n_comp", default=0)
+    desorption_rate = SizedFloatList(size="n_comp")
+    desorption_rate_linear = SizedFloatList(size="n_comp", default=0)
+    desorption_rate_quadratic = SizedFloatList(size="n_comp", default=0)
+    desorption_rate_cubic = SizedFloatList(size="n_comp", default=0)
+    desorption_rate_salt = SizedFloatList(size="n_comp", default=0)
+    desorption_rate_protein = SizedFloatList(size="n_comp", default=0)
     characteristic_charge_breaks = DependentlyModulatedUnsignedList(
-        size='n_comp', is_optional=True
+        size="n_comp", is_optional=True
     )
-    characteristic_charge = SizedFloatList(size=('n_pieces', 'n_comp'),)
-    characteristic_charge_linear = SizedFloatList(size=('n_pieces', 'n_comp'), default=0)
-    characteristic_charge_quadratic = SizedFloatList(size=('n_pieces', 'n_comp'), default=0)
-    characteristic_charge_cubic = SizedFloatList(size=('n_pieces', 'n_comp'), default=0)
-    steric_factor = SizedUnsignedList(size='n_comp')
+    characteristic_charge = SizedFloatList(
+        size=("n_pieces", "n_comp"),
+    )
+    characteristic_charge_linear = SizedFloatList(
+        size=("n_pieces", "n_comp"), default=0
+    )
+    characteristic_charge_quadratic = SizedFloatList(
+        size=("n_pieces", "n_comp"), default=0
+    )
+    characteristic_charge_cubic = SizedFloatList(size=("n_pieces", "n_comp"), default=0)
+    steric_factor = SizedUnsignedList(size="n_comp")
     capacity = UnsignedFloat()
     reference_liquid_phase_conc = UnsignedFloat(default=1)
     reference_solid_phase_conc = UnsignedFloat(default=1)
 
     _parameters = [
-        'adsorption_rate',
-        'adsorption_rate_linear',
-        'adsorption_rate_quadratic',
-        'adsorption_rate_cubic',
-        'adsorption_rate_salt',
-        'adsorption_rate_protein',
-        'desorption_rate',
-        'desorption_rate_linear',
-        'desorption_rate_quadratic',
-        'desorption_rate_cubic',
-        'desorption_rate_salt',
-        'desorption_rate_protein',
-        'characteristic_charge_breaks',
-        'characteristic_charge',
-        'characteristic_charge_linear',
-        'characteristic_charge_quadratic',
-        'characteristic_charge_cubic',
-        'steric_factor',
-        'capacity',
-        'reference_liquid_phase_conc',
-        'reference_solid_phase_conc',
+        "adsorption_rate",
+        "adsorption_rate_linear",
+        "adsorption_rate_quadratic",
+        "adsorption_rate_cubic",
+        "adsorption_rate_salt",
+        "adsorption_rate_protein",
+        "desorption_rate",
+        "desorption_rate_linear",
+        "desorption_rate_quadratic",
+        "desorption_rate_cubic",
+        "desorption_rate_salt",
+        "desorption_rate_protein",
+        "characteristic_charge_breaks",
+        "characteristic_charge",
+        "characteristic_charge_linear",
+        "characteristic_charge_quadratic",
+        "characteristic_charge_cubic",
+        "steric_factor",
+        "capacity",
+        "reference_liquid_phase_conc",
+        "reference_solid_phase_conc",
     ]
 
     @property
@@ -1042,31 +1041,31 @@ class HICConstantWaterActivity(BindingBaseClass):
     capacity : list of unsigned floats.
         Maximum adsorption capacities. Size depends on `n_comp`.
     hic_characteristic : list of unsigned floats.
-        Parameters describing the number of ligands per ligand-protein interaction. Size depends on `n_comp`.
+        Parameters describing the number of ligands per ligand-protein interaction.
+        Size depends on `n_comp`.
     beta_0 : unsigned float.
         Parameter describing the number of highly ordered water molecules that stabilize
         the hydrophobic surfaces at infinitely diluted salt concentration.
     beta_1 : unsigned float.
-        Parameter describing the change in the number of highly ordered water molecules that stabilize
-        the hydrophobic surfaces with respect to changes in the salt concentration.
-
+        Parameter describing the change in the number of highly ordered water molecules that
+        stabilize the hydrophobic surfaces with respect to changes in the salt concentration.
     """
 
-    adsorption_rate = SizedFloatList(size='n_comp')
-    desorption_rate = SizedFloatList(size='n_comp')
-    capacity = SizedFloatList(size='n_comp')
-    hic_characteristic = SizedFloatList(size='n_comp')
+    adsorption_rate = SizedFloatList(size="n_comp")
+    desorption_rate = SizedFloatList(size="n_comp")
+    capacity = SizedFloatList(size="n_comp")
+    hic_characteristic = SizedFloatList(size="n_comp")
 
     beta_0 = UnsignedFloat()
     beta_1 = UnsignedFloat()
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'hic_characteristic',
-        'capacity',
-        'beta_0',
-        'beta_1',
+        "adsorption_rate",
+        "desorption_rate",
+        "hic_characteristic",
+        "capacity",
+        "beta_0",
+        "beta_1",
     ]
 
 
@@ -1082,31 +1081,31 @@ class HICWaterOnHydrophobicSurfaces(BindingBaseClass):
     capacity : list of unsigned floats.
         Maximum adsorption capacities. Size depends on `n_comp`.
     hic_characteristic : list of unsigned floats.
-        Parameters describing the number of ligands per ligand-protein interaction. Size depends on `n_comp`.
+        Parameters describing the number of ligands per ligand-protein interaction.
+        Size depends on `n_comp`.
     beta_0 : unsigned float.
         Parameter describing the number of highly ordered water molecules that stabilize
         the hydrophobic surfaces at infinitely diluted salt concentration.
     beta_1 : unsigned float.
-        Parameter describing the change in the number of highly ordered water molecules that stabilize
-        the hydrophobic surfaces with respect to changes in the salt concentration.
-
+        Parameter describing the change in the number of highly ordered water molecules that
+        stabilize the hydrophobic surfaces with respect to changes in the salt concentration.
     """
 
-    adsorption_rate = SizedFloatList(size='n_comp')
-    desorption_rate = SizedFloatList(size='n_comp')
-    capacity = SizedFloatList(size='n_comp')
-    hic_characteristic = SizedFloatList(size='n_comp')
+    adsorption_rate = SizedFloatList(size="n_comp")
+    desorption_rate = SizedFloatList(size="n_comp")
+    capacity = SizedFloatList(size="n_comp")
+    hic_characteristic = SizedFloatList(size="n_comp")
 
     beta_0 = UnsignedFloat()
     beta_1 = UnsignedFloat()
 
     _parameters = [
-        'adsorption_rate',
-        'desorption_rate',
-        'hic_characteristic',
-        'capacity',
-        'beta_0',
-        'beta_1',
+        "adsorption_rate",
+        "desorption_rate",
+        "hic_characteristic",
+        "capacity",
+        "beta_0",
+        "beta_1",
     ]
 
 
@@ -1157,7 +1156,7 @@ class MultiComponentColloidal(BindingBaseClass):
     """
 
     bound_states = SizedUnsignedIntegerList(
-        size=('n_binding_sites', 'n_comp'), default=1
+        size=("n_binding_sites", "n_comp"), default=1
     )
 
     phase_ratio = UnsignedFloat()
@@ -1165,39 +1164,39 @@ class MultiComponentColloidal(BindingBaseClass):
     kappa_factor = UnsignedFloat()
     kappa_constant = UnsignedFloat()
     coordination_number = UnsignedInteger()
-    logkeq_ph_exponent = SizedFloatList(size='n_comp')
-    logkeq_power_exponent = SizedFloatList(size='n_comp')
-    logkeq_power_factor = SizedFloatList(size='n_comp')
-    logkeq_exponent_factor = SizedFloatList(size='n_comp')
-    logkeq_exponent_multiplier = SizedFloatList(size='n_comp')
-    bpp_ph_exponent = SizedFloatList(size='n_comp')
-    bpp_power_exponent = SizedFloatList(size='n_comp')
-    bpp_power_factor = SizedFloatList(size='n_comp')
-    bpp_exponent_factor = SizedFloatList(size='n_comp')
-    bpp_exponent_multiplier = SizedFloatList(size='n_comp')
-    protein_radius = SizedFloatList(size='n_comp')
-    kinetic_rate_constant = SizedFloatList(size='n_comp')
+    logkeq_ph_exponent = SizedFloatList(size="n_comp")
+    logkeq_power_exponent = SizedFloatList(size="n_comp")
+    logkeq_power_factor = SizedFloatList(size="n_comp")
+    logkeq_exponent_factor = SizedFloatList(size="n_comp")
+    logkeq_exponent_multiplier = SizedFloatList(size="n_comp")
+    bpp_ph_exponent = SizedFloatList(size="n_comp")
+    bpp_power_exponent = SizedFloatList(size="n_comp")
+    bpp_power_factor = SizedFloatList(size="n_comp")
+    bpp_exponent_factor = SizedFloatList(size="n_comp")
+    bpp_exponent_multiplier = SizedFloatList(size="n_comp")
+    protein_radius = SizedFloatList(size="n_comp")
+    kinetic_rate_constant = SizedFloatList(size="n_comp")
     linear_threshold = UnsignedFloat(default=1e-8)
     use_ph = Bool(default=False)
 
     _parameters = [
-        'phase_ratio',
-        'kappa_exponential',
-        'kappa_factor',
-        'kappa_constant',
-        'coordination_number',
-        'logkeq_ph_exponent',
-        'logkeq_power_exponent',
-        'logkeq_power_factor',
-        'logkeq_exponent_factor',
-        'logkeq_exponent_multiplier',
-        'bpp_ph_exponent',
-        'bpp_power_exponent',
-        'bpp_power_factor',
-        'bpp_exponent_factor',
-        'bpp_exponent_multiplier',
-        'protein_radius',
-        'kinetic_rate_constant',
-        'linear_threshold',
-        'use_ph',
+        "phase_ratio",
+        "kappa_exponential",
+        "kappa_factor",
+        "kappa_constant",
+        "coordination_number",
+        "logkeq_ph_exponent",
+        "logkeq_power_exponent",
+        "logkeq_power_factor",
+        "logkeq_exponent_factor",
+        "logkeq_exponent_multiplier",
+        "bpp_ph_exponent",
+        "bpp_power_exponent",
+        "bpp_power_factor",
+        "bpp_exponent_factor",
+        "bpp_exponent_multiplier",
+        "protein_radius",
+        "kinetic_rate_constant",
+        "linear_threshold",
+        "use_ph",
     ]

--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -120,7 +120,7 @@ class BindingBaseClass(Structure):
         return self._component_system
 
     @component_system.setter
-    def component_system(self, component_system):
+    def component_system(self, component_system: ComponentSystem) -> None:
         if not isinstance(component_system, ComponentSystem):
             raise TypeError("Expected ComponentSystem")
         self._component_system = component_system
@@ -139,7 +139,7 @@ class BindingBaseClass(Structure):
         return bound_states
 
     @bound_states.setter
-    def bound_states(self, bound_states):
+    def bound_states(self, bound_states: np.ndarray) -> None:
         indices = self.non_binding_component_indices
         if any(bound_states[i] > 0 for i in indices):
             raise CADETProcessError("Cannot set bound state for non-binding component.")
@@ -170,7 +170,8 @@ class NoBinding(BindingBaseClass):
     The number of components is set to zero for this class.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize NoBinding."""
         super().__init__(ComponentSystem(), name="NoBinding")
 
 
@@ -303,7 +304,8 @@ class BiLangmuir(BindingBaseClass):
         "capacity",
     ]
 
-    def __init__(self, *args, n_binding_sites=2, **kwargs):
+    def __init__(self, *args: Any, n_binding_sites: int = 2, **kwargs: Any) -> None:
+        """Initialize BiLangmuir."""
         self.n_binding_sites = n_binding_sites
 
         super().__init__(*args, **kwargs)
@@ -338,7 +340,8 @@ class BiLangmuirLDF(BindingBaseClass):
         "capacity",
     ]
 
-    def __init__(self, *args, n_binding_sites=2, **kwargs):
+    def __init__(self, *args: Any, n_binding_sites: int = 2, **kwargs: Any) -> None:
+        """Initialize BiLangmuirLDF."""
         self.n_binding_sites = n_binding_sites
 
         super().__init__(*args, **kwargs)
@@ -418,7 +421,7 @@ class StericMassAction(BindingBaseClass):
     ]
 
     @property
-    def adsorption_rate_untransformed(self) -> list[float] | None:
+    def adsorption_rate_untransformed(self) -> list[UnsignedFloat]:
         """list[float]: Untransformed adsorption rate."""
         if self.adsorption_rate is None:
             return None
@@ -427,7 +430,7 @@ class StericMassAction(BindingBaseClass):
         return self.adsorption_rate * self.reference_solid_phase_conc ** (-nu)
 
     @adsorption_rate_untransformed.setter
-    def adsorption_rate_untransformed(self, adsorption_rate_untransformed):
+    def adsorption_rate_untransformed(self, adsorption_rate_untransformed: list[float]) -> None:
         if self.characteristic_charge is None:
             raise ValueError(
                 "Please set nu before setting an untransformed rate constant."
@@ -439,7 +442,7 @@ class StericMassAction(BindingBaseClass):
         ).tolist()
 
     @property
-    def desorption_rate_untransformed(self) -> list[float] | None:
+    def desorption_rate_untransformed(self) -> list[UnsignedFloat]:
         """list[float]: Untransformed desorption rate."""
         if self.desorption_rate is None:
             return None
@@ -448,7 +451,7 @@ class StericMassAction(BindingBaseClass):
         return self.desorption_rate * self.reference_liquid_phase_conc ** (-nu)
 
     @desorption_rate_untransformed.setter
-    def desorption_rate_untransformed(self, desorption_rate_untransformed):
+    def desorption_rate_untransformed(self, desorption_rate_untransformed: list[float]) -> None:
         if self.characteristic_charge is None:
             raise ValueError(
                 "Please set nu before setting a transformed rate constant."
@@ -713,7 +716,8 @@ class BiStericMassAction(BindingBaseClass):
         "reference_solid_phase_conc",
     ]
 
-    def __init__(self, *args, n_states=2, **kwargs):
+    def __init__(self, *args: Any, n_states: int = 2, **kwargs: Any) -> None:
+        """Initialize BiStericMassAction class."""
         self.n_states = n_states
         super().__init__(*args, **kwargs)
 
@@ -780,7 +784,7 @@ class MultistateStericMassAction(BindingBaseClass):
     ]
 
     @property
-    def _conversion_entries(self):
+    def _conversion_entries(self) -> int:
         n = 0
         for state in self.bound_states:
             n += state**2
@@ -1049,7 +1053,7 @@ class GeneralizedIonExchange(BindingBaseClass):
     ]
 
     @property
-    def n_pieces(self):
+    def n_pieces(self) -> int:
         """int: Number of pieces for cubic polynomial description of nu."""
         if self.characteristic_charge_breaks is None:
             return 1

--- a/CADETProcess/processModel/componentSystem.py
+++ b/CADETProcess/processModel/componentSystem.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from functools import wraps
-from typing import NoReturn
+from typing import Any, Iterator
 
 from addict import Dict
 
@@ -76,7 +76,7 @@ class Component(Structure):
         charge: int | list[int | None] = None,
         molecular_weight: float | list[float | None] = None,
         density: float | list[float | None] = None,
-    ) -> NoReturn:
+    ) -> None:
         """
         Initialize Component.
 
@@ -85,13 +85,13 @@ class Component(Structure):
         name : str | None
             Name of the component.
         species : str | list[str | None]
-            Names of the subspecies.
+            Name(s) of the subspecies to initialize. If None, the component's name is used.
         charge : int | list [int | None]
-            Charges of the subspecies.
+            Charges of the subspecies. Defaults to None for each species.
         molecular_weight : float | list[float | None]
-            Molecular weights of the subspecies.
+            Molecular weights of the subspecies. Defaults to None for each species.
         density : float | list[float | None]
-            Density of component (including species).
+            Density of component (including species). Defaults to None for each species.
         """
         self.name: str | None = name
         self._species: list[Species] = []
@@ -121,14 +121,16 @@ class Component(Structure):
     def add_species(
         self,
         species: str | Species,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any
     ) -> Species:
         """
         Add a subspecies to the component.
 
         Parameters
         ----------
+        species: string | Species
+            Species to add
         *args
             Variable length argument list.
         **kwargs
@@ -173,7 +175,7 @@ class Component(Structure):
         """str: String representation of the component."""
         return self.name
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Species]:
         """Iterate over the subspecies of the component."""
         yield from self.species
 
@@ -305,9 +307,9 @@ class ComponentSystem(Structure):
     def add_component(
         self,
         component: str | Component,
-        *args: list,
-        **kwargs: dict,
-    ) -> NoReturn:
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """
         Add a component to the system.
 
@@ -315,9 +317,9 @@ class ComponentSystem(Structure):
         ----------
         component : str | Component
             The component instance or name of the component to be added.
-        *args : list
+        *args : Any
             The positional arguments to be passed to the component class's constructor.
-        **kwargs : dict
+        **kwargs : Any
             The keyword arguments to be passed to the component class's constructor.
         """
         if not isinstance(component, Component):
@@ -330,7 +332,7 @@ class ComponentSystem(Structure):
 
         self._components.append(component)
 
-    def remove_component(self, component: str | Component) -> NoReturn:
+    def remove_component(self, component: str | Component) -> None:
         """
         Remove a component from the system.
 
@@ -442,7 +444,7 @@ class ComponentSystem(Structure):
         """int: Return the number of components in the system."""
         return self.n_comp
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Component]:
         """Iterate over components in the system."""
         yield from self.components
 

--- a/CADETProcess/processModel/componentSystem.py
+++ b/CADETProcess/processModel/componentSystem.py
@@ -5,10 +5,10 @@ from typing import NoReturn
 from addict import Dict
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import String, Integer, UnsignedFloat
+from CADETProcess.dataStructure import Integer, String, Structure, UnsignedFloat
 
-__all__ = ['ComponentSystem', 'Component', 'Species']
+__all__ = ["ComponentSystem", "Component", "Species"]
+
 
 class Species(Structure):
     """
@@ -28,6 +28,7 @@ class Species(Structure):
         Density of the species.
 
     """
+
     name: String = String()
     charge: Integer = Integer(default=0)
     molecular_weight: UnsignedFloat = UnsignedFloat()
@@ -36,6 +37,7 @@ class Species(Structure):
     def __str__(self) -> str:
         """str: String representation of the component."""
         return self.name
+
 
 class Component(Structure):
     """
@@ -66,16 +68,17 @@ class Component(Structure):
     ComponentSystem
 
     """
+
     name: String = String()
 
     def __init__(
-            self,
-            name: str | None = None,
-            species: str | list[str | None] = None,
-            charge: int | list[int | None] = None,
-            molecular_weight: float | list[float | None] = None,
-            density: float | list[float | None] = None
-            ) -> NoReturn:
+        self,
+        name: str | None = None,
+        species: str | list[str | None] = None,
+        charge: int | list[int | None] = None,
+        molecular_weight: float | list[float | None] = None,
+        density: float | list[float | None] = None,
+    ) -> NoReturn:
         """
         Parameters
         ----------
@@ -116,11 +119,11 @@ class Component(Structure):
 
     @wraps(Species.__init__)
     def add_species(
-            self,
-            species: str| Species ,
-            *args,
-            **kwargs
-            ) -> Species:
+        self,
+        species: str | Species,
+        *args,
+        **kwargs,
+    ) -> Species:
         """
         Add a subspecies to the component.
 
@@ -212,16 +215,17 @@ class ComponentSystem(Structure):
     Component
 
     """
+
     name: String = String()
 
     def __init__(
-            self,
-            components: int | list[str | Component | None] = None,
-            name: str | None = None,
-            charges: list[int | None] = None,
-            molecular_weights: list[float | None] = None,
-            densities: list[float | None] = None
-            ) -> None:
+        self,
+        components: int | list[str | Component | None] = None,
+        name: str | None = None,
+        charges: list[int | None] = None,
+        molecular_weights: list[float | None] = None,
+        densities: list[float | None] = None,
+    ) -> None:
         """
         Initialize the ComponentSystem object.
 
@@ -272,7 +276,7 @@ class ComponentSystem(Structure):
                 comp,
                 charge=charges[i],
                 molecular_weight=molecular_weights[i],
-                density=densities[i]
+                density=densities[i],
             )
 
     @property
@@ -283,10 +287,7 @@ class ComponentSystem(Structure):
     @property
     def components_dict(self) -> dict[str, Component]:
         """dict[str, Component]: Components indexed by name."""
-        return {
-            name: comp
-            for name, comp in zip(self.names, self.components)
-        }
+        return {name: comp for name, comp in zip(self.names, self.components)}
 
     @property
     def n_components(self) -> int:
@@ -305,11 +306,11 @@ class ComponentSystem(Structure):
 
     @wraps(Component.__init__)
     def add_component(
-            self,
-            component: str | Component,
-            *args: list,
-            **kwargs: dict
-            ) -> NoReturn:
+        self,
+        component: str | Component,
+        *args: list,
+        **kwargs: dict,
+    ) -> NoReturn:
         """
         Add a component to the system.
 
@@ -328,8 +329,7 @@ class ComponentSystem(Structure):
 
         if component.name in self.names:
             raise CADETProcessError(
-                f"Component '{component.name}' "
-                "already exists in ComponentSystem."
+                f"Component '{component.name}' already exists in ComponentSystem."
             )
 
         self._components.append(component)
@@ -441,7 +441,7 @@ class ComponentSystem(Structure):
 
     def __repr__(self) -> str:
         """str: Return the string representation of the object."""
-        return f'{self.__class__.__name__}({self.names})'
+        return f"{self.__class__.__name__}({self.names})"
 
     def __len__(self) -> int:
         """int: Return the number of components in the system."""

--- a/CADETProcess/processModel/componentSystem.py
+++ b/CADETProcess/processModel/componentSystem.py
@@ -26,7 +26,6 @@ class Species(Structure):
         The molecular weight of the species.
     density : float
         Density of the species.
-
     """
 
     name: String = String()
@@ -66,7 +65,6 @@ class Component(Structure):
     --------
     Species
     ComponentSystem
-
     """
 
     name: String = String()
@@ -80,6 +78,8 @@ class Component(Structure):
         density: float | list[float | None] = None,
     ) -> NoReturn:
         """
+        Initialize Component.
+
         Parameters
         ----------
         name : str | None
@@ -213,7 +213,6 @@ class ComponentSystem(Structure):
     --------
     Species
     Component
-
     """
 
     name: String = String()
@@ -247,9 +246,7 @@ class ComponentSystem(Structure):
         ------
         CADETProcessError
             If the `components` argument is neither an int nor a list.
-
         """
-
         self.name: str | None = name
         self._components: list[Component] = []
 
@@ -322,7 +319,6 @@ class ComponentSystem(Structure):
             The positional arguments to be passed to the component class's constructor.
         **kwargs : dict
             The keyword arguments to be passed to the component class's constructor.
-
         """
         if not isinstance(component, Component):
             component = Component(component, *args, **kwargs)
@@ -347,7 +343,6 @@ class ComponentSystem(Structure):
         ------
         CADETProcessError
             If the component is unknown or not present in the system.
-
         """
         if isinstance(component, str):
             try:

--- a/CADETProcess/processModel/discretization.py
+++ b/CADETProcess/processModel/discretization.py
@@ -11,7 +11,7 @@ The :class:`~CADETProcess.processModel.DiscretizationParametersBase` class is th
 class for all other classes in this module and defines some common parameters.
 Specific parameters for each scheme are defined as attributes of each class.
 
-"""
+"""  # noqa
 
 from CADETProcess.dataStructure import (
     Bool,
@@ -43,7 +43,8 @@ __all__ = [
 
 @frozen_attributes
 class DiscretizationParametersBase(Structure):
-    """Base class for storing discretization parameters.
+    """
+    Base class for storing discretization parameters.
 
     Attributes
     ----------
@@ -53,7 +54,6 @@ class DiscretizationParametersBase(Structure):
         Parameters for the WENO scheme.
     consistency_solver: ConsistencySolverParameters
         Consistency solver parameters for Cadet.
-
     """
 
     _dimensionality = []
@@ -109,11 +109,14 @@ class NoDiscretization(DiscretizationParametersBase):
 
 
 class DGMixin(DiscretizationParametersBase):
+    """Mixin DG discretization parameters."""
+
     pass
 
 
 class LRMDiscretizationFV(DiscretizationParametersBase):
-    """Discretization parameters of the FV version of the LRM.
+    """
+    Discretization parameters of the FV version of the LRM.
 
     Attributes
     ----------
@@ -126,7 +129,6 @@ class LRMDiscretizationFV(DiscretizationParametersBase):
     reconstruction : Switch, optional
         Method for spatial reconstruction. Valid values are 'WENO' (Weighted
         Essentially Non-Oscillatory). Default is 'WENO'.
-
     """
 
     spatial_method = Constant(value="FV")
@@ -143,7 +145,8 @@ class LRMDiscretizationFV(DiscretizationParametersBase):
 
 
 class LRMDiscretizationDG(DGMixin):
-    """Discretization parameters of the DG version of the LRM.
+    """
+    Discretization parameters of the DG version of the LRM.
 
     Attributes
     ----------
@@ -163,7 +166,6 @@ class LRMDiscretizationDG(DGMixin):
     --------
     CADETProcess.processModel.LRMPDiscretizationFV
     CADETProcess.processModel.LumpedRateModelWithPores
-
     """
 
     spatial_method = Constant(value="DG")
@@ -187,7 +189,8 @@ class LRMDiscretizationDG(DGMixin):
 
 
 class LRMPDiscretizationFV(DiscretizationParametersBase):
-    """Discretization parameters of the FV version of the LRMP.
+    """
+    Discretization parameters of the FV version of the LRMP.
 
     Attributes
     ----------
@@ -222,7 +225,6 @@ class LRMPDiscretizationFV(DiscretizationParametersBase):
     --------
     CADETProcess.processModel.LRMPDiscretizationDG
     CADETProcess.processModel.LumpedRateModelWithPores
-
     """
 
     spatial_method = Constant(value="FV")
@@ -252,7 +254,8 @@ class LRMPDiscretizationFV(DiscretizationParametersBase):
 
 
 class LRMPDiscretizationDG(DGMixin):
-    """Discretization parameters of the DG version of the LRMP.
+    """
+    Discretization parameters of the DG version of the LRMP.
 
     Attributes
     ----------
@@ -276,7 +279,6 @@ class LRMPDiscretizationDG(DGMixin):
     --------
     CADETProcess.processModel.LRMPDiscretizationFV
     CADETProcess.processModel.LumpedRateModelWithPores
-
     """
 
     spatial_method = Constant(value="DG")
@@ -304,7 +306,8 @@ class LRMPDiscretizationDG(DGMixin):
 
 
 class GRMDiscretizationFV(DiscretizationParametersBase):
-    """Discretization parameters of the FV version of the LRMP.
+    """
+    Discretization parameters of the FV version of the LRMP.
 
     Attributes
     ----------
@@ -361,7 +364,6 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
     --------
     CADETProcess.processModel.LRMPDiscretizationDG
     CADETProcess.processModel.LumpedRateModelWithPores
-
     """
 
     spatial_method = Constant(value="FV")
@@ -427,7 +429,8 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
 
 
 class GRMDiscretizationDG(DGMixin):
-    """Discretization parameters of the DG version of the GRM.
+    """
+    Discretization parameters of the DG version of the GRM.
 
     Attributes
     ----------
@@ -465,7 +468,6 @@ class GRMDiscretizationDG(DGMixin):
     --------
     CADETProcess.processModel.GRMDiscretizationDG
     CADETProcess.processModel.GeneralRateModel
-
     """
 
     spatial_method = Constant(value="DG")
@@ -523,7 +525,8 @@ class GRMDiscretizationDG(DGMixin):
 
 @frozen_attributes
 class WenoParameters(Structure):
-    """Discretization parameters for the WENO scheme.
+    """
+    Discretization parameters for the WENO scheme.
 
     Attributes
     ----------
@@ -548,7 +551,6 @@ class WenoParameters(Structure):
     See Also
     --------
     Structure
-
     """
 
     boundary_model = UnsignedInteger(default=0, ub=3)
@@ -559,7 +561,8 @@ class WenoParameters(Structure):
 
 @frozen_attributes
 class ConsistencySolverParameters(Structure):
-    """A class for defining the consistency solver parameters for Cadet.
+    """
+    A class for defining the consistency solver parameters for Cadet.
 
     Parameters
     ----------
@@ -582,7 +585,6 @@ class ConsistencySolverParameters(Structure):
     See Also
     --------
     Structure
-
     """
 
     solver_name = Switch(
@@ -603,7 +605,8 @@ class ConsistencySolverParameters(Structure):
 
 
 class MCTDiscretizationFV(DiscretizationParametersBase):
-    """Discretization parameters of the FV version of the MCT.
+    """
+    Discretization parameters of the FV version of the MCT.
 
     Attributes
     ----------
@@ -616,7 +619,6 @@ class MCTDiscretizationFV(DiscretizationParametersBase):
     reconstruction : Switch, optional
         Method for spatial reconstruction. Valid values are 'WENO' (Weighted
         Essentially Non-Oscillatory). Default is 'WENO'.
-
     """
 
     spatial_method = Constant(value="FV")

--- a/CADETProcess/processModel/discretization.py
+++ b/CADETProcess/processModel/discretization.py
@@ -58,7 +58,7 @@ class DiscretizationParametersBase(Structure):
 
     _dimensionality = []
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a new DiscretizationParametersBase instance."""
         self.weno_parameters = WenoParameters()
         self.consistency_solver = ConsistencySolverParameters()
@@ -66,7 +66,7 @@ class DiscretizationParametersBase(Structure):
         super().__init__()
 
     @property
-    def dimensionality(self):
+    def dimensionality(self) -> dict:
         """dict: Dimensionality of the parameters."""
         dim = {}
         for d in self._dimensionality:
@@ -78,7 +78,7 @@ class DiscretizationParametersBase(Structure):
         return dim
 
     @property
-    def parameters(self):
+    def parameters(self) -> dict:
         """dict: Dictionary with parameter values."""
         parameters = super().parameters
         parameters["weno"] = self.weno_parameters.parameters
@@ -87,7 +87,7 @@ class DiscretizationParametersBase(Structure):
         return parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: dict) -> None:
         try:
             self.weno_parameters.parameters = parameters.pop("weno")
         except KeyError:
@@ -183,7 +183,7 @@ class LRMDiscretizationDG(DGMixin):
     _dimensionality = ["axial_dof"]
 
     @property
-    def axial_dof(self):
+    def axial_dof(self) -> int:
         """int: Number of degrees of freedom in the axial discretization."""
         return self.nelem * (self.polydeg + 1)
 
@@ -300,7 +300,7 @@ class LRMPDiscretizationDG(DGMixin):
     _dimensionality = ["axial_dof"]
 
     @property
-    def axial_dof(self):
+    def axial_dof(self) -> int:
         """int: Number of axial degrees of freedom in the spatial discretization."""
         return self.nelem * (self.polydeg + 1)
 
@@ -423,7 +423,7 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
     _dimensionality = ["ncol", "npar"]
 
     @property
-    def par_disc_vector_length(self):
+    def par_disc_vector_length(self) -> int:
         """int: Number of entries in the particle discretization vector."""
         return self.npar + 1
 
@@ -508,17 +508,17 @@ class GRMDiscretizationDG(DGMixin):
     _dimensionality = ["axial_dof", "par_dof"]
 
     @property
-    def axial_dof(self):
+    def axial_dof(self) -> int:
         """int: Number of axial degrees of freedom in the axial discretization."""
         return self.nelem * (self.polydeg + 1)
 
     @property
-    def par_dof(self):
+    def par_dof(self) -> int:
         """int: Number of particle degrees of freedom in the axial discretization."""
         return self.axial_dof * self.par_disc_vector_length
 
     @property
-    def par_disc_vector_length(self):
+    def par_disc_vector_length(self) -> int:
         """int: Number of entries in the particle discretization vector."""
         return self.par_nelem * (self.par_polydeg + 1)
 

--- a/CADETProcess/processModel/discretization.py
+++ b/CADETProcess/processModel/discretization.py
@@ -12,23 +12,32 @@ class for all other classes in this module and defines some common parameters.
 Specific parameters for each scheme are defined as attributes of each class.
 
 """
-from CADETProcess.dataStructure import Structure, frozen_attributes
+
 from CADETProcess.dataStructure import (
-    Constant, Bool, Switch,
-    RangedInteger, UnsignedInteger, UnsignedFloat,
-    SizedRangedList
+    Bool,
+    Constant,
+    RangedInteger,
+    SizedRangedList,
+    Structure,
+    Switch,
+    UnsignedFloat,
+    UnsignedInteger,
+    frozen_attributes,
 )
 
-
 __all__ = [
-    'DiscretizationParametersBase',
-    'NoDiscretization',
-    'LRMDiscretizationFV', 'LRMDiscretizationDG',
-    'LRMPDiscretizationFV', 'LRMPDiscretizationDG',
-    'GRMDiscretizationFV', 'GRMDiscretizationDG',
-    'WenoParameters', 'ConsistencySolverParameters',
-    'DGMixin',
-    'MCTDiscretizationFV',
+    "DiscretizationParametersBase",
+    "NoDiscretization",
+    "LRMDiscretizationFV",
+    "LRMDiscretizationDG",
+    "LRMPDiscretizationFV",
+    "LRMPDiscretizationDG",
+    "GRMDiscretizationFV",
+    "GRMDiscretizationDG",
+    "WenoParameters",
+    "ConsistencySolverParameters",
+    "DGMixin",
+    "MCTDiscretizationFV",
 ]
 
 
@@ -46,6 +55,7 @@ class DiscretizationParametersBase(Structure):
         Consistency solver parameters for Cadet.
 
     """
+
     _dimensionality = []
 
     def __init__(self):
@@ -71,20 +81,19 @@ class DiscretizationParametersBase(Structure):
     def parameters(self):
         """dict: Dictionary with parameter values."""
         parameters = super().parameters
-        parameters['weno'] = self.weno_parameters.parameters
-        parameters['consistency_solver'] = self.consistency_solver.parameters
+        parameters["weno"] = self.weno_parameters.parameters
+        parameters["consistency_solver"] = self.consistency_solver.parameters
 
         return parameters
 
     @parameters.setter
     def parameters(self, parameters):
         try:
-            self.weno_parameters.parameters = parameters.pop('weno')
+            self.weno_parameters.parameters = parameters.pop("weno")
         except KeyError:
             pass
         try:
-            self.consistency_solver.parameters \
-                = parameters.pop('consistency_solver')
+            self.consistency_solver.parameters = parameters.pop("consistency_solver")
         except KeyError:
             pass
 
@@ -120,15 +129,17 @@ class LRMDiscretizationFV(DiscretizationParametersBase):
 
     """
 
-    spatial_method = Constant(value='FV')
+    spatial_method = Constant(value="FV")
     ncol = UnsignedInteger(default=100)
     use_analytic_jacobian = Bool(default=True)
-    reconstruction = Switch(default='WENO', valid=['WENO'])
+    reconstruction = Switch(default="WENO", valid=["WENO"])
 
     _parameters = DiscretizationParametersBase._parameters + [
-        'ncol', 'use_analytic_jacobian', 'reconstruction',
+        "ncol",
+        "use_analytic_jacobian",
+        "reconstruction",
     ]
-    _dimensionality = ['ncol']
+    _dimensionality = ["ncol"]
 
 
 class LRMDiscretizationDG(DGMixin):
@@ -155,16 +166,19 @@ class LRMDiscretizationDG(DGMixin):
 
     """
 
-    spatial_method = Constant(value='DG')
+    spatial_method = Constant(value="DG")
     nelem = UnsignedInteger(default=16)
     use_analytic_jacobian = Bool(default=True)
     polydeg = UnsignedInteger(default=4)
     exact_integration = Bool(default=False)
 
     _parameters = DiscretizationParametersBase._parameters + [
-        'nelem', 'use_analytic_jacobian', 'polydeg', 'exact_integration'
+        "nelem",
+        "use_analytic_jacobian",
+        "polydeg",
+        "exact_integration",
     ]
-    _dimensionality = ['axial_dof']
+    _dimensionality = ["axial_dof"]
 
     @property
     def axial_dof(self):
@@ -211,16 +225,13 @@ class LRMPDiscretizationFV(DiscretizationParametersBase):
 
     """
 
-    spatial_method = Constant(value='FV')
+    spatial_method = Constant(value="FV")
     ncol = UnsignedInteger(default=100)
 
-    par_geom = Switch(
-        default='SPHERE',
-        valid=['SPHERE', 'CYLINDER', 'SLAB']
-    )
+    par_geom = Switch(default="SPHERE", valid=["SPHERE", "CYLINDER", "SLAB"])
 
     use_analytic_jacobian = Bool(default=True)
-    reconstruction = Switch(default='WENO', valid=['WENO'])
+    reconstruction = Switch(default="WENO", valid=["WENO"])
 
     gs_type = Bool(default=True)
     max_krylov = UnsignedInteger(default=0)
@@ -228,10 +239,16 @@ class LRMPDiscretizationFV(DiscretizationParametersBase):
     schur_safety = UnsignedFloat(default=1.0e-8)
 
     _parameters = DiscretizationParametersBase._parameters + [
-        'ncol', 'par_geom', 'use_analytic_jacobian', 'reconstruction',
-        'gs_type', 'max_krylov', 'max_restarts', 'schur_safety'
+        "ncol",
+        "par_geom",
+        "use_analytic_jacobian",
+        "reconstruction",
+        "gs_type",
+        "max_krylov",
+        "max_restarts",
+        "schur_safety",
     ]
-    _dimensionality = ['ncol']
+    _dimensionality = ["ncol"]
 
 
 class LRMPDiscretizationDG(DGMixin):
@@ -262,23 +279,23 @@ class LRMPDiscretizationDG(DGMixin):
 
     """
 
-    spatial_method = Constant(value='DG')
+    spatial_method = Constant(value="DG")
     nelem = UnsignedInteger(default=16)
 
-    par_geom = Switch(
-        default='SPHERE',
-        valid=['SPHERE', 'CYLINDER', 'SLAB']
-    )
+    par_geom = Switch(default="SPHERE", valid=["SPHERE", "CYLINDER", "SLAB"])
 
     use_analytic_jacobian = Bool(default=True)
     polydeg = UnsignedInteger(default=4)
     exact_integration = Bool(default=False)
 
     _parameters = DiscretizationParametersBase._parameters + [
-        'nelem', 'par_geom', 'use_analytic_jacobian',
-        'polydeg', 'exact_integration',
+        "nelem",
+        "par_geom",
+        "use_analytic_jacobian",
+        "polydeg",
+        "exact_integration",
     ]
-    _dimensionality = ['axial_dof']
+    _dimensionality = ["axial_dof"]
 
     @property
     def axial_dof(self):
@@ -347,26 +364,23 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
 
     """
 
-    spatial_method = Constant(value='FV')
+    spatial_method = Constant(value="FV")
     ncol = UnsignedInteger(default=100)
     npar = UnsignedInteger(default=5)
 
-    par_geom = Switch(
-        default='SPHERE',
-        valid=['SPHERE', 'CYLINDER', 'SLAB']
-    )
+    par_geom = Switch(default="SPHERE", valid=["SPHERE", "CYLINDER", "SLAB"])
     par_disc_type = Switch(
-        default='EQUIDISTANT_PAR',
-        valid=['EQUIDISTANT_PAR', 'EQUIVOLUME_PAR', 'USER_DEFINED_PAR']
+        default="EQUIDISTANT_PAR",
+        valid=["EQUIDISTANT_PAR", "EQUIVOLUME_PAR", "USER_DEFINED_PAR"],
     )
     par_disc_vector = SizedRangedList(
-        lb=0, ub=1, size='par_disc_vector_length', is_optional=True
+        lb=0, ub=1, size="par_disc_vector_length", is_optional=True
     )
 
     par_boundary_order = RangedInteger(lb=1, ub=2, default=2)
 
     use_analytic_jacobian = Bool(default=True)
-    reconstruction = Switch(default='WENO', valid=['WENO'])
+    reconstruction = Switch(default="WENO", valid=["WENO"])
 
     gs_type = Bool(default=True)
     max_krylov = UnsignedInteger(default=0)
@@ -376,20 +390,35 @@ class GRMDiscretizationFV(DiscretizationParametersBase):
     fix_zero_surface_diffusion = Bool(default=False)
 
     _parameters = DiscretizationParametersBase._parameters + [
-        'ncol', 'npar',
-        'par_geom', 'par_disc_type', 'par_disc_vector', 'par_boundary_order',
-        'use_analytic_jacobian', 'reconstruction',
-        'gs_type', 'max_krylov', 'max_restarts', 'schur_safety',
-        'fix_zero_surface_diffusion',
+        "ncol",
+        "npar",
+        "par_geom",
+        "par_disc_type",
+        "par_disc_vector",
+        "par_boundary_order",
+        "use_analytic_jacobian",
+        "reconstruction",
+        "gs_type",
+        "max_krylov",
+        "max_restarts",
+        "schur_safety",
+        "fix_zero_surface_diffusion",
     ]
     _required_parameters = [
-        'ncol', 'npar',
-        'par_geom', 'par_disc_type', 'par_boundary_order',
-        'use_analytic_jacobian', 'reconstruction',
-        'gs_type', 'max_krylov', 'max_restarts', 'schur_safety',
-        'fix_zero_surface_diffusion',
+        "ncol",
+        "npar",
+        "par_geom",
+        "par_disc_type",
+        "par_boundary_order",
+        "use_analytic_jacobian",
+        "reconstruction",
+        "gs_type",
+        "max_krylov",
+        "max_restarts",
+        "schur_safety",
+        "fix_zero_surface_diffusion",
     ]
-    _dimensionality = ['ncol', 'npar']
+    _dimensionality = ["ncol", "npar"]
 
     @property
     def par_disc_vector_length(self):
@@ -438,21 +467,17 @@ class GRMDiscretizationDG(DGMixin):
     CADETProcess.processModel.GeneralRateModel
 
     """
-    spatial_method = Constant(value='DG')
+
+    spatial_method = Constant(value="DG")
     nelem = UnsignedInteger(default=16)
     par_nelem = UnsignedInteger(default=1)
 
-    par_geom = Switch(
-        default='SPHERE',
-        valid=['SPHERE', 'CYLINDER', 'SLAB']
-    )
+    par_geom = Switch(default="SPHERE", valid=["SPHERE", "CYLINDER", "SLAB"])
     par_disc_type = Switch(
-        default='EQUIDISTANT_PAR',
-        valid=['EQUIDISTANT_PAR', 'EQUIVOLUME_PAR', 'USER_DEFINED_PAR']
+        default="EQUIDISTANT_PAR",
+        valid=["EQUIDISTANT_PAR", "EQUIVOLUME_PAR", "USER_DEFINED_PAR"],
     )
-    par_disc_vector = SizedRangedList(
-        lb=0, ub=1, size='par_disc_vector_length'
-    )
+    par_disc_vector = SizedRangedList(lb=0, ub=1, size="par_disc_vector_length")
 
     par_boundary_order = RangedInteger(lb=1, ub=2, default=2)
 
@@ -465,14 +490,20 @@ class GRMDiscretizationDG(DGMixin):
     fix_zero_surface_diffusion = Bool(default=False)
 
     _parameters = DiscretizationParametersBase._parameters + [
-        'nelem', 'par_nelem',
-        'par_geom', 'par_disc_type', 'par_disc_vector', 'par_boundary_order',
-        'use_analytic_jacobian',
-        'polydeg', 'par_polydeg',
-        'exact_integration', 'par_exact_integration',
-        'fix_zero_surface_diffusion',
+        "nelem",
+        "par_nelem",
+        "par_geom",
+        "par_disc_type",
+        "par_disc_vector",
+        "par_boundary_order",
+        "use_analytic_jacobian",
+        "polydeg",
+        "par_polydeg",
+        "exact_integration",
+        "par_exact_integration",
+        "fix_zero_surface_diffusion",
     ]
-    _dimensionality = ['axial_dof', 'par_dof']
+    _dimensionality = ["axial_dof", "par_dof"]
 
     @property
     def axial_dof(self):
@@ -523,7 +554,7 @@ class WenoParameters(Structure):
     boundary_model = UnsignedInteger(default=0, ub=3)
     weno_eps = UnsignedFloat(default=1e-10)
     weno_order = UnsignedInteger(default=3, ub=3)
-    _parameters = ['boundary_model', 'weno_eps', 'weno_order']
+    _parameters = ["boundary_model", "weno_eps", "weno_order"]
 
 
 @frozen_attributes
@@ -555,19 +586,19 @@ class ConsistencySolverParameters(Structure):
     """
 
     solver_name = Switch(
-        default='LEVMAR',
-        valid=['LEVMAR', 'ATRN_RES', 'ARTN_ERR', 'COMPOSITE']
+        default="LEVMAR", valid=["LEVMAR", "ATRN_RES", "ARTN_ERR", "COMPOSITE"]
     )
     init_damping = UnsignedFloat(default=0.01)
     min_damping = UnsignedFloat(default=0.0001)
     max_iterations = UnsignedInteger(default=50)
-    subsolvers = Switch(
-        default='LEVMAR',
-        valid=['LEVMAR', 'ATRN_RES', 'ARTN_ERR']
-    )
+    subsolvers = Switch(default="LEVMAR", valid=["LEVMAR", "ATRN_RES", "ARTN_ERR"])
 
     _parameters = [
-        'solver_name', 'init_damping', 'min_damping', 'max_iterations', 'subsolvers'
+        "solver_name",
+        "init_damping",
+        "min_damping",
+        "max_iterations",
+        "subsolvers",
     ]
 
 
@@ -588,10 +619,10 @@ class MCTDiscretizationFV(DiscretizationParametersBase):
 
     """
 
-    spatial_method = Constant(value='FV')
+    spatial_method = Constant(value="FV")
     ncol = UnsignedInteger(default=100)
     use_analytic_jacobian = Bool(default=True)
-    reconstruction = Switch(default='WENO', valid=['WENO'])
+    reconstruction = Switch(default="WENO", valid=["WENO"])
 
-    _parameters = ['ncol', 'use_analytic_jacobian', 'reconstruction']
-    _dimensionality = ['ncol']
+    _parameters = ["ncol", "use_analytic_jacobian", "reconstruction"]
+    _dimensionality = ["ncol"]

--- a/CADETProcess/processModel/flowSheet.py
+++ b/CADETProcess/processModel/flowSheet.py
@@ -16,7 +16,8 @@ from .unitOperation import Cstr, Inlet, Outlet, UnitBaseClass
 
 @frozen_attributes
 class FlowSheet(Structure):
-    """Class to design process flow sheet.
+    """
+    Class to design process flow sheet.
 
     In this class, UnitOperation models are added and connected in a flow
     sheet.
@@ -33,7 +34,6 @@ class FlowSheet(Structure):
         Connections of UnitOperations.
     output_states : dict
         Split ratios of outgoing streams of UnitOperations.
-
     """
 
     name = String()
@@ -72,6 +72,7 @@ class FlowSheet(Structure):
         return self.component_system.n_comp
 
     def unit_name_decorator(func):
+        """Wrap methods to enable calling functions with unit object or unit name."""
         @wraps(func)
         def unit_name_wrapper(self, unit, *args, **kwargs):
             """Enable calling functions with unit object or unit name."""
@@ -85,6 +86,7 @@ class FlowSheet(Structure):
         return unit_name_wrapper
 
     def origin_destination_name_decorator(func):
+        """Wrap methods to enable calling functions using origin and destination units."""
         @wraps(func)
         def origin_destination_name_wrapper(self, origin, destination, *args, **kwargs):
             """Enable calling origin and destination using unit names."""
@@ -105,6 +107,7 @@ class FlowSheet(Structure):
         return origin_destination_name_wrapper
 
     def update_parameters(self):
+        """Update current parameters."""
         for unit in self.units:
             self._parameters[unit.name] = unit.parameters
             self._section_dependent_parameters[unit.name] = (
@@ -126,6 +129,7 @@ class FlowSheet(Structure):
         }
 
     def update_parameters_decorator(func):
+        """Wrap method s.t. parameters dict is automatically updated."""
         @wraps(func)
         def wrapper(self, *args, **kwargs):
             """Update parameters dict to save time."""
@@ -158,7 +162,8 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def get_unit_index(self, unit):
-        """Return the unit index of the unit.
+        """
+        Return the unit index of the unit.
 
         Parameters
         ----------
@@ -174,15 +179,15 @@ class FlowSheet(Structure):
         -------
         unit_index : int
             Returns the unit index of the unit_operation.
-
         """
         if unit not in self.units:
             raise CADETProcessError("Unit not in flow sheet")
 
         return self.units.index(unit)
 
-    def get_port_index(self, unit, port):
-        """Return the port index of a unit.
+    def get_port_index(self, unit, port) -> int:
+        """
+        Return the port index of a unit.
 
         Parameters
         ----------
@@ -190,10 +195,12 @@ class FlowSheet(Structure):
             UnitBaseClass object of wich port index is to be returned
         port : string
             Name of port which index is to be returned
+
         Raises
         ------
         CADETProcessError
             If unit or port is not in the current flow sheet.
+
         Returns
         -------
         port_index : int
@@ -238,7 +245,8 @@ class FlowSheet(Structure):
         eluent_inlet=False,
         product_outlet=False,
     ):
-        """Add unit to the flow sheet.
+        """
+        Add unit to the flow sheet.
 
         Parameters
         ----------
@@ -262,7 +270,6 @@ class FlowSheet(Structure):
         See Also
         --------
         remove_unit
-
         """
         if not isinstance(unit, UnitBaseClass):
             raise TypeError("Expected UnitOperation")
@@ -303,7 +310,8 @@ class FlowSheet(Structure):
     @unit_name_decorator
     @update_parameters_decorator
     def remove_unit(self, unit):
-        """Remove unit from flow sheet.
+        """
+        Remove unit from flow sheet.
 
         Removes unit from the list. Tries to remove units which are twice
         located as desinations. For this the origins and destinations are
@@ -327,7 +335,6 @@ class FlowSheet(Structure):
         feed_inlet
         eluent_inlet
         product_outlet
-
         """
         if unit not in self.units:
             raise CADETProcessError("Unit not in flow sheet")
@@ -388,7 +395,8 @@ class FlowSheet(Structure):
     def add_connection(
         self, origin, destination, origin_port=None, destination_port=None
     ):
-        """Add connection between units 'origin' and 'destination'.
+        """
+        Add connection between units 'origin' and 'destination'.
 
         Parameters
         ----------
@@ -412,7 +420,6 @@ class FlowSheet(Structure):
         connections
         remove_connection
         output_state
-
         """
         if origin not in self._units:
             raise CADETProcessError("Origin not in flow sheet")
@@ -476,7 +483,8 @@ class FlowSheet(Structure):
         origin_port=None,
         destination_port=None,
     ):
-        """Remove connection between units 'origin' and 'destination'.
+        """
+        Remove connection between units 'origin' and 'destination'.
 
         Parameters
         ----------
@@ -499,7 +507,6 @@ class FlowSheet(Structure):
         --------
         connections
         add_connection
-
         """
         if origin not in self._units:
             raise CADETProcessError("Origin not in flow sheet")
@@ -579,7 +586,8 @@ class FlowSheet(Structure):
         return False
 
     def check_connections(self):
-        """Validate that units are connected correctly.
+        """
+        Validate that units are connected correctly.
 
         Raises
         ------
@@ -592,7 +600,6 @@ class FlowSheet(Structure):
         -------
         flag : bool
             True if all units are connected correctly. False otherwise.
-
         """
         flag = True
         for unit, connections in self.connections.items():
@@ -630,7 +637,8 @@ class FlowSheet(Structure):
         return flag
 
     @property
-    def missing_parameters(self):
+    def missing_parameters(self) -> dict:
+        """dict: Missing parameters of the flow sheet."""
         missing_parameters = []
 
         for unit in self.units:
@@ -641,13 +649,13 @@ class FlowSheet(Structure):
         return missing_parameters
 
     def check_units_config(self):
-        """Check if units are configured correctly.
+        """
+        Check if units are configured correctly.
 
         Returns
         -------
         flag : bool
             True if units are configured correctly. False otherwise.
-
         """
         flag = True
         for unit in self.units:
@@ -656,7 +664,8 @@ class FlowSheet(Structure):
         return flag
 
     @property
-    def output_states(self):
+    def output_states(self) -> dict:
+        """dict: Output states of the unit operations."""
         output_states_dict = self._output_states.copy()
 
         for unit, ports in output_states_dict.items():
@@ -669,7 +678,8 @@ class FlowSheet(Structure):
     @unit_name_decorator
     @update_parameters_decorator
     def set_output_state(self, unit, state, port=None):
-        """Set split ratio of outgoing streams for UnitOperation.
+        """
+        Set split ratio of outgoing streams for UnitOperation.
 
         Parameters
         ----------
@@ -691,11 +701,11 @@ class FlowSheet(Structure):
         """
 
         def get_port_index(unit_connection_dict, destination, destination_port):
-            """helper function to compute the index of a connection for the output state
+            """
+            Compute the index of a connection for the output state.
 
             Parameters
             ----------
-
             unit_connection_dict : Defaultdict
                 contains dict with connected units and their respective ports
             destination : UnitBaseClass
@@ -787,7 +797,8 @@ class FlowSheet(Structure):
         self._output_states[unit][port] = output_state
 
     def get_flow_rates(self, state=None, eps=5.9e16):
-        r"""Calculate flow rate for all connections.
+        r"""
+        Calculate flow rate for all connections.
 
         Optionally, an additional output state can be passed to update the
         current output states.
@@ -799,6 +810,7 @@ class FlowSheet(Structure):
             Default is None.
         eps : float, optional
             eps as an upper boarder for condition of flow_rate calculation
+
         Returns
         -------
         Dict
@@ -1040,7 +1052,8 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def add_feed_inlet(self, feed_inlet):
-        """Add inlet to list of units to be considered for recovery.
+        """
+        Add inlet to list of units to be considered for recovery.
 
         Parameters
         ----------
@@ -1052,7 +1065,6 @@ class FlowSheet(Structure):
         CADETProcessError
             If unit is not an Inlet.
             If unit is already marked as feed inlet.
-
         """
         if feed_inlet not in self.inlets:
             raise CADETProcessError("Expected Inlet")
@@ -1062,13 +1074,13 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def remove_feed_inlet(self, feed_inlet):
-        """Remove inlet from list of units to be considered for recovery.
+        """
+        Remove inlet from list of units to be considered for recovery.
 
         Parameters
         ----------
         feed_inlet : SourceMixin
             Unit to be removed from list of feed inlets.
-
         """
         if feed_inlet not in self._feed_inlets:
             raise CADETProcessError(f"Unit '{feed_inlet}' is not a feed inlet.")
@@ -1081,7 +1093,8 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def add_eluent_inlet(self, eluent_inlet):
-        """Add inlet to list of units to be considered for eluent consumption.
+        """
+        Add inlet to list of units to be considered for eluent consumption.
 
         Parameters
         ----------
@@ -1093,7 +1106,6 @@ class FlowSheet(Structure):
         CADETProcessError
             If unit is not an Inlet.
             If unit is already marked as eluent inlet.
-
         """
         if eluent_inlet not in self.inlets:
             raise CADETProcessError("Expected Inlet")
@@ -1103,7 +1115,8 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def remove_eluent_inlet(self, eluent_inlet):
-        """Remove inlet from list of units considered for eluent consumption.
+        """
+        Remove inlet from list of units considered for eluent consumption.
 
         Parameters
         ----------
@@ -1114,7 +1127,6 @@ class FlowSheet(Structure):
         ------
         CADETProcessError
             If unit is not in eluent inlets.
-
         """
         if eluent_inlet not in self._eluent_inlets:
             raise CADETProcessError(f"Unit '{eluent_inlet}' is not an eluent inlet.")
@@ -1127,7 +1139,8 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def add_product_outlet(self, product_outlet):
-        """Add outlet to list of units considered for fractionation.
+        """
+        Add outlet to list of units considered for fractionation.
 
         Parameters
         ----------
@@ -1139,7 +1152,6 @@ class FlowSheet(Structure):
         CADETProcessError
             If unit is not an Outlet.
             If unit is already marked as product outlet.
-
         """
         if product_outlet not in self.outlets:
             raise CADETProcessError("Expected Outlet")
@@ -1151,7 +1163,8 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     def remove_product_outlet(self, product_outlet):
-        """Remove outlet from list of units to be considered for fractionation.
+        """
+        Remove outlet from list of units to be considered for fractionation.
 
         Parameters
         ----------
@@ -1162,7 +1175,6 @@ class FlowSheet(Structure):
         ------
         CADETProcessError
             If unit is not a product outlet.
-
         """
         if product_outlet not in self._product_outlets:
             raise CADETProcessError(f"Unit '{product_outlet}' is not a product outlet.")
@@ -1233,7 +1245,8 @@ class FlowSheet(Structure):
         return iter(self.units)
 
     def __getitem__(self, unit_name) -> UnitBaseClass:
-        """Make FlowSheet substriptable s.t. units can be used as keys.
+        """
+        Make FlowSheet substriptable s.t. units can be used as keys.
 
         Parameters
         ----------
@@ -1249,7 +1262,6 @@ class FlowSheet(Structure):
         ------
         KeyError
             If unit not in FlowSheet
-
         """
         try:
             return self.units_dict[unit_name]
@@ -1257,7 +1269,8 @@ class FlowSheet(Structure):
             raise KeyError("Not a valid unit")
 
     def __contains__(self, item: UnitBaseClass | str) -> bool:
-        """Check if UnitOperation is part of the FlowSheet.
+        """
+        Check if UnitOperation is part of the FlowSheet.
 
         Parameters
         ----------
@@ -1267,7 +1280,6 @@ class FlowSheet(Structure):
         Returns
         -------
         Bool : True if item is in units, otherwise False.
-
         """
         if (item in self._units) or (item in self.unit_names):
             return True

--- a/CADETProcess/processModel/flowSheet.py
+++ b/CADETProcess/processModel/flowSheet.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 from collections import defaultdict
 from functools import wraps
-from typing import Iterator, NoReturn
+from typing import Any, Callable, Iterator, Optional
 from warnings import warn
 
 import numpy as np
@@ -11,7 +13,7 @@ from CADETProcess.dataStructure import String, Structure, frozen_attributes
 
 from .binding import NoBinding
 from .componentSystem import ComponentSystem
-from .unitOperation import Cstr, Inlet, Outlet, UnitBaseClass
+from .unitOperation import Cstr, Inlet, Outlet, SourceMixin, UnitBaseClass
 
 
 @frozen_attributes
@@ -38,7 +40,13 @@ class FlowSheet(Structure):
 
     name = String()
 
-    def __init__(self, component_system, *args, **kwargs):
+    def __init__(
+        self,
+        component_system: ComponentSystem,
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
+        """Initialize flow sheet."""
         super().__init__(*args, **kwargs)
 
         self.component_system = component_system
@@ -61,20 +69,25 @@ class FlowSheet(Structure):
         return self._component_system
 
     @component_system.setter
-    def component_system(self, component_system):
+    def component_system(self, component_system: ComponentSystem) -> None:
         if not isinstance(component_system, ComponentSystem):
             raise TypeError("Expected ComponentSystem")
         self._component_system = component_system
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
         """int: The number of components."""
         return self.component_system.n_comp
 
-    def unit_name_decorator(func):
+    def unit_name_decorator(func: Callable) -> Callable:
         """Wrap methods to enable calling functions with unit object or unit name."""
         @wraps(func)
-        def unit_name_wrapper(self, unit, *args, **kwargs):
+        def unit_name_wrapper(
+            self: FlowSheet,
+            unit: str | UnitBaseClass,
+            *args: Any,
+            **kwargs: Any
+        ) -> Any:
             """Enable calling functions with unit object or unit name."""
             if isinstance(unit, str):
                 try:
@@ -85,10 +98,16 @@ class FlowSheet(Structure):
 
         return unit_name_wrapper
 
-    def origin_destination_name_decorator(func):
+    def origin_destination_name_decorator(func: Callable) -> Callable:
         """Wrap methods to enable calling functions using origin and destination units."""
         @wraps(func)
-        def origin_destination_name_wrapper(self, origin, destination, *args, **kwargs):
+        def origin_destination_name_wrapper(
+            self: FlowSheet,
+            origin: str | UnitBaseClass,
+            destination: str | UnitBaseClass,
+            *args: Any,
+            **kwargs: Any
+        ) -> Any:
             """Enable calling origin and destination using unit names."""
             if isinstance(origin, str):
                 try:
@@ -106,7 +125,7 @@ class FlowSheet(Structure):
 
         return origin_destination_name_wrapper
 
-    def update_parameters(self):
+    def update_parameters(self) -> None:
         """Update current parameters."""
         for unit in self.units:
             self._parameters[unit.name] = unit.parameters
@@ -128,10 +147,10 @@ class FlowSheet(Structure):
             unit.name: self.output_states[unit] for unit in self.units
         }
 
-    def update_parameters_decorator(func):
+    def update_parameters_decorator(func: Callable) -> Callable:
         """Wrap method s.t. parameters dict is automatically updated."""
         @wraps(func)
-        def wrapper(self, *args, **kwargs):
+        def wrapper(self: 'FlowSheet', *args: Any, **kwargs: Any) -> Any:
             """Update parameters dict to save time."""
             results = func(self, *args, **kwargs)
             self.update_parameters()
@@ -141,27 +160,27 @@ class FlowSheet(Structure):
         return wrapper
 
     @property
-    def units(self):
+    def units(self) -> list[UnitBaseClass]:
         """list: list of all unit_operations in the flow sheet."""
         return self._units
 
     @property
-    def units_dict(self):
+    def units_dict(self) -> dict[str, UnitBaseClass]:
         """dict: Unit operation names and objects."""
         return {unit.name: unit for unit in self.units}
 
     @property
-    def unit_names(self):
+    def unit_names(self) -> list[str]:
         """list: Names of unit operations."""
         return [unit.name for unit in self.units]
 
     @property
-    def number_of_units(self):
+    def number_of_units(self) -> int:
         """int: Number of unit operations in the FlowSheet."""
         return len(self._units)
 
     @unit_name_decorator
-    def get_unit_index(self, unit):
+    def get_unit_index(self, unit: UnitBaseClass) -> int:
         """
         Return the unit index of the unit.
 
@@ -185,7 +204,7 @@ class FlowSheet(Structure):
 
         return self.units.index(unit)
 
-    def get_port_index(self, unit, port) -> int:
+    def get_port_index(self, unit: UnitBaseClass, port: str) -> int:
         """
         Return the port index of a unit.
 
@@ -214,22 +233,22 @@ class FlowSheet(Structure):
         return port_index
 
     @property
-    def inlets(self):
+    def inlets(self) -> list[Inlet]:
         """list: All Inlets in the system."""
         return [unit for unit in self._units if isinstance(unit, Inlet)]
 
     @property
-    def outlets(self):
+    def outlets(self) -> list[Outlet]:
         """list: All Outlets in the system."""
         return [unit for unit in self._units if isinstance(unit, Outlet)]
 
     @property
-    def cstrs(self):
+    def cstrs(self) -> list[Cstr]:
         """list: All Cstrs in the system."""
         return [unit for unit in self._units if isinstance(unit, Cstr)]
 
     @property
-    def units_with_binding(self):
+    def units_with_binding(self) -> list[UnitBaseClass]:
         """list: UnitOperations with binding models."""
         return [
             unit
@@ -240,11 +259,11 @@ class FlowSheet(Structure):
     @update_parameters_decorator
     def add_unit(
         self,
-        unit,
-        feed_inlet=False,
-        eluent_inlet=False,
-        product_outlet=False,
-    ):
+        unit: UnitBaseClass,
+        feed_inlet: bool = False,
+        eluent_inlet: bool = False,
+        product_outlet: bool = False
+    ) -> None:
         """
         Add unit to the flow sheet.
 
@@ -309,7 +328,7 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     @update_parameters_decorator
-    def remove_unit(self, unit):
+    def remove_unit(self, unit: UnitBaseClass) -> None:
         """
         Remove unit from flow sheet.
 
@@ -379,7 +398,7 @@ class FlowSheet(Structure):
         self.__dict__.pop(unit.name)
 
     @property
-    def connections(self):
+    def connections(self) -> Dict:
         """dict: In- and outgoing connections for each unit.
 
         See Also
@@ -393,8 +412,12 @@ class FlowSheet(Structure):
     @origin_destination_name_decorator
     @update_parameters_decorator
     def add_connection(
-        self, origin, destination, origin_port=None, destination_port=None
-    ):
+        self,
+        origin: UnitBaseClass,
+        destination: UnitBaseClass,
+        origin_port: Optional[str] = None,
+        destination_port: Optional[str] = None
+    ) -> None:
         """
         Add connection between units 'origin' and 'destination'.
 
@@ -404,9 +427,9 @@ class FlowSheet(Structure):
             UnitBaseClass from which the connection originates.
         destination : UnitBaseClass
             UnitBaseClass where the connection terminates.
-        origin_port : str
+        origin_port : str, optional
             Port from which connection originates.
-        destination_port : str
+        destination_port : str, optional
             Port where connection terminates.
 
         Raises
@@ -478,11 +501,11 @@ class FlowSheet(Structure):
     @update_parameters_decorator
     def remove_connection(
         self,
-        origin,
-        destination,
-        origin_port=None,
-        destination_port=None,
-    ):
+        origin: UnitBaseClass,
+        destination: UnitBaseClass,
+        origin_port: Optional[str] = None,
+        destination_port: Optional[str] = None,
+    ) -> None:
         """
         Remove connection between units 'origin' and 'destination'.
 
@@ -537,12 +560,13 @@ class FlowSheet(Structure):
     @origin_destination_name_decorator
     def connection_exists(
         self,
-        origin,
-        destination,
-        origin_port=None,
-        destination_port=None,
-    ):
-        """bool: check if connection exists in flow sheet.
+        origin: UnitBaseClass,
+        destination: UnitBaseClass,
+        origin_port: Optional[str] = None,
+        destination_port: Optional[str] = None,
+    ) -> bool:
+        """
+        bool: check if connection exists in flow sheet.
 
         Parameters
         ----------
@@ -550,6 +574,10 @@ class FlowSheet(Structure):
             UnitBaseClass from which the connection originates.
         destination : UnitBaseClass
             UnitBaseClass where the connection terminates.
+        origin_port : Port, optional
+            If origin unit operation has ports, origin port can be specified.
+        destination_port : Port optional
+            if destination unit operation has ports, destination port can be specified.
 
         """
         if origin.has_ports and not origin_port:
@@ -585,13 +613,12 @@ class FlowSheet(Structure):
 
         return False
 
-    def check_connections(self):
+    def check_connections(self) -> bool:
         """
         Validate that units are connected correctly.
 
-        Raises
-        ------
-        Warning
+        Warning:
+        -------
             If Inlets have ingoing streams.
             If Outlets have outgoing streams.
             If Units (other than Cstr) are not fully connected.
@@ -637,7 +664,7 @@ class FlowSheet(Structure):
         return flag
 
     @property
-    def missing_parameters(self) -> dict:
+    def missing_parameters(self) -> list[str]:
         """dict: Missing parameters of the flow sheet."""
         missing_parameters = []
 
@@ -648,7 +675,7 @@ class FlowSheet(Structure):
 
         return missing_parameters
 
-    def check_units_config(self):
+    def check_units_config(self) -> bool:
         """
         Check if units are configured correctly.
 
@@ -664,7 +691,7 @@ class FlowSheet(Structure):
         return flag
 
     @property
-    def output_states(self) -> dict:
+    def output_states(self) -> Dict:
         """dict: Output states of the unit operations."""
         output_states_dict = self._output_states.copy()
 
@@ -677,7 +704,12 @@ class FlowSheet(Structure):
 
     @unit_name_decorator
     @update_parameters_decorator
-    def set_output_state(self, unit, state, port=None):
+    def set_output_state(
+        self,
+        unit: UnitBaseClass,
+        state: int | list[float] | dict,
+        port: Optional[str] = None
+    ) -> None:
         """
         Set split ratio of outgoing streams for UnitOperation.
 
@@ -687,7 +719,7 @@ class FlowSheet(Structure):
             UnitOperation of flowsheet.
         state : int or list of floats or dict
             new output state of the unit.
-        port : int
+        port : str
             Port for which to set the output state.
 
         Raises
@@ -697,10 +729,14 @@ class FlowSheet(Structure):
             If state is integer and the state >= the state_length.
             If the length of the states is unequal the state_length.
             If the sum of the states is not equal to 1.
-            If port exceeds the number of ports
+            If port cannot be found in the unit operation.
         """
 
-        def get_port_index(unit_connection_dict, destination, destination_port):
+        def get_port_index(
+            unit_connection_dict: Dict,
+            destination: UnitBaseClass,
+            destination_port: str
+        ) -> int:
             """
             Compute the index of a connection for the output state.
 
@@ -710,7 +746,7 @@ class FlowSheet(Structure):
                 contains dict with connected units and their respective ports
             destination : UnitBaseClass
                 destination object
-            destination_port : int
+            destination_port : str
                 destination Port
             """
             ret_index = 0
@@ -796,7 +832,7 @@ class FlowSheet(Structure):
 
         self._output_states[unit][port] = output_state
 
-    def get_flow_rates(self, state=None, eps=5.9e16):
+    def get_flow_rates(self, state: Optional[Dict] = None, eps: float = 5.9e16) -> Dict:
         r"""
         Calculate flow rate for all connections.
 
@@ -1033,7 +1069,7 @@ class FlowSheet(Structure):
 
         return return_flow_rates
 
-    def check_flow_rates(self, state=None) -> NoReturn:
+    def check_flow_rates(self, state: Optional[dict] = None) -> None:
         """Check if in and outgoing flow rates of unit operations are balanced."""
         flow_rates = self.get_flow_rates(state)
         for unit, q in flow_rates.items():
@@ -1046,12 +1082,12 @@ class FlowSheet(Structure):
                 raise CADETProcessError(f"Unbalanced flow rate for unit '{unit}'.")
 
     @property
-    def feed_inlets(self):
+    def feed_inlets(self) -> list[UnitBaseClass]:
         """list: Inlets considered for calculating recovery yield."""
         return self._feed_inlets
 
     @unit_name_decorator
-    def add_feed_inlet(self, feed_inlet):
+    def add_feed_inlet(self, feed_inlet: SourceMixin) -> None:
         """
         Add inlet to list of units to be considered for recovery.
 
@@ -1073,7 +1109,7 @@ class FlowSheet(Structure):
         self._feed_inlets.append(feed_inlet)
 
     @unit_name_decorator
-    def remove_feed_inlet(self, feed_inlet):
+    def remove_feed_inlet(self, feed_inlet: SourceMixin) -> None:
         """
         Remove inlet from list of units to be considered for recovery.
 
@@ -1087,12 +1123,12 @@ class FlowSheet(Structure):
         self._feed_inlets.remove(feed_inlet)
 
     @property
-    def eluent_inlets(self):
+    def eluent_inlets(self) -> list[UnitBaseClass]:
         """list: Inlets to be considered for eluent consumption."""
         return self._eluent_inlets
 
     @unit_name_decorator
-    def add_eluent_inlet(self, eluent_inlet):
+    def add_eluent_inlet(self, eluent_inlet: SourceMixin) -> None:
         """
         Add inlet to list of units to be considered for eluent consumption.
 
@@ -1114,7 +1150,7 @@ class FlowSheet(Structure):
         self._eluent_inlets.append(eluent_inlet)
 
     @unit_name_decorator
-    def remove_eluent_inlet(self, eluent_inlet):
+    def remove_eluent_inlet(self, eluent_inlet: SourceMixin) -> None:
         """
         Remove inlet from list of units considered for eluent consumption.
 
@@ -1133,12 +1169,12 @@ class FlowSheet(Structure):
         self._eluent_inlets.remove(eluent_inlet)
 
     @property
-    def product_outlets(self):
+    def product_outlets(self) -> list[UnitBaseClass]:
         """list: Outlets to be considered for fractionation."""
         return self._product_outlets
 
     @unit_name_decorator
-    def add_product_outlet(self, product_outlet):
+    def add_product_outlet(self, product_outlet: Outlet) -> None:
         """
         Add outlet to list of units considered for fractionation.
 
@@ -1162,7 +1198,7 @@ class FlowSheet(Structure):
         self._product_outlets.append(product_outlet)
 
     @unit_name_decorator
-    def remove_product_outlet(self, product_outlet):
+    def remove_product_outlet(self, product_outlet: Outlet) -> None:
         """
         Remove outlet from list of units to be considered for fractionation.
 
@@ -1186,7 +1222,7 @@ class FlowSheet(Structure):
         return self._parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: dict) -> None:
         try:
             output_states = parameters.pop("output_states")
             for unit, state in output_states.items():
@@ -1208,17 +1244,17 @@ class FlowSheet(Structure):
         self.update_parameters()
 
     @property
-    def sized_parameters(self) -> list:
+    def sized_parameters(self) -> list[str]:
         """list: List of sized parameters."""
         return self._sized_parameters
 
     @property
-    def polynomial_parameters(self) -> list:
+    def polynomial_parameters(self) -> list[str]:
         """list: List of polynomial parameters."""
         return self._polynomial_parameters
 
     @property
-    def section_dependent_parameters(self) -> list:
+    def section_dependent_parameters(self) -> list[str]:
         """list: List of section dependent parameters."""
         return self._section_dependent_parameters
 
@@ -1230,7 +1266,7 @@ class FlowSheet(Structure):
         return initial_state
 
     @initial_state.setter
-    def initial_state(self, initial_state):
+    def initial_state(self, initial_state: dict) -> None:
         for unit, st in initial_state.items():
             if unit not in self.units_dict:
                 raise CADETProcessError("Not a valid unit")
@@ -1244,7 +1280,7 @@ class FlowSheet(Structure):
         """Iterate over the unit operations in the system."""
         return iter(self.units)
 
-    def __getitem__(self, unit_name) -> UnitBaseClass:
+    def __getitem__(self, unit_name: str) -> UnitBaseClass:
         """
         Make FlowSheet substriptable s.t. units can be used as keys.
 
@@ -1285,6 +1321,3 @@ class FlowSheet(Structure):
             return True
         else:
             return False
-
-        def __iter__(self):
-            yield from self.units

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -1,6 +1,6 @@
 from collections import defaultdict
 from dataclasses import dataclass
-from typing import Literal, Optional
+from typing import Any, Literal, Optional
 from warnings import warn
 
 import numpy as np
@@ -26,7 +26,7 @@ class Process(EventHandler):
         Name of the process object to be simulated.
     system_state : np.ndarray
         State of the process object
-    system_state_derivate : ndarray
+    system_state_derivate : np.ndarray
         Derivative of the state
 
     See Also
@@ -38,7 +38,8 @@ class Process(EventHandler):
 
     _initial_states = ["system_state", "system_state_derivative"]
 
-    def __init__(self, flow_sheet, name, *args, **kwargs):
+    def __init__(self, flow_sheet: FlowSheet, name: str, *args: Any, **kwargs: Any) -> None:
+        """Initialize Process."""
         self.flow_sheet = flow_sheet
         self.name = name
 
@@ -68,7 +69,7 @@ class Process(EventHandler):
         return self.flow_sheet.component_system
 
     @property
-    def flow_sheet(self):
+    def flow_sheet(self) -> FlowSheet:
         """FlowSheet: flow sheet of the process model.
 
         Raises
@@ -80,7 +81,7 @@ class Process(EventHandler):
         return self._flow_sheet
 
     @flow_sheet.setter
-    def flow_sheet(self, flow_sheet):
+    def flow_sheet(self, flow_sheet: FlowSheet) -> None:
         if not isinstance(flow_sheet, FlowSheet):
             raise TypeError("Expected FlowSheet")
         self._flow_sheet = flow_sheet
@@ -117,7 +118,7 @@ class Process(EventHandler):
         return feed_all
 
     @cached_property_if_locked
-    def V_eluent(self):
+    def V_eluent(self) -> float:
         """float: Volume of the eluent entering the system in one cycle."""
         flow_rate_timelines = self.flow_rate_timelines
 
@@ -130,7 +131,7 @@ class Process(EventHandler):
         return float(V_all)
 
     @cached_property_if_locked
-    def V_solid(self):
+    def V_solid(self) -> float:
         """float: Volume of all solid phase material used in flow sheet."""
         return sum([unit.volume_solid for unit in self.flow_sheet.units_with_binding])
 
@@ -283,32 +284,32 @@ class Process(EventHandler):
         return Dict(section_states)
 
     @property
-    def n_sensitivities(self):
+    def n_sensitivities(self) -> int:
         """int: Number of parameter sensitivities."""
         return len(self.parameter_sensitivities)
 
     @property
-    def parameter_sensitivities(self):
+    def parameter_sensitivities(self) -> list:
         """list: Parameter sensitivites."""
         return self._parameter_sensitivities
 
     @property
-    def parameter_sensitivity_names(self):
+    def parameter_sensitivity_names(self) -> list:
         """list: Parameter sensitivity names."""
         return [sens.name for sens in self.parameter_sensitivities]
 
     def add_parameter_sensitivity(
         self,
-        parameter_paths,
-        name=None,
-        components=None,
-        polynomial_coefficients=None,
-        reaction_indices=None,
-        bound_state_indices=None,
-        section_indices=None,
-        abstols=None,
-        factors=None,
-    ):
+        parameter_paths: str | list[str],
+        name: Optional[str] = None,
+        components: Optional[str | list[str]] = None,
+        polynomial_coefficients: Optional[str | list[str]] = None,
+        reaction_indices: Optional[int | list[int]] = None,
+        bound_state_indices: Optional[int | list[int]] = None,
+        section_indices: Optional[int | list[int]] = None,
+        abstols: Optional[float | list[float]] = None,
+        factors: Optional[int | list[int]] = None
+    ) -> None:
         """
         Add parameter sensitivty to Process.
 
@@ -508,7 +509,7 @@ class Process(EventHandler):
         return self._system_state
 
     @system_state.setter
-    def system_state(self, system_state):
+    def system_state(self, system_state: np.ndarray) -> None:
         self._system_state = system_state
 
     @property
@@ -517,7 +518,7 @@ class Process(EventHandler):
         return self._system_state_derivative
 
     @system_state_derivative.setter
-    def system_state_derivative(self, system_state_derivative):
+    def system_state_derivative(self, system_state_derivative: np.ndarray) -> None:
         self._system_state_derivative = system_state_derivative
 
     @property
@@ -530,7 +531,7 @@ class Process(EventHandler):
         return parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: dict) -> None:
         try:
             self.flow_sheet.parameters = parameters.pop("flow_sheet")
         except KeyError:
@@ -539,21 +540,21 @@ class Process(EventHandler):
         super(Process, self.__class__).parameters.fset(self, parameters)
 
     @property
-    def section_dependent_parameters(self) -> dict:
+    def section_dependent_parameters(self) -> Dict:
         """dict: Section dependent parameters of the process."""
         parameters = Dict()
         parameters.flow_sheet = self.flow_sheet.section_dependent_parameters
         return parameters
 
     @property
-    def polynomial_parameters(self) -> dict:
+    def polynomial_parameters(self) -> Dict:
         """dict: Polynomial parameters of the process."""
         parameters = super().polynomial_parameters
         parameters.flow_sheet = self.flow_sheet.polynomial_parameters
         return parameters
 
     @property
-    def sized_parameters(self) -> dict:
+    def sized_parameters(self) -> Dict:
         """dict: Sized parameters of the process."""
         parameters = super().sized_parameters
         parameters.flow_sheet = self.flow_sheet.sized_parameters
@@ -568,7 +569,7 @@ class Process(EventHandler):
         return initial_state
 
     @initial_state.setter
-    def initial_state(self, initial_state):
+    def initial_state(self, initial_state: dict) -> None:
         try:
             self.flow_sheet.initial_state = initial_state.pop("flow_sheet")
         except KeyError:
@@ -580,14 +581,14 @@ class Process(EventHandler):
             setattr(self, state_name, state_value)
 
     @property
-    def config(self) -> dict[str, dict]:
+    def config(self) -> Dict:
         """dict[str, dict]: Parameters and initial state of the process."""
         return Dict(
             {"parameters": self.parameters, "initial_state": self.initial_state}
         )
 
     @config.setter
-    def config(self, config):
+    def config(self, config: dict) -> None:
         self.parameters = config["parameters"]
         self.initial_state = config["initial_state"]
 
@@ -820,7 +821,7 @@ class Process(EventHandler):
                 t,
             )
 
-    def check_config(self):
+    def check_config(self) -> bool:
         """
         Validate that process config is setup correctly.
 
@@ -850,7 +851,7 @@ class Process(EventHandler):
 
         return flag
 
-    def check_cstr_volume(self):
+    def check_cstr_volume(self) -> bool:
         """
         Check if CSTRs run empty.
 

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -386,7 +386,7 @@ class CrossPhaseReaction(Structure):
 
     @property
     def n_comp(self):
-        """ind: number of components."""
+        """int: Number of components."""
         return self.component_system.n_comp
 
     @property
@@ -441,8 +441,6 @@ class ReactionBaseClass(Structure):
 
     Attributes
     ----------
-    n_comp : UnsignedInteger
-        number of components.
     parameters : dict
         dict with parameter values.
     name : String
@@ -450,7 +448,6 @@ class ReactionBaseClass(Structure):
 
     """
     name = String()
-    n_comp = UnsignedInteger()
 
     _parameters = []
 

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -19,7 +19,8 @@ from .componentSystem import ComponentSystem
 
 
 class Reaction(Structure):
-    """Helper class to store information about individual Mass Action Law Reactions.
+    """
+    Helper class to store information about individual Mass Action Law Reactions.
 
     This class represents an individual reaction within a MAL model, and
     stores information about the reaction's stoichiometry, rate constants,
@@ -85,7 +86,8 @@ class Reaction(Structure):
         exponents_fwd=None,
         exponents_bwd=None,
     ):
-        """Initialize individual Mass Action Law Reaction.
+        """
+        Initialize individual Mass Action Law Reaction.
 
         Parameters
         ----------
@@ -113,7 +115,6 @@ class Reaction(Structure):
             Concentration exponents of the components in order of components for
             backward reaction. If None is given, values are inferred from the
             stoichiometric coefficients. The default is None.
-
         """
         self.component_system = component_system
         super().__init__()
@@ -166,7 +167,8 @@ class Reaction(Structure):
         """float: Equilibrium constant (Ratio of forward and backward reaction)."""
         return self.k_fwd / self.k_bwd
 
-    def __str__(self):
+    def __str__(self) -> str:
+        """str: String representation of the Reaction."""
         educts = []
         products = []
         for i, nu in enumerate(self.stoich):
@@ -285,7 +287,8 @@ class CrossPhaseReaction(Structure):
         exponents_fwd_solid=None,
         exponents_bwd_solid=None,
     ):
-        """Initialize individual cross-phase MAL reaction.
+        """
+        Initialize individual cross-phase MAL reaction.
 
         Parameters
         ----------
@@ -325,7 +328,6 @@ class CrossPhaseReaction(Structure):
             Concentration exponents of the components in order of indices for
             backward reaction in solid phase. If None is given, values are
             inferred from the stoichiometric coefficients. The default is None.
-
         """
         self.component_system = component_system
         super().__init__()
@@ -415,6 +417,7 @@ class CrossPhaseReaction(Structure):
         return self.k_fwd / self.k_bwd
 
     def __str__(self):
+        """str: String representation of the Reaction."""
         educts = []
         products = []
         for i, nu in enumerate(self.stoich_liquid):
@@ -449,7 +452,8 @@ class CrossPhaseReaction(Structure):
 
 
 class ReactionBaseClass(Structure):
-    """Abstract base class for parameters of reaction models.
+    """
+    Abstract base class for parameters of reaction models.
 
     Attributes
     ----------
@@ -457,7 +461,6 @@ class ReactionBaseClass(Structure):
         dict with parameter values.
     name : String
         name of the reaction model.
-
     """
 
     name = String()
@@ -471,12 +474,13 @@ class ReactionBaseClass(Structure):
         super().__init__(*args, **kwargs)
 
     @property
-    def model(self):
+    def model(self) -> str:
+        """str: Name of the reaction model."""
         return self.__class__.__name__
 
     @property
-    def component_system(self):
-        """ComponentSystem: Component System"""
+    def component_system(self) -> ComponentSystem:
+        """ComponentSystem: Component System."""
         return self._component_system
 
     @component_system.setter
@@ -491,19 +495,21 @@ class ReactionBaseClass(Structure):
         return self.component_system.n_comp
 
     def __repr__(self):
+        """str: String representation of the Reaction."""
         return f"{self.__class__.__name__}(n_comp={self.n_comp}, name={self.name})"
 
     def __str__(self):
+        """str: String representation of the Reaction."""
         if self.name is None:
             return self.__class__.__name__
         return self.name
 
 
 class NoReaction(ReactionBaseClass):
-    """Dummy class for units that do not experience reaction behavior.
+    """
+    Dummy class for units that do not experience reaction behavior.
 
     The number of components is set to zero for this class.
-
     """
 
     def __init__(self, *args, **kwargs):
@@ -715,7 +721,8 @@ class MassActionLawParticle(ParticleReactionBase):
 
 
 def scale_to_rapid_equilibrium(k_eq, k_fwd_min=10):
-    """Scale forward and backward reaction rates if only k_eq is known.
+    """
+    Scale forward and backward reaction rates if only k_eq is known.
 
     Parameters
     ----------
@@ -730,7 +737,6 @@ def scale_to_rapid_equilibrium(k_eq, k_fwd_min=10):
         Forward reaction rate.
     k_bwd : float
         Backward reaction rate.
-
     """
     k_fwd = k_fwd_min
     k_bwd = k_fwd_min / k_eq

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -1,5 +1,8 @@
+from __future__ import annotations
+
 import warnings
 from functools import wraps
+from typing import Any, Optional
 
 import numpy as np
 
@@ -76,16 +79,16 @@ class Reaction(Structure):
     @deprecated_alias(indices="components")
     def __init__(
         self,
-        component_system,
-        components,
-        coefficients,
-        k_fwd,
-        k_bwd=1,
-        is_kinetic=True,
-        k_fwd_min=100,
-        exponents_fwd=None,
-        exponents_bwd=None,
-    ):
+        component_system: ComponentSystem,
+        components: list[int | str],
+        coefficients: np.ndarray,
+        k_fwd: float,
+        k_bwd: float = 1,
+        is_kinetic: bool = True,
+        k_fwd_min: float = 100,
+        exponents_fwd: Optional[list[float]] = None,
+        exponents_bwd: Optional[list[float]] = None
+    ) -> None:
         """
         Initialize individual Mass Action Law Reaction.
 
@@ -158,12 +161,12 @@ class Reaction(Structure):
         self.exponents_bwd = e_bwd
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
         """int: Number of components."""
         return self.component_system.n_comp
 
     @property
-    def k_eq(self):
+    def k_eq(self) -> float:
         """float: Equilibrium constant (Ratio of forward and backward reaction)."""
         return self.k_fwd / self.k_bwd
 
@@ -274,19 +277,19 @@ class CrossPhaseReaction(Structure):
     @deprecated_alias(indices="components")
     def __init__(
         self,
-        component_system,
-        components,
-        coefficients,
-        phases,
-        k_fwd,
-        k_bwd=1,
-        is_kinetic=True,
-        k_fwd_min=100,
-        exponents_fwd_liquid=None,
-        exponents_bwd_liquid=None,
-        exponents_fwd_solid=None,
-        exponents_bwd_solid=None,
-    ):
+        component_system: ComponentSystem,
+        components: list[list | str],
+        coefficients: list[float],
+        phases: list[int],
+        k_fwd: float,
+        k_bwd: float = 1,
+        is_kinetic: bool = True,
+        k_fwd_min: float = 100,
+        exponents_fwd_liquid: Optional[list[float]] = None,
+        exponents_bwd_liquid: Optional[list[float]] = None,
+        exponents_fwd_solid: Optional[list[float]] = None,
+        exponents_bwd_solid: Optional[list[float]] = None
+    ) -> None:
         """
         Initialize individual cross-phase MAL reaction.
 
@@ -407,16 +410,16 @@ class CrossPhaseReaction(Structure):
         self.exponents_bwd_solid = e_bwd
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
         """int: Number of components."""
         return self.component_system.n_comp
 
     @property
-    def k_eq(self):
+    def k_eq(self) -> float:
         """float: Equilibrium constant (Ratio of forward and backward reaction)."""
         return self.k_fwd / self.k_bwd
 
-    def __str__(self):
+    def __str__(self) -> str:
         """str: String representation of the Reaction."""
         educts = []
         products = []
@@ -467,7 +470,14 @@ class ReactionBaseClass(Structure):
 
     _parameters = []
 
-    def __init__(self, component_system, name=None, *args, **kwargs):
+    def __init__(
+        self,
+        component_system: ComponentSystem,
+        name: Optional[str] = None,
+        *args: Any,
+        **kwargs: Any
+    ) -> None:
+        """Initialize reaction base."""
         self.component_system = component_system
         self.name = name
 
@@ -484,22 +494,22 @@ class ReactionBaseClass(Structure):
         return self._component_system
 
     @component_system.setter
-    def component_system(self, component_system):
+    def component_system(self, component_system: ComponentSystem) -> None:
         if not isinstance(component_system, ComponentSystem):
             raise TypeError("Expected ComponentSystem")
         self._component_system = component_system
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
         """int: Number of components."""
         return self.component_system.n_comp
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """str: String representation of the Reaction."""
         return f"{self.__class__.__name__}(n_comp={self.n_comp}, name={self.name})"
 
-    def __str__(self):
-        """str: String representation of the Reaction."""
+    def __str__(self) -> str:
+        """str: Name of the Reaction."""
         if self.name is None:
             return self.__class__.__name__
         return self.name
@@ -512,7 +522,8 @@ class NoReaction(ReactionBaseClass):
     The number of components is set to zero for this class.
     """
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize NoReaction."""
         super().__init__(ComponentSystem(), name="NoReaction")
 
 
@@ -520,7 +531,7 @@ class BulkReactionBase(ReactionBaseClass):
     """Base class for bulk reaction systems."""
 
     @classmethod
-    def to_particle_model():
+    def to_particle_model() -> ParticleReactionBase:
         """Convert bulk reaction model to particle reaction model."""
         raise NotImplementedError
 
@@ -536,12 +547,13 @@ class MassActionLaw(BulkReactionBase):
 
     _parameters = ["stoich", "exponents_fwd", "exponents_bwd", "k_fwd", "k_bwd"]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize MassActionLaw."""
         self._reactions = []
         super().__init__(*args, **kwargs)
 
     @wraps(Reaction.__init__)
-    def add_reaction(self, *args, **kwargs) -> Reaction:
+    def add_reaction(self, *args: Any, **kwargs: Any) -> Reaction:
         """Add reaction to ReactionSystem."""
         r = Reaction(self.component_system, *args, **kwargs)
         self._reactions.append(r)
@@ -549,21 +561,21 @@ class MassActionLaw(BulkReactionBase):
         return r
 
     @property
-    def reactions(self):
+    def reactions(self) -> int:
         """list: Reactions in ReactionSystem."""
         return self._reactions
 
     @property
-    def n_reactions(self):
+    def n_reactions(self) -> int:
         """int: Number of Reactions."""
         return len(self.reactions)
 
     @property
-    def k_eq(self):
+    def k_eq(self) -> list:
         """list: Equilibrium constants of liquid phase Reactions."""
         return [r.k_eq for r in self.reactions]
 
-    def to_particle_model(self):
+    def to_particle_model(self) -> 'MassActionLawParticle':
         """Convert Bulk Reaction Model to Particle Reaction Model."""
         particle_model = MassActionLawParticle(self.component_system, self.name)
         particle_model._liquid_reactions = self.reactions
@@ -651,7 +663,8 @@ class MassActionLawParticle(ParticleReactionBase):
         "exponents_bwd_solid_modliquid",
     ]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        """Initialize MassActionLawParticle."""
         self._liquid_reactions = []
         self._solid_reactions = []
         self._cross_phase_reactions = []
@@ -659,68 +672,68 @@ class MassActionLawParticle(ParticleReactionBase):
         super().__init__(*args, **kwargs)
 
     @wraps(Reaction.__init__)
-    def add_liquid_reaction(self, *args, **kwargs):
+    def add_liquid_reaction(self, *args: Any, **kwargs: Any) -> None:
         """Add liquid phase to ReactionSystem."""
         r = Reaction(self.component_system, *args, **kwargs)
         self._liquid_reactions.append(r)
 
     @wraps(Reaction.__init__)
-    def add_solid_reaction(self, *args, **kwargs):
+    def add_solid_reaction(self, *args: Any, **kwargs: Any) -> None:
         """Add solid phase to ReactionSystem."""
         r = Reaction(self.component_system, *args, **kwargs)
         self._solid_reactions.append(r)
 
     @wraps(CrossPhaseReaction.__init__)
-    def add_cross_phase_reaction(self, *args, **kwargs):
+    def add_cross_phase_reaction(self, *args: Any, **kwargs: Any) -> None:
         """Add cross phase to ReactionSystem."""
         r = CrossPhaseReaction(self.component_system, *args, **kwargs)
         self._cross_phase_reactions.append(r)
 
     # Pore Liquid
     @property
-    def liquid_reactions(self):
+    def liquid_reactions(self) -> list:
         """list: Liquid phase Reactions."""
         return self._liquid_reactions + self.cross_phase_reactions
 
     @property
-    def n_liquid_reactions(self):
+    def n_liquid_reactions(self) -> int:
         """int: Number of liquid phase Reactions."""
         return len(self.liquid_reactions)
 
     @property
-    def k_eq_liquid(self):
+    def k_eq_liquid(self) -> list:
         """list: Equilibrium constants of liquid phase Reactions."""
         return [r.k_eq for r in self.liquid_reactions]
 
     # Solid
     @property
-    def solid_reactions(self):
+    def solid_reactions(self) -> list:
         """list: Solid phase Reactions."""
         return self._solid_reactions + self.cross_phase_reactions
 
     @property
-    def n_solid_reactions(self):
+    def n_solid_reactions(self) -> int:
         """int: Number of solid phase Reactions."""
         return len(self.solid_reactions)
 
     @property
-    def k_eq_solid(self):
+    def k_eq_solid(self) -> list:
         """list: Equilibrium constants of solid phase Reactions."""
         return [r.k_eq for r in self.solid_reactions]
 
     # Cross Phase
     @property
-    def cross_phase_reactions(self):
+    def cross_phase_reactions(self) -> list:
         """list: Cross phase reactions."""
         return self._cross_phase_reactions
 
     @property
-    def n_cross_phase_reactions(self):
+    def n_cross_phase_reactions(self) -> int:
         """int: Number of cross phase Reactions."""
         return len(self.cross_phase_reactions)
 
 
-def scale_to_rapid_equilibrium(k_eq, k_fwd_min=10):
+def scale_to_rapid_equilibrium(k_eq: float, k_fwd_min: float = 10) -> tuple[float, float]:
     """
     Scale forward and backward reaction rates if only k_eq is known.
 

--- a/CADETProcess/processModel/reaction.py
+++ b/CADETProcess/processModel/reaction.py
@@ -1,19 +1,19 @@
-from functools import wraps
 import warnings
+from functools import wraps
 
-from addict import Dict
 import numpy as np
 
-from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    Aggregator, SizedAggregator, SizedClassDependentAggregator,
+    Aggregator,
+    Bool,
+    SizedAggregator,
+    SizedClassDependentAggregator,
+    SizedNdArray,
+    String,
+    Structure,
+    UnsignedFloat,
+    deprecated_alias,
 )
-from CADETProcess.dataStructure import (
-    Bool, String, SizedNdArray, UnsignedInteger, UnsignedFloat
-)
-
-from CADETProcess.dataStructure import deprecated_alias
 
 from .componentSystem import ComponentSystem
 
@@ -53,29 +53,38 @@ class Reaction(Structure):
     k_eq : float
         The equilibrium constant for the reaction.
     """
+
     is_kinetic = Bool(default=True)
-    stoich = SizedNdArray(size='n_comp')
+    stoich = SizedNdArray(size="n_comp")
     k_fwd = UnsignedFloat()
     k_bwd = UnsignedFloat()
     k_fwd_min = UnsignedFloat(default=100)
-    exponents_fwd = SizedNdArray(size='n_comp', default=0)
-    exponents_bwd = SizedNdArray(size='n_comp', default=0)
+    exponents_fwd = SizedNdArray(size="n_comp", default=0)
+    exponents_bwd = SizedNdArray(size="n_comp", default=0)
 
     _parameters = [
-        'is_kinetic',
-        'stoich',
-        'k_fwd',
-        'k_bwd',
-        'k_fwd_min',
-        'exponents_fwd',
-        'exponents_bwd',
+        "is_kinetic",
+        "stoich",
+        "k_fwd",
+        "k_bwd",
+        "k_fwd_min",
+        "exponents_fwd",
+        "exponents_bwd",
     ]
 
-    @deprecated_alias(indices='components')
+    @deprecated_alias(indices="components")
     def __init__(
-            self, component_system, components, coefficients,
-            k_fwd, k_bwd=1, is_kinetic=True, k_fwd_min=100,
-            exponents_fwd=None, exponents_bwd=None):
+        self,
+        component_system,
+        components,
+        coefficients,
+        k_fwd,
+        k_bwd=1,
+        is_kinetic=True,
+        k_fwd_min=100,
+        exponents_fwd=None,
+        exponents_bwd=None,
+    ):
         """Initialize individual Mass Action Law Reaction.
 
         Parameters
@@ -122,7 +131,8 @@ class Reaction(Structure):
             warnings.warn(
                 "Component are expected to be specified by name. "
                 "This will be deprecated in future versions.",
-                DeprecationWarning, stacklevel=2
+                DeprecationWarning,
+                stacklevel=2,
             )
             indices = components
 
@@ -154,19 +164,17 @@ class Reaction(Structure):
     @property
     def k_eq(self):
         """float: Equilibrium constant (Ratio of forward and backward reaction)."""
-        return self.k_fwd/self.k_bwd
+        return self.k_fwd / self.k_bwd
 
     def __str__(self):
         educts = []
         products = []
         for i, nu in enumerate(self.stoich):
             if nu < 0:
-                if nu == - 1:
+                if nu == -1:
                     educts.append(f"{self.component_system.species[i]}")
                 else:
-                    educts.append(
-                        f"{abs(nu)} {self.component_system.species[i]}"
-                    )
+                    educts.append(f"{abs(nu)} {self.component_system.species[i]}")
             elif nu > 0:
                 if nu == 1:
                     products.append(f"{self.component_system.species[i]}")
@@ -174,9 +182,9 @@ class Reaction(Structure):
                     products.append(f"{nu} {self.component_system.species[i]}")
 
         if self.is_kinetic:
-            reaction_operator = f' <=>[{self.k_fwd:.2E}][{self.k_bwd:.2E}] '
+            reaction_operator = f" <=>[{self.k_fwd:.2E}][{self.k_bwd:.2E}] "
         else:
-            reaction_operator = f' <=>[{self.k_eq:.2E}] '
+            reaction_operator = f" <=>[{self.k_eq:.2E}] "
 
         return " + ".join(educts) + reaction_operator + " + ".join(products)
 
@@ -227,45 +235,56 @@ class CrossPhaseReaction(Structure):
 
     is_kinetic = Bool(default=True)
 
-    stoich_liquid = SizedNdArray(size='n_comp', default=0)
-    stoich_solid = SizedNdArray(size='n_comp', default=0)
+    stoich_liquid = SizedNdArray(size="n_comp", default=0)
+    stoich_solid = SizedNdArray(size="n_comp", default=0)
     k_fwd = UnsignedFloat()
     k_bwd = UnsignedFloat()
     k_fwd_min = UnsignedFloat(default=100)
 
-    exponents_fwd_liquid = SizedNdArray(size='n_comp', default=0)
-    exponents_fwd_solid = SizedNdArray(size='n_comp', default=0)
+    exponents_fwd_liquid = SizedNdArray(size="n_comp", default=0)
+    exponents_fwd_solid = SizedNdArray(size="n_comp", default=0)
 
-    exponents_bwd_liquid = SizedNdArray(size='n_comp', default=0)
-    exponents_bwd_solid = SizedNdArray(size='n_comp', default=0)
+    exponents_bwd_liquid = SizedNdArray(size="n_comp", default=0)
+    exponents_bwd_solid = SizedNdArray(size="n_comp", default=0)
 
-    exponents_fwd_liquid_modsolid = SizedNdArray(size='n_comp', default=0)
-    exponents_fwd_solid_modliquid = SizedNdArray(size='n_comp', default=0)
+    exponents_fwd_liquid_modsolid = SizedNdArray(size="n_comp", default=0)
+    exponents_fwd_solid_modliquid = SizedNdArray(size="n_comp", default=0)
 
-    exponents_bwd_liquid_modsolid = SizedNdArray(size='n_comp', default=0)
-    exponents_bwd_solid_modliquid = SizedNdArray(size='n_comp', default=0)
+    exponents_bwd_liquid_modsolid = SizedNdArray(size="n_comp", default=0)
+    exponents_bwd_solid_modliquid = SizedNdArray(size="n_comp", default=0)
 
     _parameters = [
-        'stoich_liquid',
-        'stoich_solid',
-        'k_fwd',
-        'k_bwd',
-        'k_fwd_min',
-        'exponents_fwd_liquid',
-        'exponents_fwd_solid',
-        'exponents_bwd_liquid',
-        'exponents_bwd_solid',
-        'exponents_fwd_liquid_modsolid',
-        'exponents_fwd_solid_modliquid',
-        'exponents_bwd_liquid_modsolid',
-        'exponents_bwd_solid_modliquid',
+        "stoich_liquid",
+        "stoich_solid",
+        "k_fwd",
+        "k_bwd",
+        "k_fwd_min",
+        "exponents_fwd_liquid",
+        "exponents_fwd_solid",
+        "exponents_bwd_liquid",
+        "exponents_bwd_solid",
+        "exponents_fwd_liquid_modsolid",
+        "exponents_fwd_solid_modliquid",
+        "exponents_bwd_liquid_modsolid",
+        "exponents_bwd_solid_modliquid",
     ]
-    @deprecated_alias(indices='components')
+
+    @deprecated_alias(indices="components")
     def __init__(
-            self, component_system, components, coefficients, phases,
-            k_fwd, k_bwd=1, is_kinetic=True, k_fwd_min=100,
-            exponents_fwd_liquid=None, exponents_bwd_liquid=None,
-            exponents_fwd_solid=None, exponents_bwd_solid=None):
+        self,
+        component_system,
+        components,
+        coefficients,
+        phases,
+        k_fwd,
+        k_bwd=1,
+        is_kinetic=True,
+        k_fwd_min=100,
+        exponents_fwd_liquid=None,
+        exponents_bwd_liquid=None,
+        exponents_fwd_solid=None,
+        exponents_bwd_solid=None,
+    ):
         """Initialize individual cross-phase MAL reaction.
 
         Parameters
@@ -324,7 +343,8 @@ class CrossPhaseReaction(Structure):
             warnings.warn(
                 "Component are expected to be specified by name. "
                 "This will be deprecated in future versions.",
-                DeprecationWarning, stacklevel=2
+                DeprecationWarning,
+                stacklevel=2,
             )
             indices = components
 
@@ -392,46 +412,38 @@ class CrossPhaseReaction(Structure):
     @property
     def k_eq(self):
         """float: Equilibrium constant (Ratio of forward and backward reaction)."""
-        return self.k_fwd/self.k_bwd
+        return self.k_fwd / self.k_bwd
 
     def __str__(self):
         educts = []
         products = []
         for i, nu in enumerate(self.stoich_liquid):
             if nu < 0:
-                if nu == - 1:
+                if nu == -1:
                     educts.append(f"{self.component_system.species[i]}(l)")
                 else:
-                    educts.append(
-                        f"{abs(nu)} {self.component_system.species[i]}(l)"
-                    )
+                    educts.append(f"{abs(nu)} {self.component_system.species[i]}(l)")
             elif nu > 0:
                 if nu == 1:
                     products.append(f"{self.component_system.species[i]}(l)")
                 else:
-                    products.append(
-                        f"{nu} {self.component_system.species[i]}(l)"
-                    )
+                    products.append(f"{nu} {self.component_system.species[i]}(l)")
         for i, nu in enumerate(self.stoich_solid):
             if nu < 0:
-                if nu == - 1:
+                if nu == -1:
                     educts.append(f"{self.component_system.species[i]}(s)")
                 else:
-                    educts.append(
-                        f"{abs(nu)} {self.component_system.species[i]}(s)"
-                    )
+                    educts.append(f"{abs(nu)} {self.component_system.species[i]}(s)")
             elif nu > 0:
                 if nu == 1:
                     products.append(f"{self.component_system.species[i]}(s)")
                 else:
-                    products.append(
-                        f"{nu} {self.component_system.species[i]}(s)"
-                    )
+                    products.append(f"{nu} {self.component_system.species[i]}(s)")
 
         if self.is_kinetic:
-            reaction_operator = f' <=>[{self.k_fwd:.2E}][{self.k_bwd:.2E}] '
+            reaction_operator = f" <=>[{self.k_fwd:.2E}][{self.k_bwd:.2E}] "
         else:
-            reaction_operator = f' <=>[{self.k_eq:.2E}] '
+            reaction_operator = f" <=>[{self.k_eq:.2E}] "
 
         return " + ".join(educts) + reaction_operator + " + ".join(products)
 
@@ -447,6 +459,7 @@ class ReactionBaseClass(Structure):
         name of the reaction model.
 
     """
+
     name = String()
 
     _parameters = []
@@ -469,7 +482,7 @@ class ReactionBaseClass(Structure):
     @component_system.setter
     def component_system(self, component_system):
         if not isinstance(component_system, ComponentSystem):
-            raise TypeError('Expected ComponentSystem')
+            raise TypeError("Expected ComponentSystem")
         self._component_system = component_system
 
     @property
@@ -478,10 +491,7 @@ class ReactionBaseClass(Structure):
         return self.component_system.n_comp
 
     def __repr__(self):
-        return \
-            f'{self.__class__.__name__}(' \
-            f'n_comp={self.n_comp}, name={self.name}' \
-            f')'
+        return f"{self.__class__.__name__}(n_comp={self.n_comp}, name={self.name})"
 
     def __str__(self):
         if self.name is None:
@@ -497,7 +507,7 @@ class NoReaction(ReactionBaseClass):
     """
 
     def __init__(self, *args, **kwargs):
-        super().__init__(ComponentSystem(), name='NoReaction')
+        super().__init__(ComponentSystem(), name="NoReaction")
 
 
 class BulkReactionBase(ReactionBaseClass):
@@ -512,13 +522,13 @@ class BulkReactionBase(ReactionBaseClass):
 class MassActionLaw(BulkReactionBase):
     """Parameters for Reaction in Bulk Phase."""
 
-    k_fwd = Aggregator('k_fwd', 'reactions')
-    k_bwd = Aggregator('k_bwd', 'reactions')
-    stoich = SizedAggregator('stoich', 'reactions', transpose=True)
-    exponents_fwd = SizedAggregator('exponents_fwd', 'reactions', transpose=True)
-    exponents_bwd = SizedAggregator('exponents_bwd', 'reactions', transpose=True)
+    k_fwd = Aggregator("k_fwd", "reactions")
+    k_bwd = Aggregator("k_bwd", "reactions")
+    stoich = SizedAggregator("stoich", "reactions", transpose=True)
+    exponents_fwd = SizedAggregator("exponents_fwd", "reactions", transpose=True)
+    exponents_bwd = SizedAggregator("exponents_bwd", "reactions", transpose=True)
 
-    _parameters = ['stoich', 'exponents_fwd', 'exponents_bwd', 'k_fwd', 'k_bwd']
+    _parameters = ["stoich", "exponents_fwd", "exponents_bwd", "k_fwd", "k_bwd"]
 
     def __init__(self, *args, **kwargs):
         self._reactions = []
@@ -563,80 +573,76 @@ class MassActionLawParticle(ParticleReactionBase):
     """Parameters for Reaction in Particle Phase."""
 
     stoich_liquid = SizedClassDependentAggregator(
-        'stoich_liquid', 'liquid_reactions',
-        mapping={
-            CrossPhaseReaction: 'stoich_liquid',
-            None: 'stoich'
-        },
+        "stoich_liquid",
+        "liquid_reactions",
+        mapping={CrossPhaseReaction: "stoich_liquid", None: "stoich"},
         transpose=True,
     )
-    k_fwd_liquid = Aggregator('k_fwd', 'liquid_reactions')
-    k_bwd_liquid = Aggregator('k_bwd', 'liquid_reactions')
+    k_fwd_liquid = Aggregator("k_fwd", "liquid_reactions")
+    k_bwd_liquid = Aggregator("k_bwd", "liquid_reactions")
     exponents_fwd_liquid = SizedAggregator(
-        'exponents_fwd', 'liquid_reactions', transpose=True
+        "exponents_fwd", "liquid_reactions", transpose=True
     )
     exponents_bwd_liquid = SizedAggregator(
-        'exponents_bwd', 'liquid_reactions', transpose=True
+        "exponents_bwd", "liquid_reactions", transpose=True
     )
 
     stoich_solid = SizedClassDependentAggregator(
-        'stoich_solid', 'solid_reactions',
-        mapping={
-            CrossPhaseReaction: 'stoich_solid',
-            None: 'stoich'
-        },
-        transpose=True
+        "stoich_solid",
+        "solid_reactions",
+        mapping={CrossPhaseReaction: "stoich_solid", None: "stoich"},
+        transpose=True,
     )
-    k_fwd_solid = Aggregator('k_fwd', 'solid_reactions')
-    k_bwd_solid = Aggregator('k_bwd', 'solid_reactions')
+    k_fwd_solid = Aggregator("k_fwd", "solid_reactions")
+    k_bwd_solid = Aggregator("k_bwd", "solid_reactions")
     exponents_fwd_solid = SizedAggregator(
-        'exponents_fwd', 'solid_reactions', transpose=True
+        "exponents_fwd", "solid_reactions", transpose=True
     )
     exponents_bwd_solid = SizedAggregator(
-        'exponents_bwd', 'solid_reactions', transpose=True
+        "exponents_bwd", "solid_reactions", transpose=True
     )
 
     exponents_fwd_liquid_modsolid = SizedClassDependentAggregator(
-        'exponents_fwd_liquid_modsolid', 'liquid_reactions',
-        mapping={
-            CrossPhaseReaction: 'exponents_fwd_liquid_modsolid',
-            None: None
-        },
+        "exponents_fwd_liquid_modsolid",
+        "liquid_reactions",
+        mapping={CrossPhaseReaction: "exponents_fwd_liquid_modsolid", None: None},
         transpose=True,
     )
     exponents_bwd_liquid_modsolid = SizedClassDependentAggregator(
-        'exponents_bwd_liquid_modsolid', 'liquid_reactions',
-        mapping={
-            CrossPhaseReaction: 'exponents_bwd_liquid_modsolid',
-            None: None
-        },
+        "exponents_bwd_liquid_modsolid",
+        "liquid_reactions",
+        mapping={CrossPhaseReaction: "exponents_bwd_liquid_modsolid", None: None},
         transpose=True,
     )
 
     exponents_fwd_solid_modliquid = SizedClassDependentAggregator(
-        'exponents_fwd_solid_modliquid', 'solid_reactions',
-        mapping={
-            CrossPhaseReaction: 'exponents_fwd_solid_modliquid',
-            None: None
-        },
+        "exponents_fwd_solid_modliquid",
+        "solid_reactions",
+        mapping={CrossPhaseReaction: "exponents_fwd_solid_modliquid", None: None},
         transpose=True,
     )
     exponents_bwd_solid_modliquid = SizedClassDependentAggregator(
-        'exponents_bwd_solid_modliquid', 'solid_reactions',
-        mapping={
-            CrossPhaseReaction: 'exponents_bwd_solid_modliquid',
-            None: None
-        },
+        "exponents_bwd_solid_modliquid",
+        "solid_reactions",
+        mapping={CrossPhaseReaction: "exponents_bwd_solid_modliquid", None: None},
         transpose=True,
     )
 
     _parameters = [
-        'stoich_liquid', 'exponents_fwd_liquid', 'exponents_bwd_liquid',
-        'k_fwd_liquid', 'k_bwd_liquid',
-        'exponents_fwd_liquid_modsolid', 'exponents_bwd_liquid_modsolid',
-        'stoich_solid', 'exponents_fwd_solid', 'exponents_bwd_solid',
-        'k_fwd_solid', 'k_bwd_solid',
-        'exponents_fwd_solid_modliquid', 'exponents_bwd_solid_modliquid'
+        "stoich_liquid",
+        "exponents_fwd_liquid",
+        "exponents_bwd_liquid",
+        "k_fwd_liquid",
+        "k_bwd_liquid",
+        "exponents_fwd_liquid_modsolid",
+        "exponents_bwd_liquid_modsolid",
+        "stoich_solid",
+        "exponents_fwd_solid",
+        "exponents_bwd_solid",
+        "k_fwd_solid",
+        "k_bwd_solid",
+        "exponents_fwd_solid_modliquid",
+        "exponents_bwd_solid_modliquid",
     ]
 
     def __init__(self, *args, **kwargs):
@@ -727,6 +733,6 @@ def scale_to_rapid_equilibrium(k_eq, k_fwd_min=10):
 
     """
     k_fwd = k_fwd_min
-    k_bwd = k_fwd_min/k_eq
+    k_bwd = k_fwd_min / k_eq
 
     return k_fwd, k_bwd

--- a/CADETProcess/processModel/solutionRecorder.py
+++ b/CADETProcess/processModel/solutionRecorder.py
@@ -46,7 +46,6 @@ class IOMixin(Structure):
     write_sensdot_outlet : bool, optional
         If True, write sensitivities derivatives of the unit operation outlet.
         The default is False.
-
     """
 
     write_solution_inlet = Bool(default=True)
@@ -117,7 +116,6 @@ class ParticleMixin(Structure):
     write_sensdot_particle : bool, optional
         If True, write the sensitivities derivatives of the particle liquid phase.
         The default is False.
-
     """
 
     write_solution_particle = Bool(default=False)
@@ -149,7 +147,6 @@ class SolidMixin(Structure):
     write_sensdot_solid : bool, optional
         If True, write the sensitivities derivatives of the particle solid phase.
         The default is False.
-
     """
 
     write_solution_solid = Bool(default=False)
@@ -179,7 +176,6 @@ class FluxMixin(Structure):
         If True, write the sensitivities of the flux. The default is False.
     write_sensdot_flux : bool, optional
         If True, write the sensitivities derivatives of the flux. The default is False.
-
     """
 
     write_solution_flux = Bool(default=False)
@@ -210,7 +206,6 @@ class VolumeMixin(Structure):
     write_sensdot_volume : bool, optional
         If True, write the sensitivities derivatives of the unit volume.
         The default is False.
-
     """
 
     write_solution_volume = Bool(default=True)
@@ -233,7 +228,8 @@ class SolutionRecorderBase:
 
 
 class IORecorder(SolutionRecorderBase, BaseMixin, IOMixin):
-    """Recorder for inlets and outlets.
+    """
+    Recorder for inlets and outlets.
 
     See Also
     --------
@@ -241,14 +237,14 @@ class IORecorder(SolutionRecorderBase, BaseMixin, IOMixin):
     IOMixin
     CADETProcess.processModel.Inlet
     CADETProcess.processModel.Outlet
-
     """
 
     pass
 
 
 class TubularReactorRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin):
-    """Recorder for TubularReactor.
+    """
+    Recorder for TubularReactor.
 
     See Also
     --------
@@ -256,14 +252,14 @@ class TubularReactorRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin
     IOMixin
     SolutionRecorderBulk
     CADETProcess.processModel.TubularReactor
-
     """
 
     pass
 
 
 class LRMRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin, SolidMixin):
-    """Recorder for TubularReactor.
+    """
+    Recorder for TubularReactor.
 
     See Also
     --------
@@ -272,7 +268,6 @@ class LRMRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin, SolidMixi
     BulkMixin
     SolidMixin
     CADETProcess.processModel.LumpedRateModelWithoutPores
-
     """
 
     pass
@@ -287,7 +282,8 @@ class LRMPRecorder(
     ParticleMixin,
     SolidMixin,
 ):
-    """Recorder for TubularReactor.
+    """
+    Recorder for TubularReactor.
 
     See Also
     --------
@@ -298,7 +294,6 @@ class LRMPRecorder(
     ParticleMixin
     SolidMixin
     CADETProcess.processModel.LumpedRateModelWithPores
-
     """
 
     pass
@@ -313,7 +308,8 @@ class GRMRecorder(
     ParticleMixin,
     SolidMixin,
 ):
-    """Recorder for TubularReactor.
+    """
+    Recorder for TubularReactor.
 
     See Also
     --------
@@ -324,7 +320,6 @@ class GRMRecorder(
     ParticleMixin
     SolidMixin
     CADETProcess.processModel.GeneralRateModel
-
     """
 
     pass
@@ -333,7 +328,8 @@ class GRMRecorder(
 class CSTRRecorder(
     SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin, SolidMixin, VolumeMixin
 ):
-    """Recorder for TubularReactor.
+    """
+    Recorder for TubularReactor.
 
     See Also
     --------
@@ -343,14 +339,14 @@ class CSTRRecorder(
     SolidMixin
     VolumeMixin
     CADETProcess.processModel.Cstr
-
     """
 
     pass
 
 
 class MCTRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin):
-    """Recorder for TubularReactor.
+    """
+    Recorder for TubularReactor.
 
     See Also
     --------
@@ -358,7 +354,6 @@ class MCTRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin):
     IOMixin
     BulkMixin
     CADETProcess.processModel.MCT
-
     """
 
     pass

--- a/CADETProcess/processModel/solutionRecorder.py
+++ b/CADETProcess/processModel/solutionRecorder.py
@@ -1,5 +1,4 @@
-from CADETProcess.dataStructure import Structure, Bool
-from CADETProcess.dataStructure import frozen_attributes
+from CADETProcess.dataStructure import Bool, Structure
 
 
 class BaseMixin(Structure):
@@ -18,8 +17,8 @@ class BaseMixin(Structure):
     write_coordinates = Bool(default=True)
 
     _parameters = [
-        'write_coordinates',
-        'write_solution_last_unit',
+        "write_coordinates",
+        "write_solution_last_unit",
     ]
 
 
@@ -61,15 +60,14 @@ class IOMixin(Structure):
     write_sensdot_outlet = Bool(default=False)
 
     _parameters = [
-        'write_solution_inlet',
-        'write_soldot_inlet',
-        'write_sens_inlet',
-        'write_sensdot_inlet',
-
-        'write_solution_outlet',
-        'write_soldot_outlet',
-        'write_sens_outlet',
-        'write_sensdot_outlet'
+        "write_solution_inlet",
+        "write_soldot_inlet",
+        "write_sens_inlet",
+        "write_sensdot_inlet",
+        "write_solution_outlet",
+        "write_soldot_outlet",
+        "write_sens_outlet",
+        "write_sensdot_outlet",
     ]
 
 
@@ -95,10 +93,10 @@ class BulkMixin(Structure):
     write_sensdot_bulk = Bool(default=False)
 
     _parameters = [
-        'write_solution_bulk',
-        'write_soldot_bulk',
-        'write_sens_bulk',
-        'write_sensdot_bulk',
+        "write_solution_bulk",
+        "write_soldot_bulk",
+        "write_sens_bulk",
+        "write_sensdot_bulk",
     ]
 
 
@@ -128,10 +126,10 @@ class ParticleMixin(Structure):
     write_sensdot_particle = Bool(default=False)
 
     _parameters = [
-            'write_solution_particle',
-            'write_soldot_particle',
-            'write_sens_particle',
-            'write_sensdot_particle',
+        "write_solution_particle",
+        "write_soldot_particle",
+        "write_sens_particle",
+        "write_sensdot_particle",
     ]
 
 
@@ -160,10 +158,10 @@ class SolidMixin(Structure):
     write_sensdot_solid = Bool(default=False)
 
     _parameters = [
-            'write_solution_solid',
-            'write_soldot_solid',
-            'write_sens_solid',
-            'write_sensdot_solid',
+        "write_solution_solid",
+        "write_soldot_solid",
+        "write_sens_solid",
+        "write_sensdot_solid",
     ]
 
 
@@ -190,10 +188,10 @@ class FluxMixin(Structure):
     write_sens_flux = Bool(default=False)
 
     _parameters = [
-        'write_solution_flux',
-        'write_soldot_flux',
-        'write_sens_flux',
-        'write_sensdot_flux',
+        "write_solution_flux",
+        "write_soldot_flux",
+        "write_sens_flux",
+        "write_sensdot_flux",
     ]
 
 
@@ -221,23 +219,20 @@ class VolumeMixin(Structure):
     write_sensdot_volume = Bool(default=False)
 
     _parameters = [
-        'write_solution_volume',
-        'write_soldot_volume',
-        'write_sens_volume',
-        'write_sensdot_volume'
+        "write_solution_volume",
+        "write_soldot_volume",
+        "write_sens_volume",
+        "write_sensdot_volume",
     ]
 
 
-class SolutionRecorderBase():
+class SolutionRecorderBase:
     """Base class for solution recorders."""
 
     pass
 
 
-class IORecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin):
+class IORecorder(SolutionRecorderBase, BaseMixin, IOMixin):
     """Recorder for inlets and outlets.
 
     See Also
@@ -252,11 +247,7 @@ class IORecorder(
     pass
 
 
-class TubularReactorRecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin,
-        BulkMixin):
+class TubularReactorRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin):
     """Recorder for TubularReactor.
 
     See Also
@@ -271,12 +262,7 @@ class TubularReactorRecorder(
     pass
 
 
-class LRMRecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin,
-        BulkMixin,
-        SolidMixin):
+class LRMRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin, SolidMixin):
     """Recorder for TubularReactor.
 
     See Also
@@ -293,13 +279,14 @@ class LRMRecorder(
 
 
 class LRMPRecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin,
-        BulkMixin,
-        FluxMixin,
-        ParticleMixin,
-        SolidMixin):
+    SolutionRecorderBase,
+    BaseMixin,
+    IOMixin,
+    BulkMixin,
+    FluxMixin,
+    ParticleMixin,
+    SolidMixin,
+):
     """Recorder for TubularReactor.
 
     See Also
@@ -318,13 +305,14 @@ class LRMPRecorder(
 
 
 class GRMRecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin,
-        BulkMixin,
-        FluxMixin,
-        ParticleMixin,
-        SolidMixin):
+    SolutionRecorderBase,
+    BaseMixin,
+    IOMixin,
+    BulkMixin,
+    FluxMixin,
+    ParticleMixin,
+    SolidMixin,
+):
     """Recorder for TubularReactor.
 
     See Also
@@ -343,12 +331,8 @@ class GRMRecorder(
 
 
 class CSTRRecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin,
-        BulkMixin,
-        SolidMixin,
-        VolumeMixin):
+    SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin, SolidMixin, VolumeMixin
+):
     """Recorder for TubularReactor.
 
     See Also
@@ -365,11 +349,7 @@ class CSTRRecorder(
     pass
 
 
-class MCTRecorder(
-        SolutionRecorderBase,
-        BaseMixin,
-        IOMixin,
-        BulkMixin):
+class MCTRecorder(SolutionRecorderBase, BaseMixin, IOMixin, BulkMixin):
     """Recorder for TubularReactor.
 
     See Also

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -1,6 +1,7 @@
 import math
 import warnings
 from abc import abstractmethod
+from typing import Any, Optional
 
 import numpy as np
 
@@ -106,16 +107,16 @@ class UnitBaseClass(Structure):
 
     def __init__(
         self,
-        component_system,
-        name,
-        *args,
-        binding_model=None,
-        bulk_reaction_model=None,
-        particle_reaction_model=None,
-        discretization=None,
-        solution_recorder=None,
-        **kwargs,
-    ):
+        component_system: ComponentSystem,
+        name: str,
+        *args: Optional[tuple],
+        binding_model: Optional[BindingBaseClass] = None,
+        bulk_reaction_model: Optional[BulkReactionBase] = None,
+        particle_reaction_model: Optional[ParticleReactionBase] = None,
+        discretization: Optional[DiscretizationParametersBase] = None,
+        solution_recorder: Optional[IORecorder] = None,
+        **kwargs: Optional[dict]
+    ) -> None:
         """
         Initialize UnitBaseClass.
 
@@ -179,7 +180,7 @@ class UnitBaseClass(Structure):
         return self._component_system
 
     @component_system.setter
-    def component_system(self, component_system):
+    def component_system(self, component_system: ComponentSystem) -> None:
         if not isinstance(component_system, ComponentSystem):
             raise TypeError("Expected ComponentSystem")
         self._component_system = component_system
@@ -190,7 +191,7 @@ class UnitBaseClass(Structure):
         return self._discretization
 
     @discretization.setter
-    def discretization(self, discretization):
+    def discretization(self, discretization: DiscretizationParametersBase) -> None:
         if not isinstance(discretization, DiscretizationParametersBase):
             raise TypeError("Expected DiscretizationParametersBase")
 
@@ -218,7 +219,7 @@ class UnitBaseClass(Structure):
         return 1
 
     @property
-    def parameters(self):
+    def parameters(self) -> dict:
         """dict: Dictionary with parameter values."""
         parameters = super().parameters
 
@@ -235,7 +236,7 @@ class UnitBaseClass(Structure):
         return parameters
 
     @parameters.setter
-    def parameters(self, parameters):
+    def parameters(self, parameters: dict) -> None:
         try:
             self.binding_model.parameters = parameters.pop("binding_model")
         except KeyError:
@@ -258,7 +259,7 @@ class UnitBaseClass(Structure):
         super(UnitBaseClass, self.__class__).parameters.fset(self, parameters)
 
     @property
-    def section_dependent_parameters(self):
+    def section_dependent_parameters(self) -> dict:
         """Return section dependent parameters."""
         parameters = {
             key: value
@@ -268,14 +269,14 @@ class UnitBaseClass(Structure):
         return parameters
 
     @property
-    def initial_state(self):
+    def initial_state(self) -> dict:
         """dict: Dictionary with initial states."""
         initial_state = {st: getattr(self, st) for st in self._initial_state}
 
         return initial_state
 
     @initial_state.setter
-    def initial_state(self, initial_state):
+    def initial_state(self, initial_state: dict) -> None:
         for st, value in initial_state.items():
             if st not in self._initial_state:
                 raise CADETProcessError("Not a valid parameter")
@@ -283,7 +284,7 @@ class UnitBaseClass(Structure):
                 setattr(self, st, value)
 
     @property
-    def missing_parameters(self):
+    def missing_parameters(self) -> list:
         """Return list of missing parameters."""
         missing_parameters = super().missing_parameters
 
@@ -293,7 +294,7 @@ class UnitBaseClass(Structure):
 
         return missing_parameters
 
-    def check_required_parameters(self):
+    def check_required_parameters(self) -> bool:
         """Checkf if there are missing parameters left."""
         if len(self.missing_parameters) == 0:
             return True
@@ -318,7 +319,7 @@ class UnitBaseClass(Structure):
         return self._binding_model
 
     @binding_model.setter
-    def binding_model(self, binding_model):
+    def binding_model(self, binding_model: BindingBaseClass) -> None:
         if not isinstance(binding_model, BindingBaseClass):
             raise TypeError("Expected BindingBaseClass")
 
@@ -335,7 +336,7 @@ class UnitBaseClass(Structure):
         self._binding_model = binding_model
 
     @property
-    def n_bound_states(self):
+    def n_bound_states(self) -> int:
         """int: Return number of bound states."""
         if isinstance(self.binding_model, NoBinding):
             return 0
@@ -358,7 +359,7 @@ class UnitBaseClass(Structure):
         return self._bulk_reaction_model
 
     @bulk_reaction_model.setter
-    def bulk_reaction_model(self, bulk_reaction_model):
+    def bulk_reaction_model(self, bulk_reaction_model: BulkReactionBase) -> None:
         if not isinstance(bulk_reaction_model, NoReaction):
             if not isinstance(bulk_reaction_model, BulkReactionBase):
                 raise TypeError("Expected BulkReactionBase")
@@ -371,7 +372,7 @@ class UnitBaseClass(Structure):
         self._bulk_reaction_model = bulk_reaction_model
 
     @property
-    def particle_reaction_model(self):
+    def particle_reaction_model(self) -> ParticleReactionBase:
         """
         ParticleReactionBase: Reaction in particle liquid phase.
 
@@ -387,7 +388,9 @@ class UnitBaseClass(Structure):
         return self._particle_reaction_model
 
     @particle_reaction_model.setter
-    def particle_reaction_model(self, particle_reaction_model):
+    def particle_reaction_model(
+        self, particle_reaction_model: ParticleReactionBase | BulkReactionBase
+    ) -> None:
         if isinstance(particle_reaction_model, BulkReactionBase):
             try:
                 warnings.warn(
@@ -409,11 +412,11 @@ class UnitBaseClass(Structure):
 
         self._particle_reaction_model = particle_reaction_model
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """str: String-representation of the object."""
         return f"{self.__class__.__name__}(n_comp={self.n_comp}, name={self.name})"
 
-    def __str__(self):
+    def __str__(self) -> str:
         """str: String-representation of the object."""
         return self.name
 
@@ -540,12 +543,12 @@ class TubularReactorBase(UnitBaseClass):
 
     @property
     @abstractmethod
-    def total_porosity(self) -> float | None:
+    def total_porosity(self) -> None:
         """Float | None: Total porosity of the unit operation."""
         pass
 
     @property
-    def cross_section_area(self):
+    def cross_section_area(self) -> float:
         """float: Cross section area of a Column.
 
         See Also
@@ -558,10 +561,10 @@ class TubularReactorBase(UnitBaseClass):
             return math.pi / 4 * self.diameter**2
 
     @cross_section_area.setter
-    def cross_section_area(self, cross_section_area):
+    def cross_section_area(self, cross_section_area: float) -> None:
         self.diameter = (4 * cross_section_area / math.pi) ** 0.5
 
-    def set_diameter_from_interstitial_velocity(self, Q, u0):
+    def set_diameter_from_interstitial_velocity(self, Q: float, u0: float) -> None:
         """
         Set diamter from flow rate and interstitial velocity.
 
@@ -584,7 +587,7 @@ class TubularReactorBase(UnitBaseClass):
         self.cross_section_area = Q / (u0 * self.total_porosity)
 
     @property
-    def cross_section_area_interstitial(self):
+    def cross_section_area_interstitial(self) -> float:
         """float: Interstitial area between particles.
 
         Notes
@@ -632,7 +635,7 @@ class TubularReactorBase(UnitBaseClass):
         """float: Volume of the solid phase."""
         return (1 - self.total_porosity) * self.cross_section_area * self.length
 
-    def calculate_interstitial_rt(self, flow_rate):
+    def calculate_interstitial_rt(self, flow_rate: float) -> float:
         """
         Calculate mean residence time of a (non adsorbing) volume element.
 
@@ -653,7 +656,7 @@ class TubularReactorBase(UnitBaseClass):
         """
         return self.volume_interstitial / flow_rate
 
-    def calculate_superficial_rt(self, flow_rate):
+    def calculate_superficial_rt(self, flow_rate: float) -> float:
         """
         Calculate mean residence time of a volume element in an empty column.
 
@@ -674,7 +677,7 @@ class TubularReactorBase(UnitBaseClass):
         """
         return self.volume / flow_rate
 
-    def calculate_interstitial_velocity(self, flow_rate):
+    def calculate_interstitial_velocity(self, flow_rate: float) -> float:
         """
         Calculate flow velocity of a (non adsorbing) volume element.
 
@@ -695,7 +698,7 @@ class TubularReactorBase(UnitBaseClass):
         """
         return self.length / self.calculate_interstitial_rt(flow_rate)
 
-    def calculate_superficial_velocity(self, flow_rate):
+    def calculate_superficial_velocity(self, flow_rate: float) -> float:
         """
         Calculate superficial flow velocity of a volume element in an empty column.
 
@@ -717,7 +720,7 @@ class TubularReactorBase(UnitBaseClass):
         """
         return self.length / self.calculate_superficial_rt(flow_rate)
 
-    def calculate_flow_rate_from_velocity(self, u0):
+    def calculate_flow_rate_from_velocity(self, u0: float) -> float:
         """
         Calculate volumetric flow rate from interstitial velocity.
 
@@ -738,7 +741,7 @@ class TubularReactorBase(UnitBaseClass):
         """
         return u0 * self.cross_section_area_interstitial
 
-    def NTP(self, flow_rate):
+    def NTP(self, flow_rate: float) -> float:
         r"""
         Calculate number of theoretical plates.
 
@@ -760,7 +763,7 @@ class TubularReactorBase(UnitBaseClass):
         u0 = self.calculate_interstitial_velocity(flow_rate)
         return u0 * self.length / (2 * np.array(self.axial_dispersion))
 
-    def set_axial_dispersion_from_NTP(self, NTP, flow_rate):
+    def set_axial_dispersion_from_NTP(self, NTP: float, flow_rate: float) -> float:
         r"""
         Set axial dispersion from number of theoretical plates (NTP).
 
@@ -839,7 +842,9 @@ class TubularReactor(TubularReactorBase):
 
     total_porosity = Constant(1)
 
-    def __init__(self, *args, discretization_scheme="FV", **kwargs):
+    def __init__(
+        self, *args: Any, discretization_scheme: Optional[str] = 'FV', **kwargs: Any
+    ) -> None:
         if discretization_scheme == "FV":
             discretization = LRMDiscretizationFV()
         elif discretization_scheme == "DG":
@@ -894,7 +899,9 @@ class LumpedRateModelWithoutPores(ChromatographicColumnBase):
     _initial_state = ChromatographicColumnBase._initial_state + ["q"]
     _parameters = _parameters + _initial_state
 
-    def __init__(self, *args, discretization_scheme="FV", **kwargs):
+    def __init__(
+        self, *args: Any, discretization_scheme: Optional[str] = 'FV', **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
 
         if discretization_scheme == "FV":
@@ -905,12 +912,12 @@ class LumpedRateModelWithoutPores(ChromatographicColumnBase):
         self.solution_recorder = LRMRecorder()
 
     @property
-    def q(self) -> float | None:
+    def q(self) -> list:
         """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
-    def q(self, q):
+    def q(self, q: list) -> None:
         if isinstance(self.binding_model, NoBinding) and q not in (None, []):
             raise CADETProcessError("Cannot set q without binding model.")
         self._q = q
@@ -973,7 +980,9 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
     _initial_state = ChromatographicColumnBase._initial_state + ["cp", "q"]
     _parameters = _parameters + _initial_state
 
-    def __init__(self, *args, discretization_scheme="FV", **kwargs):
+    def __init__(
+        self, *args: Any, discretization_scheme: Optional[str] = 'FV', **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
 
         if discretization_scheme == "FV":
@@ -989,7 +998,7 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
         return self.bed_porosity + (1 - self.bed_porosity) * self.particle_porosity
 
     @property
-    def cross_section_area_interstitial(self):
+    def cross_section_area_interstitial(self) -> float:
         """float: Interstitial area between particles.
 
         See Also
@@ -998,7 +1007,7 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
         """
         return self.bed_porosity * self.cross_section_area
 
-    def set_diameter_from_interstitial_velocity(self, Q, u0):
+    def set_diameter_from_interstitial_velocity(self, Q: float, u0: float) -> None:
         """
         Set diamter from flow rate and interstitial velocity.
 
@@ -1029,18 +1038,18 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
             return self._cp
 
     @cp.setter
-    def cp(self, cp):
+    def cp(self, cp: list[float]) -> None:
         self._cp = cp
 
         self.parameters["cp"] = cp
 
     @property
-    def q(self):
+    def q(self) -> list[float]:
         """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
-    def q(self, q):
+    def q(self, q: list) -> None:
         if isinstance(self.binding_model, NoBinding) and q not in (None, []):
             raise CADETProcessError("Cannot set q without binding model.")
         self._q = q
@@ -1112,7 +1121,9 @@ class GeneralRateModel(ChromatographicColumnBase):
     _initial_state = ChromatographicColumnBase._initial_state + ["cp", "q"]
     _parameters = _parameters + _initial_state
 
-    def __init__(self, *args, discretization_scheme="FV", **kwargs):
+    def __init__(
+        self, *args: Any, discretization_scheme: Optional[str] = 'FV', **kwargs: Any
+    ) -> None:
         super().__init__(*args, **kwargs)
 
         if discretization_scheme == "FV":
@@ -1128,7 +1139,7 @@ class GeneralRateModel(ChromatographicColumnBase):
         return self.bed_porosity + (1 - self.bed_porosity) * self.particle_porosity
 
     @property
-    def cross_section_area_interstitial(self):
+    def cross_section_area_interstitial(self) -> float:
         """float: Interstitial area between particles.
 
         See Also
@@ -1138,7 +1149,7 @@ class GeneralRateModel(ChromatographicColumnBase):
         """
         return self.bed_porosity * self.cross_section_area
 
-    def set_diameter_from_interstitial_velocity(self, Q, u0):
+    def set_diameter_from_interstitial_velocity(self, Q: float, u0: float) -> None:
         """
         Set diamter from flow rate and interstitial velocity.
 
@@ -1161,7 +1172,7 @@ class GeneralRateModel(ChromatographicColumnBase):
         self.cross_section_area = Q / (u0 * self.bed_porosity)
 
     @property
-    def cp(self):
+    def cp(self) -> list[float]:
         """list[float]: Initial particle liquid concentration."""
         if self._cp is None:
             return self.c
@@ -1169,18 +1180,18 @@ class GeneralRateModel(ChromatographicColumnBase):
             return self._cp
 
     @cp.setter
-    def cp(self, cp):
+    def cp(self, cp: list[float]) -> None:
         self._cp = cp
 
         self.parameters["cp"] = cp
 
     @property
-    def q(self):
+    def q(self) -> list[float]:
         """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
-    def q(self, q):
+    def q(self, q: list[float]) -> None:
         if isinstance(self.binding_model, NoBinding) and q not in (None, []):
             raise CADETProcessError("Cannot set q without binding model.")
         self._q = q
@@ -1188,12 +1199,12 @@ class GeneralRateModel(ChromatographicColumnBase):
         self.parameters["q"] = q
 
     @property
-    def surface_diffusion(self) -> list[float] | None:
+    def surface_diffusion(self) -> list[float]:
         """list[float] | None: Surface diffusion coefficients."""
         return self._surface_diffusion
 
     @surface_diffusion.setter
-    def surface_diffusion(self, surface_diffusion):
+    def surface_diffusion(self, surface_diffusion: list[float]) -> None:
         if isinstance(self.binding_model, NoBinding):
             raise CADETProcessError(
                 "Cannot set surface diffusion without binding model."
@@ -1253,12 +1264,12 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
     _initial_state = UnitBaseClass._initial_state + ["c", "q", "init_liquid_volume"]
     _parameters = _parameters + _initial_state
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
         self.solution_recorder = CSTRRecorder()
 
     @property
-    def required_parameters(self):
+    def required_parameters(self) -> list:
         """
         Remove 'flow_rate' from required parameters.
 
@@ -1278,7 +1289,7 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         )
 
     @porosity.setter
-    def porosity(self, porosity):
+    def porosity(self, porosity: float) -> None:
         warnings.warn(
             "Field POROSITY is only supported for backwards compatibility, but the implementation "
             "of the CSTR has changed, please refer to the documentation. The POROSITY will be "
@@ -1295,7 +1306,7 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         return self._V
 
     @V.setter
-    def V(self, V):
+    def V(self, V: float) -> None:
         warnings.warn(
             "The field V is only supported for backwards compatibility. "
             "Please set initial_liquid_volume and const_solid_volume."
@@ -1318,7 +1329,7 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         """float: Volume of the solid phase."""
         return self.const_solid_volume
 
-    def calculate_interstitial_rt(self, flow_rate):
+    def calculate_interstitial_rt(self, flow_rate: float) -> float:
         """
         Calculate mean residence time of a (non adsorbing) volume element.
 
@@ -1339,12 +1350,12 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         return self.volume_liquid / flow_rate
 
     @property
-    def q(self):
+    def q(self) -> list:
         """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
-    def q(self, q):
+    def q(self, q: list) -> None:
         if isinstance(self.binding_model, NoBinding) and q not in (None, []):
             raise CADETProcessError("Cannot set q without binding model.")
         self._q = q
@@ -1407,7 +1418,8 @@ class MCT(UnitBaseClass):
     _initial_state = UnitBaseClass._initial_state + ["c"]
     _parameters = _parameters + _initial_state
 
-    def __init__(self, *args, nchannel, **kwargs):
+    def __init__(self, *args: Any, nchannel: int, **kwargs: Any) -> None:
+        """Initialize MCT."""
         discretization = MCTDiscretizationFV()
         self._nchannel = nchannel
         super().__init__(
@@ -1418,21 +1430,21 @@ class MCT(UnitBaseClass):
         )
 
     @property
-    def nchannel(self):
+    def nchannel(self) -> int:
         """int: The number of channels in the MCT."""
         return self._nchannel
 
     @nchannel.setter
-    def nchannel(self, nchannel):
+    def nchannel(self, nchannel: int) -> None:
         self._nchannel = nchannel
 
     @property
-    def ports(self) -> list[str]:
+    def ports(self) -> list:
         """list[str]: Ports of the unit operation."""
         return [f"channel_{i}" for i in range(self.nchannel)]
 
     @property
-    def n_ports(self):
+    def n_ports(self) -> int:
         """int: Number of ports (here the number of channels)."""
         return self.nchannel
 

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -62,7 +62,8 @@ __all__ = [
 
 @frozen_attributes
 class UnitBaseClass(Structure):
-    """Base class for all UnitOperation classes.
+    """
+    Base class for all UnitOperation classes.
 
     A UnitOperation object stores model parameters and states of a unit.
     Every unit operation can be assotiated with a binding behavior and a
@@ -115,6 +116,33 @@ class UnitBaseClass(Structure):
         solution_recorder=None,
         **kwargs,
     ):
+        """
+        Initialize UnitBaseClass.
+
+        Parameters
+        ----------
+        component_system : ComponentSystem
+            The component system to which this unit belongs.
+        name : str
+            Name identifier for the unit instance.
+        *args : tuple
+            Positional arguments passed to the superclass constructor.
+        binding_model : BindingBaseClass, optional
+            A model describing specific binding interactions within the unit.
+            If None, a default `NoBinding` model is used.
+        bulk_reaction_model : BulkReactionBase, optional
+            A model for bulk phase reactions. Defaults to `NoReaction` if not provided.
+        particle_reaction_model : ParticleReactionBase, optional
+            A model for reactions within particles. Defaults to `NoReaction`.
+        discretization : DiscretizationParametersBase, optional
+            Parameters defining spatial/temporal discretization of the unit.
+            Defaults to `NoDiscretization` if None.
+        solution_recorder : IORecorder, optional
+            Object responsible for recording the simulation results.
+            Defaults to a new `IORecorder` instance.
+        **kwargs : dict
+            Additional keyword arguments passed to the superclass constructor.
+        """
         self.name = name
         self.component_system = component_system
 
@@ -141,11 +169,13 @@ class UnitBaseClass(Structure):
         super().__init__(*args, **kwargs)
 
     @property
-    def model(self):
+    def model(self) -> str:
+        """str: Return model name."""
         return self.__class__.__name__
 
     @property
-    def component_system(self):
+    def component_system(self) -> ComponentSystem:
+        """ComponentSystem: Component of the unit operation."""
         return self._component_system
 
     @component_system.setter
@@ -155,7 +185,8 @@ class UnitBaseClass(Structure):
         self._component_system = component_system
 
     @property
-    def discretization(self):
+    def discretization(self) -> DiscretizationParametersBase:
+        """DiscretizationParametersBase: Discretization parameters of the unit operation."""
         return self._discretization
 
     @discretization.setter
@@ -172,15 +203,18 @@ class UnitBaseClass(Structure):
         self._discretization = discretization
 
     @property
-    def n_comp(self):
+    def n_comp(self) -> int:
+        """int: Number of components."""
         return self.component_system.n_comp
 
     @property
-    def ports(self):
+    def ports(self) -> list:
+        """list: Ports of the unit operation."""
         return [None]
 
     @property
-    def n_ports(self):
+    def n_ports(self) -> int:
+        """int: Number of ports."""
         return 1
 
     @property
@@ -225,6 +259,7 @@ class UnitBaseClass(Structure):
 
     @property
     def section_dependent_parameters(self):
+        """Return section dependent parameters."""
         parameters = {
             key: value
             for key, value in self.parameters.items()
@@ -249,6 +284,7 @@ class UnitBaseClass(Structure):
 
     @property
     def missing_parameters(self):
+        """Return list of missing parameters."""
         missing_parameters = super().missing_parameters
 
         missing_parameters += [
@@ -258,6 +294,7 @@ class UnitBaseClass(Structure):
         return missing_parameters
 
     def check_required_parameters(self):
+        """Checkf if there are missing parameters left."""
         if len(self.missing_parameters) == 0:
             return True
         else:
@@ -266,8 +303,9 @@ class UnitBaseClass(Structure):
             return False
 
     @property
-    def binding_model(self):
-        """binding_model: BindingModel of the unit operation.
+    def binding_model(self) -> BindingBaseClass:
+        """
+        BindingBaseClass: binding model parameters of the unit operation.
 
         Raises
         ------
@@ -298,13 +336,15 @@ class UnitBaseClass(Structure):
 
     @property
     def n_bound_states(self):
+        """int: Return number of bound states."""
         if isinstance(self.binding_model, NoBinding):
             return 0
         return self.binding_model.n_bound_states
 
     @property
-    def bulk_reaction_model(self):
-        """bulk_reaction_model: Reaction in bulk phase.
+    def bulk_reaction_model(self) -> BulkReactionBase:
+        """
+        BulkReactionBase: Reaction in bulk phase.
 
         Raises
         ------
@@ -332,7 +372,8 @@ class UnitBaseClass(Structure):
 
     @property
     def particle_reaction_model(self):
-        """particle_liquid_reaction_model: Reaction in particle liquid phase.
+        """
+        ParticleReactionBase: Reaction in particle liquid phase.
 
         Raises
         ------
@@ -378,7 +419,8 @@ class UnitBaseClass(Structure):
 
 
 class SourceMixin(Structure):
-    """Mixin class for Units that have Source-like behavior.
+    """
+    Mixin class for Units that have Source-like behavior.
 
     See Also
     --------
@@ -394,7 +436,8 @@ class SourceMixin(Structure):
 
 
 class SinkMixin:
-    """Mixin class for Units that have Sink-like behavior.
+    """
+    Mixin class for Units that have Sink-like behavior.
 
     See Also
     --------
@@ -406,7 +449,8 @@ class SinkMixin:
 
 
 class Inlet(UnitBaseClass, SourceMixin):
-    """Pseudo unit operation model for streams entering the system.
+    """
+    Pseudo unit operation model for streams entering the system.
 
     Attributes
     ----------
@@ -430,7 +474,8 @@ class Inlet(UnitBaseClass, SourceMixin):
 
 
 class Outlet(UnitBaseClass, SinkMixin):
-    """Pseudo unit operation model for streams leaving the system.
+    """
+    Pseudo unit operation model for streams leaving the system.
 
     Attributes
     ----------
@@ -448,7 +493,8 @@ class MixerSplitter(UnitBaseClass):
 
 
 class TubularReactorBase(UnitBaseClass):
-    """Base class for tubular reactors and chromatographic columns.
+    """
+    Base class for tubular reactors and chromatographic columns.
 
     Provides methods for calculating geometric properties such as the cross
     section area and volume, as well as methods for convective and dispersive
@@ -494,7 +540,8 @@ class TubularReactorBase(UnitBaseClass):
 
     @property
     @abstractmethod
-    def total_porosity(self):
+    def total_porosity(self) -> float | None:
+        """Float | None: Total porosity of the unit operation."""
         pass
 
     @property
@@ -515,7 +562,8 @@ class TubularReactorBase(UnitBaseClass):
         self.diameter = (4 * cross_section_area / math.pi) ** 0.5
 
     def set_diameter_from_interstitial_velocity(self, Q, u0):
-        """Set diamter from flow rate and interstitial velocity.
+        """
+        Set diamter from flow rate and interstitial velocity.
 
         In literature, often only the interstitial velocity is given.
         This method, the diameter / cross section area can be inferred from
@@ -532,7 +580,6 @@ class TubularReactorBase(UnitBaseClass):
         Notes
         -----
             Needs to be overwritten depending on the model porosities!
-
         """
         self.cross_section_area = Q / (u0 * self.total_porosity)
 
@@ -552,8 +599,9 @@ class TubularReactorBase(UnitBaseClass):
         return self.total_porosity * self.cross_section_area
 
     @property
-    def volume(self):
-        """float: Volume of the TubularReactor.
+    def volume(self) -> float:
+        """
+        float: Volume of the TubularReactor.
 
         See Also
         --------
@@ -563,8 +611,9 @@ class TubularReactorBase(UnitBaseClass):
         return self.cross_section_area * self.length
 
     @property
-    def volume_interstitial(self):
-        """float: Interstitial volume between particles.
+    def volume_interstitial(self) -> float:
+        """
+        float: Interstitial volume between particles.
 
         See Also
         --------
@@ -574,17 +623,18 @@ class TubularReactorBase(UnitBaseClass):
         return self.cross_section_area_interstitial * self.length
 
     @property
-    def volume_liquid(self):
+    def volume_liquid(self) -> float:
         """float: Volume of the liquid phase."""
         return self.total_porosity * self.cross_section_area * self.length
 
     @property
-    def volume_solid(self):
+    def volume_solid(self) -> float:
         """float: Volume of the solid phase."""
         return (1 - self.total_porosity) * self.cross_section_area * self.length
 
     def calculate_interstitial_rt(self, flow_rate):
-        """Calculate mean residence time of a (non adsorbing) volume element.
+        """
+        Calculate mean residence time of a (non adsorbing) volume element.
 
         Parameters
         ----------
@@ -600,12 +650,12 @@ class TubularReactorBase(UnitBaseClass):
         --------
         calculate_interstitial_velocity
         calculate_superficial_rt
-
         """
         return self.volume_interstitial / flow_rate
 
     def calculate_superficial_rt(self, flow_rate):
-        """Calculate mean residence time of a volume element in an empty column.
+        """
+        Calculate mean residence time of a volume element in an empty column.
 
         Parameters
         ----------
@@ -621,12 +671,12 @@ class TubularReactorBase(UnitBaseClass):
         --------
         calculate_superficial_velocity
         calculate_interstitial_rt
-
         """
         return self.volume / flow_rate
 
     def calculate_interstitial_velocity(self, flow_rate):
-        """Calculate flow velocity of a (non adsorbing) volume element.
+        """
+        Calculate flow velocity of a (non adsorbing) volume element.
 
         Parameters
         ----------
@@ -642,12 +692,12 @@ class TubularReactorBase(UnitBaseClass):
         --------
         calculate_interstitial_rt
         calculate_superficial_velocity
-
         """
         return self.length / self.calculate_interstitial_rt(flow_rate)
 
     def calculate_superficial_velocity(self, flow_rate):
-        """Calculate superficial flow velocity of a volume element in an empty column.
+        """
+        Calculate superficial flow velocity of a volume element in an empty column.
 
         Parameters
         ----------
@@ -664,12 +714,12 @@ class TubularReactorBase(UnitBaseClass):
         calculate_superficial_rt
         calculate_interstitial_velocity
         NTP
-
         """
         return self.length / self.calculate_superficial_rt(flow_rate)
 
     def calculate_flow_rate_from_velocity(self, u0):
-        """Calculate volumetric flow rate from interstitial velocity.
+        """
+        Calculate volumetric flow rate from interstitial velocity.
 
         Parameters
         ----------
@@ -689,7 +739,8 @@ class TubularReactorBase(UnitBaseClass):
         return u0 * self.cross_section_area_interstitial
 
     def NTP(self, flow_rate):
-        r"""Calculate number of theoretical plates.
+        r"""
+        Calculate number of theoretical plates.
 
         Parameters
         ----------
@@ -710,7 +761,8 @@ class TubularReactorBase(UnitBaseClass):
         return u0 * self.length / (2 * np.array(self.axial_dispersion))
 
     def set_axial_dispersion_from_NTP(self, NTP, flow_rate):
-        r"""Set axial dispersion from number of theoretical plates (NTP).
+        r"""
+        Set axial dispersion from number of theoretical plates (NTP).
 
         Parameters
         ----------
@@ -733,13 +785,13 @@ class TubularReactorBase(UnitBaseClass):
         --------
         calculate_interstitial_velocity
         NTP
-
         """
         u0 = self.calculate_interstitial_velocity(flow_rate)
         self.axial_dispersion = u0 * self.length / (2 * NTP)
 
     def calculate_bodenstein_number(self, flow_rate: float) -> float:
-        r"""Calculate the Bodenstein number for a given flow rate.
+        r"""
+        Calculate the Bodenstein number for a given flow rate.
 
         Parameters
         ----------
@@ -763,14 +815,14 @@ class TubularReactorBase(UnitBaseClass):
         --------
         calculate_interstitial_velocity
         NTP
-
         """
         u0 = self.calculate_interstitial_velocity(flow_rate)
         return u0 * self.length / np.array(self.axial_dispersion)
 
 
 class TubularReactor(TubularReactorBase):
-    """Class for tubular reactors and tubing.
+    """
+    Class for tubular reactors and tubing.
 
     Class can be used for a regular tubular reactor.
 
@@ -780,7 +832,6 @@ class TubularReactor(TubularReactorBase):
         Initial concentration of the reactor.
     solution_recorder : TubularReactorRecorder
         Solution recorder for the unit operation.
-
     """
 
     supports_bulk_reaction = True
@@ -803,11 +854,14 @@ class TubularReactor(TubularReactorBase):
 
 
 class ChromatographicColumnBase(TubularReactorBase):
+    """Base class for chromatogrpahic columns."""
+
     pass
 
 
 class LumpedRateModelWithoutPores(ChromatographicColumnBase):
-    """Parameters for a lumped rate model without pores.
+    """
+    Parameters for a lumped rate model without pores.
 
     Attributes
     ----------
@@ -825,7 +879,6 @@ class LumpedRateModelWithoutPores(ChromatographicColumnBase):
     Although technically the LumpedRateModelWithoutPores does not have
     particles, the particle reactions interface is used to support
     reactions in the solid phase and cross-phase reactions.
-
     """
 
     supports_binding = True
@@ -852,7 +905,8 @@ class LumpedRateModelWithoutPores(ChromatographicColumnBase):
         self.solution_recorder = LRMRecorder()
 
     @property
-    def q(self):
+    def q(self) -> float | None:
+        """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
@@ -865,7 +919,8 @@ class LumpedRateModelWithoutPores(ChromatographicColumnBase):
 
 
 class LumpedRateModelWithPores(ChromatographicColumnBase):
-    """Parameters for the lumped rate model with pores.
+    """
+    Parameters for the lumped rate model with pores.
 
     Attributes
     ----------
@@ -929,7 +984,7 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
         self.solution_recorder = LRMPRecorder()
 
     @property
-    def total_porosity(self):
+    def total_porosity(self) -> float:
         """float: Total porosity of the column."""
         return self.bed_porosity + (1 - self.bed_porosity) * self.particle_porosity
 
@@ -944,7 +999,8 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
         return self.bed_porosity * self.cross_section_area
 
     def set_diameter_from_interstitial_velocity(self, Q, u0):
-        """Set diamter from flow rate and interstitial velocity.
+        """
+        Set diamter from flow rate and interstitial velocity.
 
         In literature, often only the interstitial velocity is given.
         This method, the diameter / cross section area can be inferred from
@@ -961,12 +1017,12 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
         Notes
         -----
             Overwrites parent method.
-
         """
         self.cross_section_area = Q / (u0 * self.bed_porosity)
 
     @property
-    def cp(self):
+    def cp(self) -> list[float]:
+        """list[float]: Initial particle liquid concentration."""
         if self._cp is None:
             return self.c
         else:
@@ -980,6 +1036,7 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
 
     @property
     def q(self):
+        """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
@@ -992,7 +1049,8 @@ class LumpedRateModelWithPores(ChromatographicColumnBase):
 
 
 class GeneralRateModel(ChromatographicColumnBase):
-    """Parameters for the general rate model.
+    """
+    Parameters for the general rate model.
 
     Attributes
     ----------
@@ -1018,7 +1076,6 @@ class GeneralRateModel(ChromatographicColumnBase):
         Initial concentration of the bound phase.
     solution_recorder : GRMRecorder
         Solution recorder for the unit operation.
-
     """
 
     supports_binding = True
@@ -1066,8 +1123,8 @@ class GeneralRateModel(ChromatographicColumnBase):
         self.solution_recorder = GRMRecorder()
 
     @property
-    def total_porosity(self):
-        """float: Total porosity of the column"""
+    def total_porosity(self) -> float:
+        """float: Total porosity of the column."""
         return self.bed_porosity + (1 - self.bed_porosity) * self.particle_porosity
 
     @property
@@ -1082,7 +1139,8 @@ class GeneralRateModel(ChromatographicColumnBase):
         return self.bed_porosity * self.cross_section_area
 
     def set_diameter_from_interstitial_velocity(self, Q, u0):
-        """Set diamter from flow rate and interstitial velocity.
+        """
+        Set diamter from flow rate and interstitial velocity.
 
         In literature, often only the interstitial velocity is given.
         This method, the diameter / cross section area can be inferred from
@@ -1099,12 +1157,12 @@ class GeneralRateModel(ChromatographicColumnBase):
         Notes
         -----
             Overwrites parent method.
-
         """
         self.cross_section_area = Q / (u0 * self.bed_porosity)
 
     @property
     def cp(self):
+        """list[float]: Initial particle liquid concentration."""
         if self._cp is None:
             return self.c
         else:
@@ -1118,6 +1176,7 @@ class GeneralRateModel(ChromatographicColumnBase):
 
     @property
     def q(self):
+        """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
@@ -1129,7 +1188,8 @@ class GeneralRateModel(ChromatographicColumnBase):
         self.parameters["q"] = q
 
     @property
-    def surface_diffusion(self):
+    def surface_diffusion(self) -> list[float] | None:
+        """list[float] | None: Surface diffusion coefficients."""
         return self._surface_diffusion
 
     @surface_diffusion.setter
@@ -1144,7 +1204,8 @@ class GeneralRateModel(ChromatographicColumnBase):
 
 
 class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
-    """Parameters for an ideal mixer.
+    """
+    Parameters for an ideal mixer.
 
     Parameters
     ----------
@@ -1169,7 +1230,6 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
     -----
     CADET generally supports particle reactions for the CSTR, however, this is currently
     not exposed since there are some issues with the interface (.
-
     """
 
     supports_binding = True
@@ -1209,7 +1269,8 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         return required_parameters
 
     @property
-    def porosity(self):
+    def porosity(self) -> float:
+        """float: Porosity of the unit operation."""
         if self.const_solid_volume is None or self.init_liquid_volume is None:
             return None
         return self.init_liquid_volume / (
@@ -1219,9 +1280,9 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
     @porosity.setter
     def porosity(self, porosity):
         warnings.warn(
-            "Field POROSITY is only supported for backwards compatibility, but the implementation of the CSTR has "
-            "changed, please refer to the documentation. The POROSITY will be used to compute the "
-            "constant solid volume from the total volume V."
+            "Field POROSITY is only supported for backwards compatibility, but the implementation "
+            "of the CSTR has changed, please refer to the documentation. The POROSITY will be "
+            "used to compute the constant solid volume from the total volume V."
         )
         if self.V is None:
             raise RuntimeError("Please set the volume first before setting a porosity.")
@@ -1229,35 +1290,37 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         self.init_liquid_volume = self.V * porosity
 
     @property
-    def V(self):
+    def V(self) -> float:
+        """float: Total volume of the unit operation."""
         return self._V
 
     @V.setter
     def V(self, V):
         warnings.warn(
-            "The field V is only supported for backwards compatibility. Please set initial_liquid_volume and "
-            "const_solid_volume"
+            "The field V is only supported for backwards compatibility. "
+            "Please set initial_liquid_volume and const_solid_volume."
         )
         self.init_liquid_volume = V
         self._V = V
 
     @property
-    def volume(self):
+    def volume(self) -> float:
         """float: Alias for volume."""
         return self.const_solid_volume + self.init_liquid_volume
 
     @property
-    def volume_liquid(self):
+    def volume_liquid(self) -> float:
         """float: Volume of the liquid phase."""
         return self.init_liquid_volume
 
     @property
-    def volume_solid(self):
+    def volume_solid(self) -> float:
         """float: Volume of the solid phase."""
         return self.const_solid_volume
 
     def calculate_interstitial_rt(self, flow_rate):
-        """Calculate mean residence time of a (non adsorbing) volume element.
+        """
+        Calculate mean residence time of a (non adsorbing) volume element.
 
         Parameters
         ----------
@@ -1272,12 +1335,12 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
         See Also
         --------
         calculate_interstitial_velocity
-
         """
         return self.volume_liquid / flow_rate
 
     @property
     def q(self):
+        """list[float]: Initial solid phase concentration."""
         return self._q
 
     @q.setter
@@ -1290,7 +1353,8 @@ class Cstr(UnitBaseClass, SourceMixin, SinkMixin):
 
 
 class MCT(UnitBaseClass):
-    """Parameters for multi-channel transportmodel.
+    """
+    Parameters for multi-channel transportmodel.
 
     Parameters
     ----------
@@ -1363,16 +1427,19 @@ class MCT(UnitBaseClass):
         self._nchannel = nchannel
 
     @property
-    def ports(self):
+    def ports(self) -> list[str]:
+        """list[str]: Ports of the unit operation."""
         return [f"channel_{i}" for i in range(self.nchannel)]
 
     @property
     def n_ports(self):
+        """int: Number of ports (here the number of channels)."""
         return self.nchannel
 
     @property
-    def volume(self):
-        """float: Combined Volumes of all channels.
+    def volume(self) -> float:
+        """
+        float: Combined Volumes of all channels.
 
         See Also
         --------
@@ -1382,11 +1449,11 @@ class MCT(UnitBaseClass):
         return sum(self.channel_cross_section_areas) * self.length
 
     @property
-    def volume_liquid(self):
+    def volume_liquid(self) -> float:
         """float: Volume of the liquid phase. Equals the volume, since there is no solid phase."""
         return self.volume
 
     @property
-    def volume_solid(self):
+    def volume_solid(self) -> float:
         """float: Volume of the solid phase. Equals zero, since there is no solid phase."""
         return 0

--- a/CADETProcess/processModel/unitOperation.py
+++ b/CADETProcess/processModel/unitOperation.py
@@ -1288,7 +1288,8 @@ class MCT(UnitBaseClass):
     exchange_matrix : List of unsigned floats. Lenght depends on nchannel.
     solution_recorder : MCTRecorder
         Solution recorder for the unit operation.
-    n_channel : int number of channels
+    n_channel : int
+        Number of channels
     """
     has_ports = True
     supports_bulk_reaction = True
@@ -1299,7 +1300,6 @@ class MCT(UnitBaseClass):
     channel_cross_section_areas = SizedFloatList(size='nchannel')
     axial_dispersion = SizedUnsignedList(size=('n_comp', 'nchannel'))
     flow_direction = Switch(valid=[-1, 1], default=1)
-    nchannel = UnsignedInteger()
 
     exchange_matrix = SizedNdArray(size=('nchannel', 'nchannel', 'n_comp'))
 

--- a/CADETProcess/reference.py
+++ b/CADETProcess/reference.py
@@ -22,8 +22,7 @@ from CADETProcess import CADETProcessError
 from CADETProcess.processModel import ComponentSystem
 from CADETProcess.solution import SolutionBase, SolutionIO
 
-
-__all__ = ['ReferenceBase', 'ReferenceIO', 'FractionationReference']
+__all__ = ["ReferenceBase", "ReferenceIO", "FractionationReference"]
 
 
 class ReferenceBase(SolutionBase):
@@ -61,9 +60,7 @@ class ReferenceIO(ReferenceBase, SolutionIO):
 
     """
 
-    def __init__(
-            self, name, time, solution,
-            flow_rate=None, component_system=None):
+    def __init__(self, name, time, solution, flow_rate=None, component_system=None):
         """Initialize a ReferenceIO object.
 
         Parameters
@@ -106,7 +103,7 @@ class ReferenceIO(ReferenceBase, SolutionIO):
 
         if flow_rate is None:
             flow_rate = 1
-        if isinstance(flow_rate, (int,  float)):
+        if isinstance(flow_rate, (int, float)):
             flow_rate = flow_rate * np.ones(time.shape)
 
         super().__init__(name, component_system, time, solution, flow_rate)
@@ -132,7 +129,7 @@ class FractionationReference(ReferenceBase):
     CADETProcess.fractionation.Fraction
     """
 
-    dimensions = SolutionBase.dimensions + ['component_coordinates']
+    dimensions = SolutionBase.dimensions + ["component_coordinates"]
 
     def __init__(self, name, fractions, component_system=None, *args, **kwargs):
         from CADETProcess.fractionation import Fraction
@@ -147,7 +144,7 @@ class FractionationReference(ReferenceBase):
 
         self.fractions = fractions
 
-        time = np.array([(frac.start + frac.end)/2 for frac in self.fractions])
+        time = np.array([(frac.start + frac.end) / 2 for frac in self.fractions])
         solution = np.array([frac.mass / frac.volume for frac in self.fractions])
 
         if component_system is None:

--- a/CADETProcess/reference.py
+++ b/CADETProcess/reference.py
@@ -16,7 +16,10 @@ comparison with ``SimulationResults``
 
 """  # noqa
 
+from typing import Any, Optional
+
 import numpy as np
+import numpy.typing as npt
 
 from CADETProcess import CADETProcessError
 from CADETProcess.processModel import ComponentSystem
@@ -60,7 +63,14 @@ class ReferenceIO(ReferenceBase, SolutionIO):
     CADETProcess.solution.SolutionIO
     """
 
-    def __init__(self, name, time, solution, flow_rate=None, component_system=None):
+    def __init__(
+        self,
+        name: str,
+        time: npt.ArrayLike,
+        solution: npt.ArrayLike,
+        flow_rate: Optional[float | npt.ArrayLike] = None,
+        component_system: Optional[ComponentSystem] = None
+    ) -> None:
         """
         Initialize a ReferenceIO object.
 
@@ -132,7 +142,15 @@ class FractionationReference(ReferenceBase):
 
     dimensions = SolutionBase.dimensions + ["component_coordinates"]
 
-    def __init__(self, name, fractions, component_system=None, *args, **kwargs):
+    def __init__(
+        self,
+        name: str,
+        fractions: list,
+        component_system: Optional[ComponentSystem] = None,
+        *args: Any,
+        **kwargs:  Any,
+        ) -> None:
+        """Initialize FractionationReference object."""
         from CADETProcess.fractionation import Fraction
 
         for frac in fractions:

--- a/CADETProcess/reference.py
+++ b/CADETProcess/reference.py
@@ -14,7 +14,7 @@ comparison with ``SimulationResults``
     ReferenceBase
     ReferenceIO
 
-"""
+"""  # noqa
 
 import numpy as np
 
@@ -26,19 +26,20 @@ __all__ = ["ReferenceBase", "ReferenceIO", "FractionationReference"]
 
 
 class ReferenceBase(SolutionBase):
-    """Class representing references to be compared with SimulationResults.
+    """
+    Class representing references to be compared with SimulationResults.
 
     See Also
     --------
     CADETProcess.solution.SolutionBase
-
     """
 
     pass
 
 
 class ReferenceIO(ReferenceBase, SolutionIO):
-    """A class representing reference data of inlet or outlet concentration profiles.
+    """
+    A class representing reference data of inlet or outlet concentration profiles.
 
     Attributes
     ----------
@@ -57,11 +58,11 @@ class ReferenceIO(ReferenceBase, SolutionIO):
     --------
     CADETProcess.reference.ReferenceBase
     CADETProcess.solution.SolutionIO
-
     """
 
     def __init__(self, name, time, solution, flow_rate=None, component_system=None):
-        """Initialize a ReferenceIO object.
+        """
+        Initialize a ReferenceIO object.
 
         Parameters
         ----------
@@ -86,7 +87,6 @@ class ReferenceIO(ReferenceBase, SolutionIO):
         ValueError
             If the time and solution arrays are not the same length.
             If the flow rate array and time array are not the same length.
-
         """
         time = np.array(time, dtype=np.float64).reshape(-1)
 
@@ -110,7 +110,8 @@ class ReferenceIO(ReferenceBase, SolutionIO):
 
 
 class FractionationReference(ReferenceBase):
-    """A class representing reference data of fractionation data.
+    """
+    A class representing reference data of fractionation data.
 
     Attributes
     ----------

--- a/CADETProcess/settings.py
+++ b/CADETProcess/settings.py
@@ -12,7 +12,7 @@ This module provides functionality for general settings.
 
     Settings
 
-"""
+"""  # noqa
 
 import os
 import shutil
@@ -26,7 +26,8 @@ __all__ = ["Settings"]
 
 
 class Settings(Structure):
-    """A class for managing general settings.
+    """
+    A class for managing general settings.
 
     Attributes
     ----------
@@ -62,7 +63,8 @@ class Settings(Structure):
 
     @property
     def working_directory(self):
-        """The path of the working directory.
+        """
+        The path of the working directory.
 
         If the working directory is not set, the current directory is used.
 
@@ -92,6 +94,7 @@ class Settings(Structure):
         self._working_directory = working_directory
 
     def set_working_directory(self, working_directory):
+        """Set working directory."""
         warn(
             "This function is deprecated, use working_directory property.",
             DeprecationWarning,

--- a/CADETProcess/settings.py
+++ b/CADETProcess/settings.py
@@ -13,17 +13,16 @@ This module provides functionality for general settings.
     Settings
 
 """
+
 import os
-from pathlib import Path
 import shutil
 import tempfile
+from pathlib import Path
 from warnings import warn
 
-from CADETProcess.dataStructure import Structure
-from CADETProcess.dataStructure import Bool, Switch
+from CADETProcess.dataStructure import Bool, Structure, Switch
 
-
-__all__ = ['Settings']
+__all__ = ["Settings"]
 
 
 class Settings(Structure):
@@ -53,8 +52,8 @@ class Settings(Structure):
     _save_log = Bool(default=False)
     debug_mode = Bool(default=False)
     LOG_LEVEL = Switch(
-        valid=['DEBUG', 'INFO', 'WARNING', 'ERROR', 'CRITICAL'],
-        default='INFO'
+        valid=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        default="INFO",
     )
 
     def __init__(self):
@@ -78,7 +77,7 @@ class Settings(Structure):
             The absolute path of the working directory.
         """
         if self._working_directory is None:
-            _working_directory = Path('./')
+            _working_directory = Path("./")
         else:
             _working_directory = Path(self._working_directory)
 
@@ -94,8 +93,9 @@ class Settings(Structure):
 
     def set_working_directory(self, working_directory):
         warn(
-            'This function is deprecated, use working_directory property.',
-            DeprecationWarning, stacklevel=2
+            "This function is deprecated, use working_directory property.",
+            DeprecationWarning,
+            stacklevel=2,
         )
         self.working_directory = working_directory
 
@@ -107,6 +107,7 @@ class Settings(Structure):
     @save_log.setter
     def save_log(self, save_log):
         from CADETProcess import log
+
         log.update_loggers(self.log_directory, save_log)
 
         self._save_log = save_log
@@ -114,16 +115,16 @@ class Settings(Structure):
     @property
     def log_directory(self):
         """pathlib.Path: Log directory."""
-        return self.working_directory / 'log'
+        return self.working_directory / "log"
 
     @property
     def temp_dir(self):
         """pathlib.Path: Directory for temporary files."""
         if self._temp_dir is None:
-            if 'XDG_RUNTIME_DIR' in os.environ:
-                _temp_dir = Path(os.environ['XDG_RUNTIME_DIR']) / 'CADET-Process'
+            if "XDG_RUNTIME_DIR" in os.environ:
+                _temp_dir = Path(os.environ["XDG_RUNTIME_DIR"]) / "CADET-Process"
             else:
-                _temp_dir = self.working_directory / 'tmp'
+                _temp_dir = self.working_directory / "tmp"
         else:
             _temp_dir = Path(self._temp_dir).absolute()
 

--- a/CADETProcess/settings.py
+++ b/CADETProcess/settings.py
@@ -57,12 +57,13 @@ class Settings(Structure):
         default="INFO",
     )
 
-    def __init__(self):
+    def __init__(self) -> None:
+        """Initialize Settings Object."""
         self._temp_dir = None
         self.working_directory = None
 
     @property
-    def working_directory(self):
+    def working_directory(self) -> str:
         """
         The path of the working directory.
 
@@ -90,10 +91,10 @@ class Settings(Structure):
         return _working_directory
 
     @working_directory.setter
-    def working_directory(self, working_directory):
+    def working_directory(self, working_directory: str) -> None:
         self._working_directory = working_directory
 
-    def set_working_directory(self, working_directory):
+    def set_working_directory(self, working_directory: str) -> None:
         """Set working directory."""
         warn(
             "This function is deprecated, use working_directory property.",
@@ -103,12 +104,12 @@ class Settings(Structure):
         self.working_directory = working_directory
 
     @property
-    def save_log(self):
+    def save_log(self) -> bool:
         """bool: If True, save log files."""
         return self._save_log
 
     @save_log.setter
-    def save_log(self, save_log):
+    def save_log(self, save_log: bool) -> None:
         from CADETProcess import log
 
         log.update_loggers(self.log_directory, save_log)
@@ -116,12 +117,12 @@ class Settings(Structure):
         self._save_log = save_log
 
     @property
-    def log_directory(self):
+    def log_directory(self) -> str:
         """pathlib.Path: Log directory."""
         return self.working_directory / "log"
 
     @property
-    def temp_dir(self):
+    def temp_dir(self) -> str:
         """pathlib.Path: Directory for temporary files."""
         if self._temp_dir is None:
             if "XDG_RUNTIME_DIR" in os.environ:
@@ -137,10 +138,10 @@ class Settings(Structure):
         return Path(tempfile.gettempdir())
 
     @temp_dir.setter
-    def temp_dir(self, temp_dir):
+    def temp_dir(self, temp_dir: str) -> None:
         self._temp_dir = temp_dir
 
-    def delete_temporary_files(self):
+    def delete_temporary_files(self) -> None:
         """Delete the temporary files directory."""
         shutil.rmtree(self.temp_dir / "simulation_files", ignore_errors=True)
         self.temp_dir = self._temp_dir

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -13,7 +13,7 @@ This module provides a class for storing simulation results.
 
     SimulationResults
 
-"""
+"""  # noqa
 
 import copy
 
@@ -34,7 +34,8 @@ __all__ = ["SimulationResults"]
 
 
 class SimulationResults(Structure):
-    """Class for storing simulation results including the solver configuration.
+    """
+    Class for storing simulation results including the solver configuration.
 
     Attributes
     ----------
@@ -69,7 +70,6 @@ class SimulationResults(Structure):
     -----
         Ideally, the final state for each unit operation should be saved.
         However, CADET does currently provide this functionality.
-
     """
 
     solver_name = String()
@@ -114,6 +114,7 @@ class SimulationResults(Structure):
         self._sensitivity = None
 
     def update(self, new_results):
+        """Update the simulation results with results from a new cycle."""
         if self.process.name != new_results.process.name:
             raise CADETProcessError("Process does not match")
 
@@ -135,6 +136,7 @@ class SimulationResults(Structure):
 
     @property
     def component_system(self):
+        """ComponentSystem: The component system used in the simulation."""
         solution = self.solution_cycles[self._first_unit][self._first_solution]
         return solution[0].component_system
 
@@ -236,6 +238,7 @@ class SimulationResults(Structure):
 
     @property
     def n_cycles(self):
+        """int: Number of simulated cycles."""
         return len(self.solution_cycles[self._first_unit][self._first_solution])
 
     @property
@@ -248,11 +251,12 @@ class SimulationResults(Structure):
 
     @property
     def time_cycle(self):
-        """np.array: Solution times vector"""
+        """np.array: Solution times vector."""
         return self.solution_cycles[self._first_unit][self._first_solution][0].time
 
     @property
     def time_complete(self):
+        """np.ndarray: Solution times vector for all cycles."""
         if self._time_complete is not None:
             return self._time_complete
 

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -29,6 +29,8 @@ from CADETProcess.dataStructure import (
     UnsignedFloat,
     UnsignedInteger,
 )
+from CADETProcess.processModel import ComponentSystem, Process, UnitBaseClass
+from CADETProcess.solution import SolutionBase
 
 __all__ = ["SimulationResults"]
 
@@ -84,17 +86,18 @@ class SimulationResults(Structure):
 
     def __init__(
         self,
-        solver_name,
-        solver_parameters,
-        exit_flag,
-        exit_message,
-        time_elapsed,
-        process,
-        solution_cycles,
-        sensitivity_cycles,
-        system_state,
-        chromatograms,
-    ):
+        solver_name: str,
+        solver_parameters: dict,
+        exit_flag: int,
+        exit_message: str,
+        time_elapsed: float,
+        process: Process,
+        solution_cycles: dict,
+        sensitivity_cycles: dict,
+        system_state: dict,
+        chromatograms: list
+    ) -> None:
+        """Initialize SimulationResults."""
         self.solver_name = solver_name
         self.solver_parameters = solver_parameters
 
@@ -113,7 +116,7 @@ class SimulationResults(Structure):
         self._solution = None
         self._sensitivity = None
 
-    def update(self, new_results):
+    def update(self, new_results: 'SimulationResults') -> None:
         """Update the simulation results with results from a new cycle."""
         if self.process.name != new_results.process.name:
             raise CADETProcessError("Process does not match")
@@ -135,13 +138,13 @@ class SimulationResults(Structure):
         self._sensitivity = None
 
     @property
-    def component_system(self):
+    def component_system(self) -> ComponentSystem:
         """ComponentSystem: The component system used in the simulation."""
         solution = self.solution_cycles[self._first_unit][self._first_solution]
         return solution[0].component_system
 
     @property
-    def solution(self):
+    def solution(self) -> Dict:
         """Construct complete solution from individual cyles."""
         if self._solution is not None:
             return self._solution
@@ -194,7 +197,7 @@ class SimulationResults(Structure):
         return solution
 
     @property
-    def sensitivity(self):
+    def sensitivity(self) -> Dict:
         """Construct complete sensitivity from individual cyles."""
         if self._sensitivity is not None:
             return self._sensitivity
@@ -237,25 +240,25 @@ class SimulationResults(Structure):
         return sensitivity
 
     @property
-    def n_cycles(self):
+    def n_cycles(self) -> int:
         """int: Number of simulated cycles."""
         return len(self.solution_cycles[self._first_unit][self._first_solution])
 
     @property
-    def _first_unit(self):
+    def _first_unit(self) -> UnitBaseClass:
         return next(iter(self.solution_cycles))
 
     @property
-    def _first_solution(self):
+    def _first_solution(self) -> SolutionBase:
         return next(iter(self.solution_cycles[self._first_unit]))
 
     @property
-    def time_cycle(self):
+    def time_cycle(self) -> np.ndarray:
         """np.array: Solution times vector."""
         return self.solution_cycles[self._first_unit][self._first_solution][0].time
 
     @property
-    def time_complete(self):
+    def time_complete(self) -> np.ndarray:
         """np.ndarray: Solution times vector for all cycles."""
         if self._time_complete is not None:
             return self._time_complete

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -16,20 +16,21 @@ This module provides a class for storing simulation results.
 """
 
 import copy
-import os
 
 import numpy as np
 from addict import Dict
 
 from CADETProcess import CADETProcessError
-from CADETProcess import settings
-from CADETProcess.dataStructure import Structure
 from CADETProcess.dataStructure import (
-    Dictionary, String, List, UnsignedInteger, UnsignedFloat
+    Dictionary,
+    List,
+    String,
+    Structure,
+    UnsignedFloat,
+    UnsignedInteger,
 )
 
-
-__all__ = ['SimulationResults']
+__all__ = ["SimulationResults"]
 
 
 class SimulationResults(Structure):
@@ -82,13 +83,18 @@ class SimulationResults(Structure):
     chromatograms = List()
 
     def __init__(
-            self,
-            solver_name, solver_parameters,
-            exit_flag, exit_message, time_elapsed,
-            process,
-            solution_cycles, sensitivity_cycles, system_state,
-            chromatograms
-            ):
+        self,
+        solver_name,
+        solver_parameters,
+        exit_flag,
+        exit_message,
+        time_elapsed,
+        process,
+        solution_cycles,
+        sensitivity_cycles,
+        system_state,
+        chromatograms,
+    ):
         self.solver_name = solver_name
         self.solver_parameters = solver_parameters
 
@@ -109,7 +115,7 @@ class SimulationResults(Structure):
 
     def update(self, new_results):
         if self.process.name != new_results.process.name:
-            raise CADETProcessError('Process does not match')
+            raise CADETProcessError("Process does not match")
 
         self.exit_flag = new_results.exit_flag
         self.exit_message = new_results.exit_message
@@ -142,7 +148,6 @@ class SimulationResults(Structure):
 
         solution = Dict()
         for unit, solutions in self.solution_cycles.items():
-
             for sol, ports_cycles in solutions.items():
                 if isinstance(ports_cycles, Dict):
                     ports = ports_cycles
@@ -196,15 +201,14 @@ class SimulationResults(Structure):
 
         sensitivity = Dict()
         for sens_name, sensitivities in self.sensitivity_cycles.items():
-
             for unit, sensitivities in sensitivities.items():
-
                 for flow, ports_cycles in sensitivities.items():
                     if isinstance(ports_cycles, Dict):
                         ports = ports_cycles
                         for port, cycles in ports.items():
                             sensitivity[sens_name][unit][flow][port] = copy.deepcopy(
-                                cycles[0])
+                                cycles[0]
+                            )
                             sensitivity_complete = cycles[0].solution
                             for i in range(1, self.n_cycles):
                                 sensitivity_complete = np.vstack((
@@ -232,9 +236,7 @@ class SimulationResults(Structure):
 
     @property
     def n_cycles(self):
-        return len(
-            self.solution_cycles[self._first_unit][self._first_solution]
-        )
+        return len(self.solution_cycles[self._first_unit][self._first_solution])
 
     @property
     def _first_unit(self):
@@ -257,8 +259,7 @@ class SimulationResults(Structure):
         time_complete = self.time_cycle
         for i in range(1, self.n_cycles):
             time_complete = np.hstack((
-                time_complete,
-                self.time_cycle[1:] + i*self.process.cycle_time
+                time_complete, self.time_cycle[1:] + i * self.process.cycle_time
             ))
 
         self._time_complete = time_complete

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -179,7 +179,7 @@ class Cadet(SimulatorBase):
         cadet.delete_file()
 
         if return_information.return_code != 0:
-            raise CADETProcessError(return_information)
+            raise CADETProcessError(return_information.error_message)
 
         print("Test simulation completed successfully")
 
@@ -355,6 +355,9 @@ class Cadet(SimulatorBase):
             return_information = cadet.run_simulation(timeout=self.timeout)
         else:
             return_information = cadet.run_load(timeout=self.timeout)
+
+        if return_information.return_code != 0:
+            raise CADETProcessError(return_information.error_message)
 
         return cadet
 

--- a/CADETProcess/smoothing.py
+++ b/CADETProcess/smoothing.py
@@ -17,12 +17,15 @@ This module provides functionality for smoothing data.
 """  # noqa
 
 import multiprocessing
+from typing import Any, Callable, Optional
 
 import numpy as np
+import numpy.typing as npt
 import scipy.signal
 from pymoo.algorithms.soo.nonconvex.pattern import PatternSearch
 from pymoo.core.problem import ElementwiseProblem
 from pymoo.optimize import minimize
+from scipy.interpolate import UnivariateSpline
 
 butter_order = 3
 
@@ -30,14 +33,28 @@ __all__ = ["find_smoothing_factors", "full_smooth"]
 
 
 class TargetProblem(ElementwiseProblem):
-    def __init__(self, lb, ub, sse_target, func, values, fs):
+    def __init__(
+        self,
+        lb: float,
+        ub: float,
+        sse_target: float,
+        func: Callable,
+        values: npt.ArrayLike,
+        fs: float,
+    ) -> None:
         super().__init__(n_var=1, n_obj=1, n_constr=0, xl=lb, xu=ub)
         self.sse_target = sse_target
         self.func = func
         self.values = values
         self.fs = fs
 
-    def _evaluate(self, crit_fs, out, *args, **kwargs):
+    def _evaluate(
+        self,
+        crit_fs: float,
+        out: dict,
+        *args: Optional[tuple],
+        **kwargs: Optional[dict]
+    ) -> None:
         crit_fs = 10**crit_fs
         try:
             sos = self.func(crit_fs, self.fs)
@@ -51,7 +68,19 @@ class TargetProblem(ElementwiseProblem):
 
 
 class MaxDistance(ElementwiseProblem):
-    def __init__(self, lb, ub, func, fs, values, x_min, y_min, p1, p2, factor):
+    def __init__(
+        self,
+        lb: float,
+        ub: float,
+        func: Callable,
+        fs: float,
+        values: npt.ArrayLike,
+        x_min: float,
+        y_min: float,
+        p1: float,
+        p2: float,
+        factor: float,
+    ) -> None:
         super().__init__(n_var=1, n_obj=1, n_constr=0, xl=lb, xu=ub)
         self.func = func
         self.fs = fs
@@ -62,7 +91,13 @@ class MaxDistance(ElementwiseProblem):
         self.p2 = p2
         self.factor = factor
 
-    def _evaluate(self, crit_fs, out, *args, **kwargs):
+    def _evaluate(
+        self,
+        crit_fs: float,
+        out: dict,
+        *args: Optional[tuple],
+        **kwargs: Optional[dict]
+    ) -> None:
         crit_fs = 10.0 ** crit_fs[0]
         try:
             sos = self.func(crit_fs, self.fs)
@@ -86,7 +121,7 @@ class MaxDistance(ElementwiseProblem):
         out["F"] = -d
 
 
-def get_p(x, y):
+def get_p(x: npt.ArrayLike, y: npt.ArrayLike) -> tuple:
     x = np.array(x)
     y = np.array(y)
 
@@ -107,7 +142,7 @@ def get_p(x, y):
     return x, min(x), y, min(y), p1, p2, p3, factor
 
 
-def signal_bessel(crit_fs, fs):
+def signal_bessel(crit_fs: float, fs: float) -> np.ndarray:
     return scipy.signal.bessel(
         butter_order,
         crit_fs,
@@ -119,13 +154,21 @@ def signal_bessel(crit_fs, fs):
     )
 
 
-def signal_butter(crit_fs, fs):
+def signal_butter(crit_fs: float, fs: float) -> np.ndarray:
     return scipy.signal.butter(
         butter_order, crit_fs, btype="lowpass", analog=False, fs=fs, output="sos"
     )
 
 
-def refine_signal(func, times, values, x, y, fs, start):
+def refine_signal(
+    func: Callable,
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    x: npt.ArrayLike,
+    y: npt.ArrayLike,
+    fs: float,
+    start: float,
+) -> float:
     x, x_min, y, y_min, p1, p2, p3, factor = get_p(x, y)
 
     lb = np.log10(x[0])
@@ -142,7 +185,7 @@ def refine_signal(func, times, values, x, y, fs, start):
     return crit_fs
 
 
-def find_L(x, y):
+def find_L(x: npt.ArrayLike, y: npt.ArrayLike) -> tuple[float, float]:
     # find the largest value greater than 0
     # otherwise return none to just turn off butter filter
     x, x_min, y, y_min, p1, p2, p3, factor = get_p(x, y)
@@ -160,7 +203,12 @@ def find_L(x, y):
     return l_x, l_y
 
 
-def find_signal(func, times, values, sse_target):
+def find_signal(
+    func: Callable,
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    sse_target: float
+) -> float:
     filters = []
     sse = []
 
@@ -191,7 +239,14 @@ def find_signal(func, times, values, sse_target):
     return L_x
 
 
-def find_max_signal(func, times, values, sse_target, filters, sse):
+def find_max_signal(
+    func: Callable,
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    sse_target: float,
+    filters: list,
+    sse: Any
+) -> float:
     fs = 1.0 / (times[1] - times[0])
 
     filters = np.log10(filters)
@@ -206,7 +261,12 @@ def find_max_signal(func, times, values, sse_target, filters, sse):
     return crit_fs
 
 
-def smoothing_filter_signal(func, times, values, crit_fs):
+def smoothing_filter_signal(
+    func: Callable,
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    crit_fs: float,
+) -> np.ndarray:
     if crit_fs is None:
         return values
     fs = 1.0 / (times[1] - times[0])
@@ -215,7 +275,11 @@ def smoothing_filter_signal(func, times, values, crit_fs):
     return low_passed
 
 
-def find_smoothing_factors(times, values, rmse_target=1e-4):
+def find_smoothing_factors(
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    rmse_target: float = 1e-4,
+) -> tuple:
     """Find smoothing factors."""
     sse_target = (rmse_target**2.0) * len(values)
 
@@ -245,7 +309,12 @@ def find_smoothing_factors(times, values, rmse_target=1e-4):
     return s, crit_fs, crit_fs_der
 
 
-def create_spline(times, values, crit_fs, s):
+def create_spline(
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    crit_fs: float,
+    s: Optional[float],
+) -> tuple[UnivariateSpline, float]:
     factor = 1.0 / np.max(values)
     values = values * factor
     values_filter = smoothing_filter_signal(signal_bessel, times, values, crit_fs)
@@ -256,13 +325,20 @@ def create_spline(times, values, crit_fs, s):
     )
 
 
-def smooth_data(times, values, crit_fs, s):
+def smooth_data(times: npt.ArrayLike, values: npt.ArrayLike, crit_fs: float, s: float) -> float:
     spline, factor = create_spline(times, values, crit_fs, s)
 
     return spline(times) / factor
 
 
-def smooth_data_derivative(times, values, crit_fs, s, crit_fs_der, smooth=True):
+def smooth_data_derivative(
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    crit_fs: float,
+    s: float,
+    crit_fs_der: float,
+    smooth: bool = True,
+) -> float:
     spline, factor = create_spline(times, values, crit_fs, s)
 
     if smooth:
@@ -281,8 +357,14 @@ def smooth_data_derivative(times, values, crit_fs, s, crit_fs_der, smooth=True):
     return values_filter_der
 
 
-def full_smooth(times, values, crit_fs, s, crit_fs_der, smooth=True):
-    # return smooth data derivative of data
+def full_smooth(
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    crit_fs: float,
+    s: float,
+    crit_fs_der: float,
+    smooth: bool = True,
+) -> tuple:
     """Create full smooth data."""
     spline, factor = create_spline(times, values, crit_fs, s)
 
@@ -307,7 +389,11 @@ def full_smooth(times, values, crit_fs, s, crit_fs_der, smooth=True):
     return values_filter, values_filter_der
 
 
-def butter(times, values, crit_fs_der):
+def butter(
+    times: npt.ArrayLike,
+    values: npt.ArrayLike,
+    crit_fs_der: float,
+) -> np.ndarray:
     values_filter = smoothing_filter_signal(signal_bessel, times, values, crit_fs_der)
 
     return values_filter

--- a/CADETProcess/smoothing.py
+++ b/CADETProcess/smoothing.py
@@ -14,7 +14,7 @@ This module provides functionality for smoothing data.
     find_smoothing_factors
     full_smooth
 
-"""
+"""  # noqa
 
 import multiprocessing
 
@@ -216,6 +216,7 @@ def smoothing_filter_signal(func, times, values, crit_fs):
 
 
 def find_smoothing_factors(times, values, rmse_target=1e-4):
+    """Find smoothing factors."""
     sse_target = (rmse_target**2.0) * len(values)
 
     try:
@@ -282,6 +283,7 @@ def smooth_data_derivative(times, values, crit_fs, s, crit_fs_der, smooth=True):
 
 def full_smooth(times, values, crit_fs, s, crit_fs_der, smooth=True):
     # return smooth data derivative of data
+    """Create full smooth data."""
     spline, factor = create_spline(times, values, crit_fs, s)
 
     values_filter = spline(times) / factor

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -32,12 +32,13 @@ Method to slice a Solution:
 from __future__ import annotations
 
 import copy
-from typing import NoReturn, Optional
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
 from matplotlib.axes import Axes
+from matplotlib.collections import QuadMesh
 from scipy import integrate
 from scipy.interpolate import PchipInterpolator
 
@@ -105,7 +106,7 @@ class SolutionBase(Structure):
         component_system: ComponentSystem,
         time: npt.ArrayLike,
         solution: npt.ArrayLike,
-    ) -> NoReturn:
+    ) -> None:
         """
         Initialize the SolutionBase.
 
@@ -127,11 +128,11 @@ class SolutionBase(Structure):
 
         self.update_solution()
 
-    def update_solution(self):
+    def update_solution(self) -> None:
         """Update the solution."""
         pass
 
-    def update_transform(self):
+    def update_transform(self) -> None:
         """Update the transforms."""
         pass
 
@@ -223,7 +224,7 @@ class SolutionBase(Structure):
 
         return purity
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.name
 
 
@@ -246,7 +247,7 @@ class SolutionIO(SolutionBase):
         time: npt.ArrayLike,
         solution: npt.ArrayLike,
         flow_rate: TimeLine | npt.ArrayLike,
-    ) -> NoReturn:
+    ) -> None:
         """
         Initialize the SolutionIO.
 
@@ -269,7 +270,7 @@ class SolutionIO(SolutionBase):
 
         super().__init__(name, component_system, time, solution)
 
-    def update_solution(self):
+    def update_solution(self) -> None:
         """Update solution method."""
         self._solution_interpolated = None
         self._dm_dt_interpolated = None
@@ -295,7 +296,7 @@ class SolutionIO(SolutionBase):
 
         return antiderivative
 
-    def update_transform(self) -> NoReturn:
+    def update_transform(self) -> None:
         """Update the Transformer."""
         self.transform = transform.NormLinearTransformer(
             np.min(self.solution, axis=0),
@@ -305,7 +306,7 @@ class SolutionIO(SolutionBase):
         )
 
     @property
-    def solution_interpolated(self) -> "InterpolatedSignal":
+    def solution_interpolated(self) -> InterpolatedSignal:
         """InterpolatedSignal: The interpolated signal."""
         if self._solution_interpolated is None:
             self._solution_interpolated = InterpolatedSignal(self.time, self.solution)
@@ -313,7 +314,7 @@ class SolutionIO(SolutionBase):
         return self._solution_interpolated
 
     @property
-    def dm_dt_interpolated(self):
+    def dm_dt_interpolated(self) -> InterpolatedSignal:
         """Return the dm/dt interpolated signal."""
         if self._dm_dt_interpolated is None:
             dm_dt = self.solution * self.flow_rate.value(self.time)
@@ -535,7 +536,7 @@ class SolutionIO(SolutionBase):
         # Note, we do not use self.dm_dt_interpolated to better account for
         # discontinuities in the flow rate profile, by passing the section times to
         # `quad_vec`. Maybe this can be improved in the future.
-        def dm_dt(t, flow_rate, solution):
+        def dm_dt(t: float, flow_rate: np.ndarray, solution: np.ndarray) -> np.ndarray:
             dm_dt = flow_rate.value(t) * solution(t)
             return dm_dt
 
@@ -595,8 +596,8 @@ class SolutionIO(SolutionBase):
         y_max: Optional[float] = None,
         x_axis_in_minutes: Optional[bool] = True,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot the entire time_signal for each component.
@@ -621,6 +622,10 @@ class SolutionIO(SolutionBase):
             If True, the x-axis will be plotted using minutes.
         ax : Optional[Axes]
             Axes to plot on. If None, a new figure is created.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -863,14 +868,14 @@ class SolutionBulk(SolutionBase):
         super().__init__(name, component_system, time, solution)
 
     @property
-    def ncol(self):
+    def ncol(self) -> int:
         """int: Number of axial discretization points."""
         if self.axial_coordinates is None:
             return
         return len(self.axial_coordinates)
 
     @property
-    def nrad(self):
+    def nrad(self) -> int:
         """int: Number of radial discretization points."""
         if self.radial_coordinates is None:
             return
@@ -886,8 +891,8 @@ class SolutionBulk(SolutionBase):
         y_max: Optional[float] = None,
         x_axis_in_minutes: Optional[bool] = True,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot the entire time_signal for each component.
@@ -911,6 +916,10 @@ class SolutionBulk(SolutionBase):
             If True, the x-axis will be plotted using minutes.
         ax : Optional[Axes]
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -972,8 +981,8 @@ class SolutionBulk(SolutionBase):
         components: Optional[list[str]] = None,
         layout: Optional[plotting.Layout] = None,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot bulk solution over space at given time.
@@ -989,6 +998,10 @@ class SolutionBulk(SolutionBase):
             Plot layout options.
         ax : Optional[Axes]
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -1033,8 +1046,8 @@ class SolutionBulk(SolutionBase):
         layout: Optional[plotting.Layout] = None,
         x_axis_in_minutes: bool = True,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot bulk solution over time at given position.
@@ -1058,6 +1071,10 @@ class SolutionBulk(SolutionBase):
             If True, the x-axis will be plotted using minutes. The default is True.
         ax : Optional[Axes]
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -1187,8 +1204,8 @@ class SolutionParticle(SolutionBase):
         y_max: Optional[float] = None,
         x_axis_in_minutes: Optional[bool] = True,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot the entire particle liquid phase solution for each component.
@@ -1212,6 +1229,10 @@ class SolutionParticle(SolutionBase):
             If True, the x-axis will be plotted using minutes. The default is True.
         ax : Optional[Axes]
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -1269,8 +1290,8 @@ class SolutionParticle(SolutionBase):
         components: Optional[list[str]] = None,
         layout: Optional[plotting.Layout] = None,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot particle solution over space at given time.
@@ -1286,6 +1307,10 @@ class SolutionParticle(SolutionBase):
             Plot layout options.
         ax : Optional[Axes]
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -1320,7 +1345,13 @@ class SolutionParticle(SolutionBase):
 
         return ax
 
-    def _plot_2D(self, ax, t, comp=0, vmax=None):
+    def _plot_2D(
+        self,
+        ax: Axes,
+        t: float,
+        comp: int = 0,
+        vmax: Optional[float] = None,
+    ) -> Axes:
         x = self.axial_coordinates
         y = self.particle_coordinates
 
@@ -1356,7 +1387,7 @@ class SolutionParticle(SolutionBase):
         comp: Optional[int] = None,
         vmax: Optional[float] = None,
         ax: Optional[Axes] = None,
-    ):
+    ) -> Axes:
         """
         Plot particle liquid solution for a given component over space at given time.
 
@@ -1486,8 +1517,8 @@ class SolutionSolid(SolutionBase):
         y_max: Optional[float] = None,
         x_axis_in_minutes: Optional[bool] = True,
         ax: Optional[Axes] = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot the entire solid phase solution for each component.
@@ -1511,6 +1542,10 @@ class SolutionSolid(SolutionBase):
             If True, the x-axis will be plotted using minutes. The default is True.
         ax : Optional[Axes]
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -1568,8 +1603,8 @@ class SolutionSolid(SolutionBase):
         components: list[str] | None = None,
         layout: plotting.Layout | None = None,
         ax: Axes | None = None,
-        *args,
-        **kwargs,
+        *args: Any,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot solid solution over space at given time.
@@ -1587,6 +1622,10 @@ class SolutionSolid(SolutionBase):
             The default is None.
         ax : Axes
             Axes to plot on.
+        *args : Any
+            Optional arguments passed down to _plot_solution_1D.
+        **kwargs : Any
+            Optional arguments passed down to _plot_solution_1D.
 
         Returns
         -------
@@ -1621,7 +1660,14 @@ class SolutionSolid(SolutionBase):
 
         return ax
 
-    def _plot_2D(self, ax, t, comp, bound_state=0, vmax=None):
+    def _plot_2D(
+        self,
+        ax: Axes,
+        t: float,
+        comp: int,
+        bound_state: int = 0,
+        vmax: Optional[float] = None
+    ) -> tuple[Axes, QuadMesh]:
         x = self.axial_coordinates
         y = self.particle_coordinates
 
@@ -1657,7 +1703,7 @@ class SolutionSolid(SolutionBase):
         bound_state: Optional[int] = 0,
         vmax: Optional[float] = None,
         ax: Optional[Axes] = None,
-    ):
+    ) -> Axes:
         """
         Plot particle solid solution for a given bound state over space at given time.
 
@@ -1665,7 +1711,9 @@ class SolutionSolid(SolutionBase):
         ----------
         t : float
             Solution time at with to plot.
-        bound_state : Optional[int], default=0
+        comp : Optional[int], default=None
+            Number of components.
+        bound_state : int, default=0
             Bound state index.
         vmax: Optional[float]
             Maximum data value to scale color map.
@@ -1700,7 +1748,7 @@ class SolutionVolume(SolutionBase):
     """Volume solution (of e.g. CSTR)."""
 
     @property
-    def solution_shape(self):
+    def solution_shape(self) -> tuple[int, ...]:
         """tuple: (Expected) shape of the solution."""
         return (self.nt,)
 
@@ -1712,7 +1760,7 @@ class SolutionVolume(SolutionBase):
         x_axis_in_minutes: Optional[bool] = True,
         ax: Optional[Axes] = None,
         update_layout: Optional[bool] = True,
-        **kwargs,
+        **kwargs: Any,
     ) -> Axes:
         """
         Plot the unit operation"s volume over time.
@@ -1731,6 +1779,8 @@ class SolutionVolume(SolutionBase):
             Axes to plot on.
         update_layout : Optional[bool], default=True
             If True, update the figure"s layout.
+        **kwargs : Any
+            Additional arguments passed down to ax.plot()
 
         Returns
         -------
@@ -1770,21 +1820,18 @@ class SolutionVolume(SolutionBase):
 
 
 def _plot_solution_1D(
-    ax,
-    x,
-    solution,
-    layout=None,
-    plot_species=False,
-    plot_components=True,
-    plot_total_concentration=False,
-    alpha=1,
-    hide_labels=False,
-    hide_species_labels=False,
-    secondary_axis=None,
-    secondary_layout=None,
-    show_legend=True,
-    update_layout=True,
-):
+    ax: Axes,
+    x: np.ndarray,
+    solution: SolutionBase,
+    layout: Optional[Any] = None,
+    plot_species: bool = False,
+    plot_components: bool = True,
+    plot_total_concentration: bool = False,
+    alpha: int = 1, hide_labels: bool = False, hide_species_labels: bool = False,
+    secondary_axis: Optional[Axes] = None, secondary_layout: Optional[Any] = None,
+    show_legend: bool = True,
+    update_layout: bool = True,
+) -> Axes:
     sol = solution.solution
     c_total_comp = solution.total_concentration_components
 
@@ -1920,7 +1967,7 @@ def _plot_solution_1D(
 
 
 class InterpolatedSignal:
-    def __init__(self, time, signal):
+    def __init__(self, time: np.ndarray, signal: npt.ArrayLike) -> None:
         if len(signal.shape) == 1:
             signal = np.array(signal, ndmin=2).transpose()
         self._solutions = [
@@ -1960,7 +2007,7 @@ class InterpolatedSignal:
         return der
 
     @property
-    def antiderivatives(self):
+    def antiderivatives(self) -> list[PchipInterpolator]:
         """list[PchipInterpolator]: Antiderivative interpolators for each component."""
         return self._antiderivatives
 
@@ -2006,7 +2053,7 @@ class InterpolatedSignal:
         """
         return np.array([comp.integrate(start, end) for comp in self._solutions])
 
-    def __call__(self, t):
+    def __call__(self, t: float) -> np.ndarray:
         return np.array([comp(t) for comp in self._solutions]).transpose()
 
 

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -26,7 +26,8 @@ Method to slice a Solution:
    slice_solution
    slice_solution_front
 
-"""
+
+"""  # noqa
 
 from __future__ import annotations
 
@@ -269,6 +270,7 @@ class SolutionIO(SolutionBase):
         super().__init__(name, component_system, time, solution)
 
     def update_solution(self):
+        """Update solution method."""
         self._solution_interpolated = None
         self._dm_dt_interpolated = None
         self.update_transform()
@@ -294,6 +296,7 @@ class SolutionIO(SolutionBase):
         return antiderivative
 
     def update_transform(self) -> NoReturn:
+        """Update the Transformer."""
         self.transform = transform.NormLinearTransformer(
             np.min(self.solution, axis=0),
             np.max(self.solution, axis=0),
@@ -311,6 +314,7 @@ class SolutionIO(SolutionBase):
 
     @property
     def dm_dt_interpolated(self):
+        """Return the dm/dt interpolated signal."""
         if self._dm_dt_interpolated is None:
             dm_dt = self.solution * self.flow_rate.value(self.time)
             self._dm_dt_interpolated = InterpolatedSignal(self.time, dm_dt)
@@ -318,7 +322,7 @@ class SolutionIO(SolutionBase):
         return self._dm_dt_interpolated
 
     def normalize(self) -> "SolutionIO":
-        """ "SolutionIO: Normalize the solution using the transformation function."""
+        """"SolutionIO: Normalize the solution using the transformation function."""
         solution = copy.deepcopy(self)
 
         solution.solution = self.transform.transform(self.solution)
@@ -487,7 +491,6 @@ class SolutionIO(SolutionBase):
         -------
         Fraction
             a Fraction object in the interval [start, end]
-
         """
         if start is None:
             start = self.time[0]
@@ -507,7 +510,7 @@ class SolutionIO(SolutionBase):
         end: Optional[float] = None,
     ) -> np.ndarray:
         """
-        Component mass in a fraction interval
+        Component mass in a fraction interval.
 
         Parameters
         ----------
@@ -817,7 +820,6 @@ class SolutionBulk(SolutionBase):
     Solution in the bulk phase of the ``UnitOperation``.
 
     Dimensions: NCOL * NRAD * NCOMP
-
     """
 
     dimensions = SolutionBase.dimensions + [
@@ -1699,7 +1701,7 @@ class SolutionVolume(SolutionBase):
 
     @property
     def solution_shape(self):
-        """tuple: (Expected) shape of the solution"""
+        """tuple: (Expected) shape of the solution."""
         return (self.nt,)
 
     @plotting.create_and_save_figure
@@ -1939,7 +1941,7 @@ class InterpolatedSignal:
 
     def derivative(self, time: np.ndarray) -> np.ndarray:
         """
-        Derivatives of the solution spline(s) at given time points.
+        Calculate derivatives of the solution spline(s) at given time points.
 
         Parameters
         ----------

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -74,6 +74,7 @@ class StationarityEvaluator(Comparator):
         kwargs : dict
             Additional keyword arguments.
         """
+        # TODO: Check why cirteria are not stored.
         super().__init__(*args, **kwargs)
 
         self.logger = log.get_logger("StationarityEvaluator", level=log_level)

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -16,6 +16,8 @@ Module to evaluate cyclic stationarity of succeeding cycles.
 
 """  # noqa
 
+from typing import Any, Optional
+
 import numpy as np
 from addict import Dict
 
@@ -30,7 +32,7 @@ __all__ = ["RelativeArea", "NRMSE", "StationarityEvaluator"]
 class CriterionBase(Structure):
     threshold = UnsignedFloat(default=1e-3)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return self.__class__.__name__
 
 
@@ -52,12 +54,12 @@ class StationarityEvaluator(Comparator):
     valid_criteria = ["RelativeArea", "NRMSE"]
 
     def __init__(
-            self,
-            criteria=None,
-            log_level="WARNING",
-            *args,
-            **kwargs,
-    ):
+        self,
+        criteria: Optional[list[CriterionBase]] = None,
+        log_level: str = 'WARNING',
+        *args: Any,
+        **kwargs: Any,
+    ) -> None:
         """
         Initialize the stationarity evaluator.
 
@@ -79,11 +81,11 @@ class StationarityEvaluator(Comparator):
         self._criteria = []
 
     @property
-    def criteria(self):
+    def criteria(self) -> list:
         """list: List of criteria."""
         return self._criteria
 
-    def add_criterion(self, criterion):
+    def add_criterion(self, criterion: CriterionBase) -> None:
         """
         Add a criterion to the list of criteria.
 
@@ -97,7 +99,7 @@ class StationarityEvaluator(Comparator):
 
         self._criteria.append(criterion)
 
-    def assert_stationarity(self, simulation_results):
+    def assert_stationarity(self, simulation_results: SimulationResults) -> bool:
         """
         Check stationarity of two succeeding cycles.
 

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -14,7 +14,7 @@ Module to evaluate cyclic stationarity of succeeding cycles.
     NRMSE
     StationarityEvaluator
 
-"""
+"""  # noqa
 
 import numpy as np
 from addict import Dict
@@ -58,7 +58,8 @@ class StationarityEvaluator(Comparator):
             *args,
             **kwargs,
     ):
-        """Initialize the stationarity evaluator.
+        """
+        Initialize the stationarity evaluator.
 
         Parameters
         ----------
@@ -83,13 +84,13 @@ class StationarityEvaluator(Comparator):
         return self._criteria
 
     def add_criterion(self, criterion):
-        """Add a criterion to the list of criteria.
+        """
+        Add a criterion to the list of criteria.
 
         Parameters
         ----------
         criterion : CriterionBase
             Criterion to add to the list of criteria.
-
         """
         if not isinstance(criterion, CriterionBase):
             raise TypeError("Expected CriterionBase.")
@@ -97,7 +98,8 @@ class StationarityEvaluator(Comparator):
         self._criteria.append(criterion)
 
     def assert_stationarity(self, simulation_results):
-        """Check stationarity of two succeeding cycles.
+        """
+        Check stationarity of two succeeding cycles.
 
         Parameters
         ----------
@@ -113,7 +115,6 @@ class StationarityEvaluator(Comparator):
         ------
         TypeError
             If simulation_results is not a SimulationResults object.
-
         """
         self._metrics = []
         criteria = Dict()

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -16,17 +16,15 @@ Module to evaluate cyclic stationarity of succeeding cycles.
 
 """
 
-from addict import Dict
 import numpy as np
+from addict import Dict
 
-from CADETProcess import log
-from CADETProcess.dataStructure import Structure, UnsignedFloat
-from CADETProcess import SimulationResults
+from CADETProcess import SimulationResults, log
 from CADETProcess.comparison import Comparator
+from CADETProcess.dataStructure import Structure, UnsignedFloat
 from CADETProcess.processModel import Inlet
 
-
-__all__ = ['RelativeArea', 'NRMSE', 'StationarityEvaluator']
+__all__ = ["RelativeArea", "NRMSE", "StationarityEvaluator"]
 
 
 class CriterionBase(Structure):
@@ -51,13 +49,15 @@ class NRMSE(CriterionBase):
 class StationarityEvaluator(Comparator):
     """Class for checking two succeding chromatograms for stationarity."""
 
-    valid_criteria = ['RelativeArea', 'NRMSE']
+    valid_criteria = ["RelativeArea", "NRMSE"]
 
     def __init__(
             self,
             criteria=None,
-            log_level='WARNING',
-            *args, **kwargs):
+            log_level="WARNING",
+            *args,
+            **kwargs,
+    ):
         """Initialize the stationarity evaluator.
 
         Parameters
@@ -73,7 +73,7 @@ class StationarityEvaluator(Comparator):
         """
         super().__init__(*args, **kwargs)
 
-        self.logger = log.get_logger('StationarityEvaluator', level=log_level)
+        self.logger = log.get_logger("StationarityEvaluator", level=log_level)
 
         self._criteria = []
 
@@ -118,7 +118,7 @@ class StationarityEvaluator(Comparator):
         self._metrics = []
         criteria = Dict()
         if not isinstance(simulation_results, SimulationResults):
-            raise TypeError('Expcected SimulationResults')
+            raise TypeError("Expcected SimulationResults")
 
         stationarity = True
         for unit, solution in simulation_results.solution_cycles.items():
@@ -130,18 +130,18 @@ class StationarityEvaluator(Comparator):
 
             for c in self.criteria:
                 metric = self.add_difference_metric(
-                    str(c), unit, f'{unit}.outlet', smooth=False
+                    str(c), unit, f"{unit}.outlet", smooth=False
                 )
-                criteria[unit][str(c)]['threshold'] = c.threshold
+                criteria[unit][str(c)]["threshold"] = c.threshold
                 diff = metric.evaluate(solution_this)
-                criteria[unit][str(c)]['metric'] = diff
+                criteria[unit][str(c)]["metric"] = diff
                 if not np.all(diff <= c.threshold):
                     s = False
                     stationarity = s
                 else:
                     s = True
-                criteria[unit][str(c)]['stationarity'] = s
+                criteria[unit][str(c)]["stationarity"] = s
 
-        self.logger.debug(f'Stationrity criteria: {criteria}')
+        self.logger.debug(f"Stationrity criteria: {criteria}")
 
         return stationarity

--- a/CADETProcess/sysinfo.py
+++ b/CADETProcess/sysinfo.py
@@ -1,4 +1,5 @@
 import platform
+
 import psutil
 
 uname = platform.uname()
@@ -7,14 +8,13 @@ memory = psutil.virtual_memory()
 memory_total = psutil._common.bytes2human(memory.total)
 
 system_information = {
-    'system': uname.system,
-    'release': uname.release,
-    'machine': uname.machine,
-    'processor': uname.processor,
-    'n_cores': psutil.cpu_count(logical=True),
-    'n_cores_physical': psutil.cpu_count(logical=False),
-    'max_frequency': cpu_freq.max,
-    'min_frequency': cpu_freq.min,
-    'memory_total': memory_total,
-
+    "system": uname.system,
+    "release": uname.release,
+    "machine": uname.machine,
+    "processor": uname.processor,
+    "n_cores": psutil.cpu_count(logical=True),
+    "n_cores_physical": psutil.cpu_count(logical=False),
+    "max_frequency": cpu_freq.max,
+    "min_frequency": cpu_freq.min,
+    "memory_total": memory_total,
 }

--- a/CADETProcess/tools/yamamoto.py
+++ b/CADETProcess/tools/yamamoto.py
@@ -17,6 +17,8 @@ __all__ = [
 
 
 class GradientExperiment:
+    """Gradient Experiment Class."""
+
     def __init__(
         self,
         time: npt.ArrayLike,
@@ -305,7 +307,8 @@ class YamamotoResults:
 
 
 def fit_parameters(experiments, column):
-    """Fit parameters using Yamamoto's method.
+    """
+    Fit parameters using Yamamoto's method.
 
     Parameters
     ----------
@@ -318,7 +321,6 @@ def fit_parameters(experiments, column):
     -------
     yamamoto_results : YamamotoResults
         Parameter values.
-
     """
     if not isinstance(column, TubularReactorBase):
         raise TypeError("Expected Column Model.")

--- a/CADETProcess/tools/yamamoto.py
+++ b/CADETProcess/tools/yamamoto.py
@@ -1,32 +1,31 @@
 from typing import NoReturn, Optional
 
+import matplotlib.pyplot as plt
 import numpy as np
 import numpy.typing as npt
-import matplotlib.pyplot as plt
 from scipy.optimize import curve_fit
 
 from CADETProcess import CADETProcessError
-from CADETProcess.processModel import TubularReactorBase, StericMassAction
-
+from CADETProcess.processModel import StericMassAction, TubularReactorBase
 
 __all__ = [
-    'GradientExperiment',
-    'plot_experiments',
-    'YamamotoResults',
-    'fit_parameters'
+    "GradientExperiment",
+    "plot_experiments",
+    "YamamotoResults",
+    "fit_parameters",
 ]
 
 
-class GradientExperiment():
+class GradientExperiment:
     def __init__(
-            self,
-            time: npt.ArrayLike,
-            c_salt: npt.ArrayLike,
-            c_protein: npt.ArrayLike,
-            gradient_volume: float,
-            c_salt_start: Optional[float] = None,
-            c_salt_end: Optional[float] = None
-            ) -> NoReturn:
+        self,
+        time: npt.ArrayLike,
+        c_salt: npt.ArrayLike,
+        c_protein: npt.ArrayLike,
+        gradient_volume: float,
+        c_salt_start: Optional[float] = None,
+        c_salt_end: Optional[float] = None,
+    ) -> NoReturn:
         """
         Initialize a GradientExperiment instance.
 
@@ -82,10 +81,8 @@ class GradientExperiment():
         return self.time[max_c_protein]
 
     def calculate_normalized_gradient_slope(
-            self,
-            column_volume,
-            total_porosity
-            ) -> float:
+        self, column_volume, total_porosity
+    ) -> float:
         """
         Calculate normalized concentration gradient slope.
 
@@ -102,15 +99,15 @@ class GradientExperiment():
             Gradient slope in mM.
         """
         slope = (self.c_salt_end - self.c_salt_start) / self.gradient_volume
-        vol_factor = column_volume - total_porosity*column_volume
+        vol_factor = column_volume - total_porosity * column_volume
         return slope * vol_factor
 
     def plot(
-            self,
-            fig: Optional[plt.Figure] = None,
-            ax: Optional[plt.Axes] = None,
-            sec_ax: Optional[plt.Axes] = None,
-            ) -> tuple[plt.Figure, plt.Axes, plt.Axes]:
+        self,
+        fig: Optional[plt.Figure] = None,
+        ax: Optional[plt.Axes] = None,
+        sec_ax: Optional[plt.Axes] = None,
+    ) -> tuple[plt.Figure, plt.Axes, plt.Axes]:
         """
         Plot the gradient experiment data.
 
@@ -135,18 +132,18 @@ class GradientExperiment():
         if ax is None:
             fig, ax = plt.subplots()
 
-            ax.set_xlabel('$Time / s$')
-            ax.set_ylabel('$c_{Protein} / mM$')
+            ax.set_xlabel("$Time / s$")
+            ax.set_ylabel("$c_{Protein} / mM$")
 
             sec_ax = ax.twinx()
-            sec_ax.set_ylabel('$c_{Salt} / mM$')
+            sec_ax.set_ylabel("$c_{Salt} / mM$")
 
-        ax.plot(self.time, self.c_protein, label='Protein')
+        ax.plot(self.time, self.c_protein, label="Protein")
 
         c_p_max = np.max(self.c_protein, axis=0)
-        ax.vlines(self.t_at_max, ymin=0, ymax=c_p_max, color='k', linestyle='--')
-        sec_ax.plot(self.time, self.c_salt, 'k', label='Salt')
-        sec_ax.plot(self.t_at_max, self.c_salt_at_max, 'ro')
+        ax.vlines(self.t_at_max, ymin=0, ymax=c_p_max, color="k", linestyle="--")
+        sec_ax.plot(self.time, self.c_salt, "k", label="Salt")
+        sec_ax.plot(self.t_at_max, self.c_salt_at_max, "ro")
 
         fig.tight_layout()
 
@@ -169,11 +166,11 @@ def plot_experiments(experiments: list[GradientExperiment]):
 
 
 def yamamoto_equation(
-        log_c_salt_at_max_M: float,
-        lambda_: float,
-        nu: float,
-        k_eq: float,
-        ) -> np.ndarray:
+    log_c_salt_at_max_M: float,
+    lambda_: float,
+    nu: float,
+    k_eq: float,
+) -> np.ndarray:
     r"""
     Calculate the theoretical normalized gradient slope using Yamamoto's method.
 
@@ -212,21 +209,23 @@ def yamamoto_equation(
     np.ndarray
         Calculated normalized gradient slope (GH) values in logarithmic scale.
     """
-    lambda_M = lambda_/1000
+    lambda_M = lambda_ / 1000
 
-    return np.multiply((nu + 1), log_c_salt_at_max_M) - np.log10(k_eq * lambda_M**nu * (nu + 1))
+    return np.multiply((nu + 1), log_c_salt_at_max_M) - np.log10(
+        k_eq * lambda_M**nu * (nu + 1)
+    )
 
 
 class YamamotoResults:
     """Parameter values determined using Yamamoto's method."""
 
     def __init__(
-            self,
-            column,
-            experiments: list[GradientExperiment],
-            log_gradient_slope: npt.ArrayLike,
-            log_c_salt_at_max_M: npt.ArrayLike,
-            ) -> NoReturn:
+        self,
+        column,
+        experiments: list[GradientExperiment],
+        log_gradient_slope: npt.ArrayLike,
+        log_c_salt_at_max_M: npt.ArrayLike,
+    ) -> NoReturn:
         """
         Initialize YamamotoResults with column, experiments, and log-transformed data.
 
@@ -257,10 +256,8 @@ class YamamotoResults:
         return np.array(self.column.binding_model.adsorption_rate[1:])
 
     def plot(
-            self,
-            fig: Optional[plt.Figure] = None,
-            ax: Optional[plt.Axes] = None
-            ) -> tuple[plt.Figure, plt.Axes]:
+        self, fig: Optional[plt.Figure] = None, ax: Optional[plt.Axes] = None
+    ) -> tuple[plt.Figure, plt.Axes]:
         """
         Plot the normalized gradient slope against the peak salt concentration.
 
@@ -280,8 +277,8 @@ class YamamotoResults:
         """
         if ax is None:
             fig, ax = plt.subplots()
-            ax.set_ylabel('Normalized Gradient Slope $GH$ / $M$')
-            ax.set_xlabel('Peak Salt Concentration $I_R$ / $M$')
+            ax.set_ylabel("Normalized Gradient Slope $GH$ / $M$")
+            ax.set_xlabel("Peak Salt Concentration $I_R$ / $M$")
 
         n_proteins = self.experiments[0].n_proteins
 
@@ -291,7 +288,7 @@ class YamamotoResults:
 
             x = [
                 min(self.log_c_salt_at_max_M[:, i_p]) * 1.05,
-                max(self.log_c_salt_at_max_M[:, i_p]) * 0.95
+                max(self.log_c_salt_at_max_M[:, i_p]) * 0.95,
             ]
 
             y = yamamoto_equation(
@@ -300,8 +297,8 @@ class YamamotoResults:
                 nu=nu,
                 k_eq=k_eq,
             )
-            ax.plot(x, y, 'k')
-            ax.plot(self.log_c_salt_at_max_M[:, i_p], self.log_gradient_slope, 'ro')
+            ax.plot(x, y, "k")
+            ax.plot(self.log_c_salt_at_max_M[:, i_p], self.log_gradient_slope, "ro")
 
         fig.tight_layout()
         return fig, ax
@@ -342,34 +339,36 @@ def fit_parameters(experiments, column):
 
     nu = np.zeros((experiments[0].n_proteins,))
     k_eq = np.zeros((experiments[0].n_proteins,))
-    log_c_salt_at_max_M = np.zeros((len(experiments), experiments[0].n_proteins,))
+    log_c_salt_at_max_M = np.zeros(
+        (
+            len(experiments),
+            experiments[0].n_proteins,
+        )
+    )
 
     for i_p in range(experiments[0].n_proteins):
         c_salt_at_max = [exp.c_salt_at_max[i_p] for exp in experiments]
-        log_c_salt_at_max_M[:, i_p] = np.log10(np.array(c_salt_at_max)/1000)
+        log_c_salt_at_max_M[:, i_p] = np.log10(np.array(c_salt_at_max) / 1000)
 
         nu[i_p], k_eq[i_p] = _fit_yamamoto(
             log_c_salt_at_max_M[:, i_p],
             log_gradient_slope,
-            column.binding_model.capacity
+            column.binding_model.capacity,
         )
 
     column.binding_model.characteristic_charge = [0, *nu.tolist()]
     column.binding_model.adsorption_rate = [0, *k_eq.tolist()]
 
     yamamoto_results = YamamotoResults(
-        column, experiments,
-        log_gradient_slope, log_c_salt_at_max_M
-        )
+        column, experiments, log_gradient_slope, log_c_salt_at_max_M
+    )
 
     return yamamoto_results
 
 
 def _fit_yamamoto(
-        log_c_salt_at_max_M: np.ndarray,
-        log_gradient_slope: np.ndarray,
-        lambda_: float
-        ) -> tuple[float, float]:
+    log_c_salt_at_max_M: np.ndarray, log_gradient_slope: np.ndarray, lambda_: float
+) -> tuple[float, float]:
     """
     Fit the Yamamoto model to experimental data using non-linear curve fitting.
 
@@ -399,7 +398,7 @@ def _fit_yamamoto(
         log_c_salt_at_max_M,
         log_gradient_slope,
         bounds=bounds,
-        p0=(1, 1)
+        p0=(1, 1),
     )
 
     return results

--- a/CADETProcess/tools/yamamoto.py
+++ b/CADETProcess/tools/yamamoto.py
@@ -1,4 +1,4 @@
-from typing import NoReturn, Optional
+from typing import Callable, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -6,7 +6,11 @@ import numpy.typing as npt
 from scipy.optimize import curve_fit
 
 from CADETProcess import CADETProcessError
-from CADETProcess.processModel import StericMassAction, TubularReactorBase
+from CADETProcess.processModel import (
+    ChromatographicColumnBase,
+    StericMassAction,
+    TubularReactorBase,
+)
 
 __all__ = [
     "GradientExperiment",
@@ -27,7 +31,7 @@ class GradientExperiment:
         gradient_volume: float,
         c_salt_start: Optional[float] = None,
         c_salt_end: Optional[float] = None,
-    ) -> NoReturn:
+    ) -> None:
         """
         Initialize a GradientExperiment instance.
 
@@ -83,7 +87,9 @@ class GradientExperiment:
         return self.time[max_c_protein]
 
     def calculate_normalized_gradient_slope(
-        self, column_volume, total_porosity
+        self,
+        column_volume: float,
+        total_porosity: float
     ) -> float:
         """
         Calculate normalized concentration gradient slope.
@@ -152,7 +158,7 @@ class GradientExperiment:
         return fig, ax, sec_ax
 
 
-def plot_experiments(experiments: list[GradientExperiment]):
+def plot_experiments(experiments: list[GradientExperiment]) -> None:
     """
     Plot multiple gradient experiments in a single figure.
 
@@ -223,11 +229,11 @@ class YamamotoResults:
 
     def __init__(
         self,
-        column,
+        column: ChromatographicColumnBase,
         experiments: list[GradientExperiment],
         log_gradient_slope: npt.ArrayLike,
         log_c_salt_at_max_M: npt.ArrayLike,
-    ) -> NoReturn:
+        ) -> None:
         """
         Initialize YamamotoResults with column, experiments, and log-transformed data.
 
@@ -306,7 +312,7 @@ class YamamotoResults:
         return fig, ax
 
 
-def fit_parameters(experiments, column):
+def fit_parameters(experiments: list, column: ChromatographicColumnBase) -> YamamotoResults:
     """
     Fit parameters using Yamamoto's method.
 
@@ -392,7 +398,7 @@ def _fit_yamamoto(
     """
     bounds = ((0, 1e-10), (1000, 1000))
 
-    def yamamoto_wrapper(c_s, nu, k_eq):
+    def yamamoto_wrapper(c_s: float, nu: float, k_eq: float) -> Callable:
         return yamamoto_equation(c_s, lambda_, nu, k_eq)
 
     results, pcov = curve_fit(

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -20,7 +20,7 @@ This module provides functionality for transforming data.
 """  # noqa
 
 from abc import ABC, abstractmethod
-from typing import NoReturn, Optional
+from typing import Any, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -78,9 +78,9 @@ class TransformerBase(ABC):
         self,
         lb_input: float | np.ndarray = -np.inf,
         ub_input: float | np.ndarray = np.inf,
-        allow_extended_input: bool = False,
-        allow_extended_output: bool = False,
-    ) -> NoReturn:
+        allow_extended_input: Optional[bool] = False,
+        allow_extended_output: Optional[bool] = False,
+    ) -> None:
         """
         Initialize TransformerBase.
 
@@ -114,7 +114,7 @@ class TransformerBase(ABC):
         return self._lb_input
 
     @lb_input.setter
-    def lb_input(self, lb_input: float | np.ndarray) -> NoReturn:
+    def lb_input(self, lb_input: float | np.ndarray) -> None:
         self._lb_input = lb_input
 
     @property
@@ -123,7 +123,7 @@ class TransformerBase(ABC):
         return self._ub_input
 
     @ub_input.setter
-    def ub_input(self, ub_input: float | np.ndarray) -> NoReturn:
+    def ub_input(self, ub_input: float | np.ndarray) -> None:
         self._ub_input = ub_input
 
     @property
@@ -256,7 +256,7 @@ class TransformerBase(ABC):
         pass
 
     @plotting.create_and_save_figure
-    def plot(self, ax: plt.Axes, use_log_scale: bool = False) -> NoReturn:
+    def plot(self, ax: plt.Axes, use_log_scale: bool = False) -> None:
         """
         Plot the transformed space against the input space.
 
@@ -507,7 +507,7 @@ class AutoTransformer(TransformerBase):
     NormLogTransformer
     """
 
-    def __init__(self, *args, threshold: int = 100, **kwargs) -> NoReturn:
+    def __init__(self, *args: Any, threshold: int = 100, **kwargs: Any) -> None:
         """
         Initialize an AutoTransformer object.
 
@@ -517,7 +517,7 @@ class AutoTransformer(TransformerBase):
             Arguments for the :class:`TransformerBase` class.
         threshold : int, optional
             The maximum threshold to switch from linear to logarithmic
-            transformation. The default is 1000.
+            transformation. The default is 100.
         **kwargs : dict
             Keyword arguments for the :class:`TransformerBase` class.
         """
@@ -565,7 +565,7 @@ class AutoTransformer(TransformerBase):
         return self._lb_input
 
     @lb_input.setter
-    def lb_input(self, lb_input: float | np.ndarray) -> NoReturn:
+    def lb_input(self, lb_input: float | np.ndarray) -> None:
         """Set the lower bounds of the input parameter space."""
         self.linear.lb_input = lb_input
         self.log.lb_input = lb_input
@@ -577,7 +577,7 @@ class AutoTransformer(TransformerBase):
         return self._ub_input
 
     @ub_input.setter
-    def ub_input(self, ub_input: float | np.ndarray) -> NoReturn:
+    def ub_input(self, ub_input: float | np.ndarray) -> None:
         """Set the upper bounds of the input parameter space."""
         self.linear.ub_input = ub_input
         self.log.ub_input = ub_input

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -20,7 +20,7 @@ This module provides functionality for transforming data.
 """
 
 from abc import ABC, abstractmethod
-from typing import NoReturn, Optional, Union
+from typing import NoReturn, Optional
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -75,12 +75,12 @@ class TransformerBase(ABC):
     """
 
     def __init__(
-            self,
-            lb_input: float | np.ndarray = -np.inf,
-            ub_input: float | np.ndarray = np.inf,
-            allow_extended_input: bool = False,
-            allow_extended_output: bool = False
-            ) -> NoReturn:
+        self,
+        lb_input: float | np.ndarray = -np.inf,
+        ub_input: float | np.ndarray = np.inf,
+        allow_extended_input: bool = False,
+        allow_extended_output: bool = False,
+    ) -> NoReturn:
         """Initialize TransformerBase.
 
         Parameters
@@ -159,17 +159,15 @@ class TransformerBase(ABC):
         ValueError
             If `x` exceeds input or output bounds and `allow_extended_*` is False.
         """
-        if (
-            not self.allow_extended_input and
-            not np.all((self.lb_input <= x) & (x <= self.ub_input))
+        if not self.allow_extended_input and not np.all(
+            (self.lb_input <= x) & (x <= self.ub_input)
         ):
             raise ValueError("Value exceeds input bounds.")
 
         x = self._transform(x)
 
-        if (
-            not self.allow_extended_output and
-            not np.all((self.lb <= x) & (x <= self.ub))
+        if not self.allow_extended_output and not np.all(
+            (self.lb <= x) & (x <= self.ub)
         ):
             raise ValueError("Value exceeds output bounds.")
 
@@ -194,10 +192,10 @@ class TransformerBase(ABC):
         pass
 
     def untransform(
-            self,
-            x: float | np.ndarray,
-            significant_digits: Optional[int] = None
-            ) -> float | np.ndarray:
+        self,
+        x: float | np.ndarray,
+        significant_digits: Optional[int] = None,
+    ) -> float | np.ndarray:
         """Transform the output parameter space back to the input parameter space.
 
         Parameters
@@ -216,7 +214,8 @@ class TransformerBase(ABC):
         x_ = round_to_significant_digits(x, digits=significant_digits)
 
         if (
-            not self.allow_extended_output and
+            not self.allow_extended_output
+            and
             not np.all((self.lb <= x_) & (x_ <= self.ub))
         ):
             raise ValueError("Value exceeds output bounds.")
@@ -225,7 +224,8 @@ class TransformerBase(ABC):
         x_ = round_to_significant_digits(x_, digits=significant_digits)
 
         if (
-            not self.allow_extended_input and
+            not self.allow_extended_input
+            and
             not np.all((self.lb_input <= x_) & (x_ <= self.ub_input))
         ):
             raise ValueError("Value exceeds input bounds.")
@@ -459,8 +459,11 @@ class NormLogTransformer(TransformerBase):
             The untransformed input value(s) in the original range.
         """
         if self.lb_input <= 0:
-            return \
-                np.exp(x * np.log(self.ub_input - self.lb_input + 1)) + self.lb_input - 1
+            return (
+                np.exp(x * np.log(self.ub_input - self.lb_input + 1))
+                + self.lb_input
+                - 1
+            )
         else:
             return self.lb_input * np.exp(x * np.log(self.ub_input / self.lb_input))
 

--- a/CADETProcess/transform.py
+++ b/CADETProcess/transform.py
@@ -17,7 +17,7 @@ This module provides functionality for transforming data.
     NormLogTransformer
     AutoTransformer
 
-"""
+"""  # noqa
 
 from abc import ABC, abstractmethod
 from typing import NoReturn, Optional
@@ -81,7 +81,8 @@ class TransformerBase(ABC):
         allow_extended_input: bool = False,
         allow_extended_output: bool = False,
     ) -> NoReturn:
-        """Initialize TransformerBase.
+        """
+        Initialize TransformerBase.
 
         Parameters
         ----------
@@ -138,7 +139,8 @@ class TransformerBase(ABC):
         pass
 
     def transform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Transform the input parameter space to the output parameter space.
+        """
+        Transform the input parameter space to the output parameter space.
 
         Applies the transformation function `_transform` to `x` after performing input
         bounds checking. If the transformed value exceeds the output bounds, an error
@@ -175,7 +177,8 @@ class TransformerBase(ABC):
 
     @abstractmethod
     def _transform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Apply the transformation from input to output parameter space.
+        """
+        Apply the transformation from input to output parameter space.
 
         Must be implemented in the child class.
 
@@ -196,7 +199,8 @@ class TransformerBase(ABC):
         x: float | np.ndarray,
         significant_digits: Optional[int] = None,
     ) -> float | np.ndarray:
-        """Transform the output parameter space back to the input parameter space.
+        """
+        Transform the output parameter space back to the input parameter space.
 
         Parameters
         ----------
@@ -234,7 +238,8 @@ class TransformerBase(ABC):
 
     @abstractmethod
     def _untransform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Apply the inverse transformation from output to input parameter space.
+        """
+        Apply the inverse transformation from output to input parameter space.
 
         Must be implemented in the child class.
 
@@ -252,7 +257,8 @@ class TransformerBase(ABC):
 
     @plotting.create_and_save_figure
     def plot(self, ax: plt.Axes, use_log_scale: bool = False) -> NoReturn:
-        """Plot the transformed space against the input space.
+        """
+        Plot the transformed space against the input space.
 
         Parameters
         ----------
@@ -282,7 +288,8 @@ class TransformerBase(ABC):
 
 
 class NullTransformer(TransformerBase):
-    """A transformer that performs no transformation.
+    """
+    A transformer that performs no transformation.
 
     This class simply returns the input values as output without modification.
 
@@ -307,7 +314,8 @@ class NullTransformer(TransformerBase):
         return self.ub_input
 
     def _transform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Return the input value(s) as output without modification.
+        """
+        Return the input value(s) as output without modification.
 
         Parameters
         ----------
@@ -322,7 +330,8 @@ class NullTransformer(TransformerBase):
         return x
 
     def _untransform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Return the output value(s) as input without modification.
+        """
+        Return the output value(s) as input without modification.
 
         Parameters
         ----------
@@ -338,7 +347,8 @@ class NullTransformer(TransformerBase):
 
 
 class NormLinearTransformer(TransformerBase):
-    """A transformer that normalizes values linearly to the range [0, 1].
+    """
+    A transformer that normalizes values linearly to the range [0, 1].
 
     This transformation scales the input value between the given lower
     and upper bounds into a normalized range of [0,1].
@@ -364,7 +374,8 @@ class NormLinearTransformer(TransformerBase):
         return 1.0
 
     def _transform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Normalize input values to the range [0,1].
+        """
+        Normalize input values to the range [0,1].
 
         Parameters
         ----------
@@ -379,7 +390,8 @@ class NormLinearTransformer(TransformerBase):
         return (x - self.lb_input) / (self.ub_input - self.lb_input)
 
     def _untransform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Denormalize output values back to the original range.
+        """
+        Denormalize output values back to the original range.
 
         Parameters
         ----------
@@ -395,7 +407,8 @@ class NormLinearTransformer(TransformerBase):
 
 
 class NormLogTransformer(TransformerBase):
-    """A transformer that normalizes values logarithmically to the range [0, 1].
+    """
+    A transformer that normalizes values logarithmically to the range [0, 1].
 
     This transformation scales input values logarithmically between the given lower
     and upper bounds into a normalized range of [0,1].
@@ -421,7 +434,8 @@ class NormLogTransformer(TransformerBase):
         return 1.0
 
     def _transform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Normalize input values to the range [0,1] using a logarithmic transformation.
+        """
+        Normalize input values to the range [0,1] using a logarithmic transformation.
 
         Parameters
         ----------
@@ -446,7 +460,8 @@ class NormLogTransformer(TransformerBase):
             return np.log(x / self.lb_input) / np.log(self.ub_input / self.lb_input)
 
     def _untransform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Denormalize output values back to the original range using logarithmic inverse.
+        """
+        Denormalize output values back to the original range using logarithmic inverse.
 
         Parameters
         ----------
@@ -493,7 +508,8 @@ class AutoTransformer(TransformerBase):
     """
 
     def __init__(self, *args, threshold: int = 100, **kwargs) -> NoReturn:
-        """Initialize an AutoTransformer object.
+        """
+        Initialize an AutoTransformer object.
 
         Parameters
         ----------
@@ -568,7 +584,8 @@ class AutoTransformer(TransformerBase):
         self._ub_input = ub_input
 
     def _transform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Transform the input value to an output value in the range [0, 1].
+        """
+        Transform the input value to an output value in the range [0, 1].
 
         Parameters
         ----------
@@ -583,7 +600,8 @@ class AutoTransformer(TransformerBase):
         return self.log._transform(x) if self.use_log else self.linear._transform(x)
 
     def _untransform(self, x: float | np.ndarray) -> float | np.ndarray:
-        """Untransform the output value back to the input parameter space.
+        """
+        Untransform the output value back to the input parameter space.
 
         Parameters
         ----------

--- a/examples/batch_elution/optimization_multi.md
+++ b/examples/batch_elution/optimization_multi.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -96,6 +96,7 @@ def callback(fractionation, individual, evaluation_object, callbacks_dir):
         file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_fractionation.png',
         show=False
     )
+
 
 optimization_problem.add_callback(
     callback, requires=[process_simulator, frac_opt]

--- a/examples/batch_elution/optimization_multi.py
+++ b/examples/batch_elution/optimization_multi.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -99,6 +99,7 @@ def callback(fractionation, individual, evaluation_object, callbacks_dir):
         file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_fractionation.png',
         show=False
     )
+
 
 optimization_problem.add_callback(
     callback, requires=[process_simulator, frac_opt]

--- a/examples/batch_elution/optimization_single.md
+++ b/examples/batch_elution/optimization_single.md
@@ -1,12 +1,12 @@
 ---
 jupytext:
   formats: md:myst,py:percent
-  main_language: python
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
+  main_language: python
 kernelspec:
   display_name: Python 3
   name: python3
@@ -66,6 +66,7 @@ def callback(fractionation, individual, evaluation_object, callbacks_dir):
         file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_fractionation.png',
         show=False
     )
+
 
 optimization_problem.add_callback(
     callback, requires=[process_simulator, frac_opt]

--- a/examples/batch_elution/optimization_single.py
+++ b/examples/batch_elution/optimization_single.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -68,6 +68,7 @@ def callback(fractionation, individual, evaluation_object, callbacks_dir):
         file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_fractionation.png',
         show=False
     )
+
 
 optimization_problem.add_callback(
     callback, requires=[process_simulator, frac_opt]

--- a/examples/batch_elution/process.md
+++ b/examples/batch_elution/process.md
@@ -1,12 +1,12 @@
 ---
 jupytext:
   formats: md:myst,py:percent
-  main_language: python
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
+  main_language: python
 kernelspec:
   display_name: Python 3
   name: python3
@@ -101,7 +101,7 @@ Events of batch elution process.
 from CADETProcess.processModel import Process
 process = Process(flow_sheet, 'batch elution')
 
-Q = 60/(60*1e6)
+Q = 60 / (60 * 1e6)
 process.add_event('feed_on', 'flow_sheet.feed.flow_rate', Q)
 process.add_event('feed_off', 'flow_sheet.feed.flow_rate', 0.0)
 

--- a/examples/batch_elution/process.py
+++ b/examples/batch_elution/process.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -102,7 +102,7 @@ flow_sheet.add_connection(column, outlet)
 from CADETProcess.processModel import Process
 process = Process(flow_sheet, 'batch elution')
 
-Q = 60/(60*1e6)
+Q = 60 / (60 * 1e6)
 process.add_event('feed_on', 'flow_sheet.feed.flow_rate', Q)
 process.add_event('feed_off', 'flow_sheet.feed.flow_rate', 0.0)
 

--- a/examples/characterize_chromatographic_system/Yamamoto_method.md
+++ b/examples/characterize_chromatographic_system/Yamamoto_method.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -30,7 +30,7 @@ using the Yamamoto method.
 ```{code-cell}
 import numpy as np
 
-from CADETProcess.processModel import ComponentSystem, StericMassAction, LumpedRateModelWithPores
+from CADETProcess.processModel import ComponentSystem
 from CADETProcess.tools.yamamoto import GradientExperiment, fit_parameters
 
 from binding_model_parameters import create_column_model, create_in_silico_experimental_data

--- a/examples/characterize_chromatographic_system/Yamamoto_method.py
+++ b/examples/characterize_chromatographic_system/Yamamoto_method.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -29,7 +29,7 @@ sys.path.append(root_dir.as_posix())
 # %%
 import numpy as np
 
-from CADETProcess.processModel import ComponentSystem, StericMassAction, LumpedRateModelWithPores
+from CADETProcess.processModel import ComponentSystem
 from CADETProcess.tools.yamamoto import GradientExperiment, fit_parameters
 
 from binding_model_parameters import create_column_model, create_in_silico_experimental_data

--- a/examples/characterize_chromatographic_system/binding_model_parameters.md
+++ b/examples/characterize_chromatographic_system/binding_model_parameters.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3 (ipykernel)
   language: python
@@ -290,7 +290,6 @@ if __name__ == '__main__':
         transform=lambda k_kin, k_eq: k_eq / k_kin
     )
 
-
     def callback(simulation_results, individual, evaluation_object, callbacks_dir='./'):
         comparator = comparators[evaluation_object.name]
         comparator.plot_comparison(
@@ -298,7 +297,6 @@ if __name__ == '__main__':
             file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_comparison.png',
             show=False
         )
-
 
     optimization_problem.add_callback(callback, requires=[simulator])
 

--- a/examples/characterize_chromatographic_system/binding_model_parameters.py
+++ b/examples/characterize_chromatographic_system/binding_model_parameters.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3 (ipykernel)
 #     language: python
@@ -292,7 +292,6 @@ if __name__ == '__main__':
         transform=lambda k_kin, k_eq: k_eq / k_kin
     )
 
-
     def callback(simulation_results, individual, evaluation_object, callbacks_dir='./'):
         comparator = comparators[evaluation_object.name]
         comparator.plot_comparison(
@@ -300,7 +299,6 @@ if __name__ == '__main__':
             file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_comparison.png',
             show=False
         )
-
 
     optimization_problem.add_callback(callback, requires=[simulator])
 

--- a/examples/characterize_chromatographic_system/column_transport_parameters.md
+++ b/examples/characterize_chromatographic_system/column_transport_parameters.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -108,11 +108,11 @@ flow_sheet.add_connection(column, outlet)
 from CADETProcess.processModel import Process
 
 Q_ml_min = 0.5  # ml/min
-Q_m3_s = Q_ml_min/(60*1e6)
+Q_m3_s = Q_ml_min / (60 * 1e6)
 V_tracer = 50e-9  # m3
 
 process = Process(flow_sheet, 'Tracer')
-process.cycle_time = 15*60
+process.cycle_time = 15 * 60
 
 process.add_event(
     'feed_on',
@@ -123,14 +123,14 @@ process.add_event(
     'feed_off',
     'flow_sheet.feed.flow_rate',
     0,
-    V_tracer/Q_m3_s
+    V_tracer / Q_m3_s
 )
 
 process.add_event(
     'feed_water_on',
     'flow_sheet.eluent.flow_rate',
      Q_m3_s,
-     V_tracer/Q_m3_s
+     V_tracer / Q_m3_s
 )
 
 process.add_event(
@@ -194,6 +194,7 @@ optimization_problem.add_objective(
     n_objectives=comparator.n_metrics,
     requires=[simulator]
 )
+
 
 def callback(simulation_results, individual, evaluation_object, callbacks_dir='./'):
     comparator.plot_comparison(

--- a/examples/characterize_chromatographic_system/column_transport_parameters.py
+++ b/examples/characterize_chromatographic_system/column_transport_parameters.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -104,11 +104,11 @@ flow_sheet.add_connection(column, outlet)
 from CADETProcess.processModel import Process
 
 Q_ml_min = 0.5  # ml/min
-Q_m3_s = Q_ml_min/(60*1e6)
+Q_m3_s = Q_ml_min / (60 * 1e6)
 V_tracer = 50e-9  # m3
 
 process = Process(flow_sheet, 'Tracer')
-process.cycle_time = 15*60
+process.cycle_time = 15 * 60
 
 process.add_event(
     'feed_on',
@@ -119,14 +119,14 @@ process.add_event(
     'feed_off',
     'flow_sheet.feed.flow_rate',
     0,
-    V_tracer/Q_m3_s
+    V_tracer / Q_m3_s
 )
 
 process.add_event(
     'feed_water_on',
     'flow_sheet.eluent.flow_rate',
      Q_m3_s,
-     V_tracer/Q_m3_s
+     V_tracer / Q_m3_s
 )
 
 process.add_event(
@@ -190,6 +190,7 @@ optimization_problem.add_objective(
     n_objectives=comparator.n_metrics,
     requires=[simulator]
 )
+
 
 def callback(simulation_results, individual, evaluation_object, callbacks_dir='./'):
     comparator.plot_comparison(

--- a/examples/characterize_chromatographic_system/particle_porosity.md
+++ b/examples/characterize_chromatographic_system/particle_porosity.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -88,11 +88,11 @@ flow_sheet.add_connection(column, outlet)
 from CADETProcess.processModel import Process
 
 Q_ml_min = 0.5  # ml/min
-Q_m3_s = Q_ml_min/(60*1e6)
+Q_m3_s = Q_ml_min / (60 * 1e6)
 V_tracer = 50e-9  # m3
 
 process = Process(flow_sheet, 'Tracer')
-process.cycle_time = 15*60
+process.cycle_time = 15 * 60
 
 process.add_event(
     'feed_on',
@@ -103,14 +103,14 @@ process.add_event(
     'feed_off',
     'flow_sheet.feed.flow_rate',
     0,
-    V_tracer/Q_m3_s
+    V_tracer / Q_m3_s
 )
 
 process.add_event(
     'feed_water_on',
     'flow_sheet.eluent.flow_rate',
      Q_m3_s,
-     V_tracer/Q_m3_s
+     V_tracer / Q_m3_s
 )
 
 process.add_event(
@@ -170,6 +170,7 @@ optimization_problem.add_objective(
     n_objectives=comparator.n_metrics,
     requires=[simulator]
 )
+
 
 def callback(simulation_results, individual, evaluation_object, callbacks_dir='./'):
     comparator.plot_comparison(

--- a/examples/characterize_chromatographic_system/particle_porosity.py
+++ b/examples/characterize_chromatographic_system/particle_porosity.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -87,11 +87,11 @@ flow_sheet.add_connection(column, outlet)
 from CADETProcess.processModel import Process
 
 Q_ml_min = 0.5  # ml/min
-Q_m3_s = Q_ml_min/(60*1e6)
+Q_m3_s = Q_ml_min / (60 * 1e6)
 V_tracer = 50e-9  # m3
 
 process = Process(flow_sheet, 'Tracer')
-process.cycle_time = 15*60
+process.cycle_time = 15 * 60
 
 process.add_event(
     'feed_on',
@@ -102,14 +102,14 @@ process.add_event(
     'feed_off',
     'flow_sheet.feed.flow_rate',
     0,
-    V_tracer/Q_m3_s
+    V_tracer / Q_m3_s
 )
 
 process.add_event(
     'feed_water_on',
     'flow_sheet.eluent.flow_rate',
      Q_m3_s,
-     V_tracer/Q_m3_s
+     V_tracer / Q_m3_s
 )
 
 process.add_event(
@@ -169,6 +169,7 @@ optimization_problem.add_objective(
     n_objectives=comparator.n_metrics,
     requires=[simulator]
 )
+
 
 def callback(simulation_results, individual, evaluation_object, callbacks_dir='./'):
     comparator.plot_comparison(

--- a/examples/characterize_chromatographic_system/system_periphery.md
+++ b/examples/characterize_chromatographic_system/system_periphery.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python

--- a/examples/characterize_chromatographic_system/system_periphery.py
+++ b/examples/characterize_chromatographic_system/system_periphery.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python

--- a/examples/load_wash_elute/lwe_concentration.md
+++ b/examples/load_wash_elute/lwe_concentration.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -57,9 +57,9 @@ column.bed_porosity = 0.37
 column.particle_radius = 4.5e-5
 column.particle_porosity = 0.75
 column.axial_dispersion = 5.75e-8
-column.film_diffusion = column.n_comp*[6.9e-6]
+column.film_diffusion = column.n_comp * [6.9e-6]
 column.pore_diffusion = [7e-10, 6.07e-11, 6.07e-11, 6.07e-11]
-column.surface_diffusion = column.n_bound_states*[0.0]
+column.surface_diffusion = column.n_bound_states * [0.0]
 
 column.c = [50, 0, 0, 0]
 column.cp = [50, 0, 0, 0]
@@ -94,11 +94,11 @@ gradient_duration = process.cycle_time - t_gradient_start
 c_load = np.array([50.0, 1.0, 1.0, 1.0])
 c_wash = np.array([50.0, 0.0, 0.0, 0.0])
 c_elute = np.array([500.0, 0.0, 0.0, 0.0])
-gradient_slope = (c_elute - c_wash)/gradient_duration
+gradient_slope = (c_elute - c_wash) / gradient_duration
 c_gradient_poly = np.array(list(zip(c_wash, gradient_slope)))
 
 process.add_event('load', 'flow_sheet.inlet.c', c_load)
-process.add_event('wash', 'flow_sheet.inlet.c',  c_wash, load_duration)
+process.add_event('wash', 'flow_sheet.inlet.c', c_wash, load_duration)
 process.add_event('grad_start', 'flow_sheet.inlet.c', c_gradient_poly, t_gradient_start)
 ```
 

--- a/examples/load_wash_elute/lwe_concentration.py
+++ b/examples/load_wash_elute/lwe_concentration.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -59,9 +59,9 @@ column.bed_porosity = 0.37
 column.particle_radius = 4.5e-5
 column.particle_porosity = 0.75
 column.axial_dispersion = 5.75e-8
-column.film_diffusion = column.n_comp*[6.9e-6]
+column.film_diffusion = column.n_comp * [6.9e-6]
 column.pore_diffusion = [7e-10, 6.07e-11, 6.07e-11, 6.07e-11]
-column.surface_diffusion = column.n_bound_states*[0.0]
+column.surface_diffusion = column.n_bound_states * [0.0]
 
 column.c = [50, 0, 0, 0]
 column.cp = [50, 0, 0, 0]
@@ -96,11 +96,11 @@ gradient_duration = process.cycle_time - t_gradient_start
 c_load = np.array([50.0, 1.0, 1.0, 1.0])
 c_wash = np.array([50.0, 0.0, 0.0, 0.0])
 c_elute = np.array([500.0, 0.0, 0.0, 0.0])
-gradient_slope = (c_elute - c_wash)/gradient_duration
+gradient_slope = (c_elute - c_wash) / gradient_duration
 c_gradient_poly = np.array(list(zip(c_wash, gradient_slope)))
 
 process.add_event('load', 'flow_sheet.inlet.c', c_load)
-process.add_event('wash', 'flow_sheet.inlet.c',  c_wash, load_duration)
+process.add_event('wash', 'flow_sheet.inlet.c', c_wash, load_duration)
 process.add_event('grad_start', 'flow_sheet.inlet.c', c_gradient_poly, t_gradient_start)
 
 # %%

--- a/examples/load_wash_elute/lwe_flow_rate.md
+++ b/examples/load_wash_elute/lwe_flow_rate.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -62,9 +62,9 @@ column.bed_porosity = 0.37
 column.particle_radius = 4.5e-5
 column.particle_porosity = 0.75
 column.axial_dispersion = 5.75e-8
-column.film_diffusion = column.n_comp*[6.9e-6]
+column.film_diffusion = column.n_comp * [6.9e-6]
 column.pore_diffusion = [7e-10, 6.07e-11, 6.07e-11, 6.07e-11]
-column.surface_diffusion = column.n_bound_states*[0.0]
+column.surface_diffusion = column.n_bound_states * [0.0]
 
 column.c = [50, 0, 0, 0]
 column.cp = [50, 0, 0, 0]
@@ -101,7 +101,7 @@ t_gradient_start = 90.0
 gradient_duration = process.cycle_time - t_gradient_start
 
 Q = 6.683738370512285e-8
-gradient_slope = Q/(process.cycle_time - t_gradient_start)
+gradient_slope = Q / (process.cycle_time - t_gradient_start)
 
 process.add_event('load_on', 'flow_sheet.load.flow_rate', Q)
 process.add_event('load_off', 'flow_sheet.load.flow_rate', 0.0)

--- a/examples/load_wash_elute/lwe_flow_rate.py
+++ b/examples/load_wash_elute/lwe_flow_rate.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -64,9 +64,9 @@ column.bed_porosity = 0.37
 column.particle_radius = 4.5e-5
 column.particle_porosity = 0.75
 column.axial_dispersion = 5.75e-8
-column.film_diffusion = column.n_comp*[6.9e-6]
+column.film_diffusion = column.n_comp * [6.9e-6]
 column.pore_diffusion = [7e-10, 6.07e-11, 6.07e-11, 6.07e-11]
-column.surface_diffusion = column.n_bound_states*[0.0]
+column.surface_diffusion = column.n_bound_states * [0.0]
 
 column.c = [50, 0, 0, 0]
 column.cp = [50, 0, 0, 0]
@@ -103,7 +103,7 @@ t_gradient_start = 90.0
 gradient_duration = process.cycle_time - t_gradient_start
 
 Q = 6.683738370512285e-8
-gradient_slope = Q/(process.cycle_time - t_gradient_start)
+gradient_slope = Q / (process.cycle_time - t_gradient_start)
 
 process.add_event('load_on', 'flow_sheet.load.flow_rate', Q)
 process.add_event('load_off', 'flow_sheet.load.flow_rate', 0.0)

--- a/examples/load_wash_elute/lwe_hic.md
+++ b/examples/load_wash_elute/lwe_hic.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -25,7 +25,7 @@ import numpy as np
 import matplotlib
 matplotlib.use("TkAgg")
 
-from CADETProcess.processModel import ComponentSystem, HICConstantWaterActivity, HICWaterOnHydrophobicSurfaces
+from CADETProcess.processModel import ComponentSystem, HICConstantWaterActivity
 from CADETProcess.processModel import Inlet, GeneralRateModel, Outlet
 from CADETProcess.processModel import FlowSheet
 from CADETProcess.processModel import Process

--- a/examples/load_wash_elute/lwe_hic.py
+++ b/examples/load_wash_elute/lwe_hic.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -27,7 +27,7 @@ import numpy as np
 import matplotlib
 matplotlib.use("TkAgg")
 
-from CADETProcess.processModel import ComponentSystem, HICConstantWaterActivity, HICWaterOnHydrophobicSurfaces
+from CADETProcess.processModel import ComponentSystem, HICConstantWaterActivity
 from CADETProcess.processModel import Inlet, GeneralRateModel, Outlet
 from CADETProcess.processModel import FlowSheet
 from CADETProcess.processModel import Process

--- a/examples/recycling/clr_process.md
+++ b/examples/recycling/clr_process.md
@@ -5,7 +5,7 @@ jupytext:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
 kernelspec:
   display_name: Python 3
   language: python
@@ -107,7 +107,7 @@ process = Process(flow_sheet, 'clr')
 ### Create Events and Durations
 
 ```{code-cell}
-Q = 60/(60*1e6)
+Q = 60 / (60 * 1e6)
 
 process.add_event('feed_on', 'flow_sheet.feed.flow_rate', Q)
 process.add_event('feed_off', 'flow_sheet.feed.flow_rate', 0.0)

--- a/examples/recycling/clr_process.py
+++ b/examples/recycling/clr_process.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     language: python
@@ -109,7 +109,7 @@ process = Process(flow_sheet, 'clr')
 # ### Create Events and Durations
 
 # %%
-Q = 60/(60*1e6)
+Q = 60 / (60 * 1e6)
 
 process.add_event('feed_on', 'flow_sheet.feed.flow_rate', Q)
 process.add_event('feed_off', 'flow_sheet.feed.flow_rate', 0.0)

--- a/examples/recycling/mrssr_process.md
+++ b/examples/recycling/mrssr_process.md
@@ -1,12 +1,12 @@
 ---
 jupytext:
   formats: md:myst,py:percent
-  main_language: python
   text_representation:
     extension: .md
     format_name: myst
     format_version: 0.13
-    jupytext_version: 1.14.5
+    jupytext_version: 1.17.1
+  main_language: python
 kernelspec:
   display_name: Python 3
   name: python3
@@ -113,7 +113,7 @@ Events for mixed-recycle steady-state recycling process with event dependencies.
 from CADETProcess.processModel import Process
 process = Process(flow_sheet, 'mrssr')
 
-Q = 60/(60*1e6)
+Q = 60 / (60 * 1e6)
 
 # Create Events and Durations
 process.add_event('feed_on', 'flow_sheet.feed.flow_rate', Q)

--- a/examples/recycling/mrssr_process.py
+++ b/examples/recycling/mrssr_process.py
@@ -6,7 +6,7 @@
 #       extension: .py
 #       format_name: percent
 #       format_version: '1.3'
-#       jupytext_version: 1.14.5
+#       jupytext_version: 1.17.1
 #   kernelspec:
 #     display_name: Python 3
 #     name: python3
@@ -114,7 +114,7 @@ flow_sheet.add_connection(column, outlet)
 from CADETProcess.processModel import Process
 process = Process(flow_sheet, 'mrssr')
 
-Q = 60/(60*1e6)
+Q = 60 / (60 * 1e6)
 
 # Create Events and Durations
 process.add_event('feed_on', 'flow_sheet.feed.flow_rate', Q)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ dev = [
     {include-group = "testing"},
     "certifi", # tries to prevent certificate problems on windows
     "pre-commit",
-    "ruff",
+    "ruff<=0.11.4",
 ]
 
 [project.optional-dependencies]
@@ -75,14 +75,49 @@ documentation = "https://cadet-process.readthedocs.io"
 "Bug Tracker" = "https://github.com/fau-advanced-separations/CADET-Process/issues"
 
 [tool.setuptools.packages.find]
-include = ["CADETProcess*", "examples*", "tests*"]
+include = [
+  "CADETProcess*",
+  "examples*",
+  "tests*"
+]
 
 [tool.setuptools.dynamic]
 version = { attr = "CADETProcess.__version__" }
 
 [tool.ruff]
-src = ["CADETProcess"]
-line-length = 88
+src = ["CADETProcess", "tests"]
+exclude = ["examples", "docs", "__init__.py"]
+line-length = 100
+fix = true
+
+[tool.ruff.lint]
+preview = true
+select = [
+  "E",    # pycodestyle errors
+  "F",    # Pyflakes (undefined names, etc.)
+  "I",    # isort (import sorting)
+  "W",    # pycodestyle warnings
+]
+ignore = [
+  "D100",    # Missing docstring in public module
+  "ANN401",  # Dynamically typed expressions
+]
+
+[tool.ruff.format]
+docstring-code-format = true
+
+[tool.ruff.lint.pydocstyle]
+convention = "numpy"
+
+[tool.ruff.lint.per-file-ignores]
+"tests/*.py" = [
+  "ANN",   # type annotations
+  "D",     # docstrings
+  "E402",  # imports on top of module 
+  "E731",  # lamba assignments
+  "F841",  # unused variables
+]
+
 
 [tool.pytest.ini_options]
 testpaths = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,14 +93,14 @@ fix = true
 [tool.ruff.lint]
 preview = true
 select = [
+  "D",    # docstrings
   "E",    # pycodestyle errors
-  "F",    # Pyflakes (undefined names, etc.)
-  "I",    # isort (import sorting)
+  "F",    # pyflakes
   "W",    # pycodestyle warnings
+  "I",    # isort
 ]
 ignore = [
-  "D100",    # Missing docstring in public module
-  "ANN401",  # Dynamically typed expressions
+  "D100",    # Allow missing docstring in public module
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,7 @@ fix = true
 [tool.ruff.lint]
 preview = true
 select = [
+  "ANN",  # type annotations
   "D",    # docstrings
   "E",    # pycodestyle errors
   "F",    # pyflakes
@@ -100,6 +101,7 @@ select = [
   "I",    # isort
 ]
 ignore = [
+  "ANN401",  # Allow dynamically typed expressions like `Any`
   "D100",    # Allow missing docstring in public module
 ]
 

--- a/tests/dataStructure/test_nested_dict.py
+++ b/tests/dataStructure/test_nested_dict.py
@@ -1,18 +1,18 @@
 import copy
-import pytest
 
+import pytest
 from CADETProcess.dataStructure.nested_dict import (
     check_nested,
     generate_nested_dict,
-    insert_path,
     get_leaves,
-    set_nested_value,
-    get_nested_value,
-    update_dict_recursively,
     get_nested_attribute,
-    set_nested_attribute,
     get_nested_list_value,
+    get_nested_value,
+    insert_path,
+    set_nested_attribute,
     set_nested_list_value,
+    set_nested_value,
+    update_dict_recursively,
 )
 
 
@@ -22,14 +22,14 @@ def sample_dict():
     return {
         "a": {
             "b": {
-                "c": 42
-            }
+                "c": 42,
+            },
         },
         "x": {
             "y": {
-                "z": 99
-            }
-        }
+                "z": 99,
+            },
+        },
     }
 
 
@@ -40,6 +40,7 @@ def sample_list():
 
 
 # --- TESTS FOR NESTED DICTIONARY FUNCTIONS --- #
+
 
 def test_check_nested(sample_dict):
     assert check_nested(sample_dict, "a.b.c") is True
@@ -84,6 +85,7 @@ def test_get_nested_value(sample_dict):
 
 # --- TESTS FOR DICTIONARY UPDATING --- #
 
+
 def test_update_dict_recursively(sample_dict):
     target = {"a": {"b": 1}, "c": 3}
     updates = {"a": {"b": 2, "d": 4}, "c": 30, "e": 5}
@@ -98,6 +100,7 @@ def test_update_dict_recursively(sample_dict):
 
 
 # --- TESTS FOR OBJECT ATTRIBUTE FUNCTIONS --- #
+
 
 class SampleObject:
     def __init__(self):
@@ -135,6 +138,7 @@ def test_set_nested_attribute(sample_obj):
 
 
 # --- TESTS FOR NESTED LIST FUNCTIONS --- #
+
 
 def test_get_nested_list_value(sample_list):
     assert get_nested_list_value(sample_list, (0, 1, 1)) == 4

--- a/tests/test_binding.py
+++ b/tests/test_binding.py
@@ -1,21 +1,24 @@
 import unittest
 
 import numpy
-
-from CADETProcess.processModel import ComponentSystem, binding, BindingBaseClass
 from CADETProcess.processModel import (
-    Langmuir, BiLangmuir, MultistateStericMassAction, StericMassAction, MobilePhaseModulator
+    BiLangmuir,
+    BindingBaseClass,
+    ComponentSystem,
+    Langmuir,
+    MobilePhaseModulator,
+    MultistateStericMassAction,
+    StericMassAction,
+    binding,
 )
 from CADETProcess.simulator.cadetAdapter import adsorption_parameters_map
 
 
 class Test_Binding(unittest.TestCase):
-
     def setUp(self):
-
         component_system = ComponentSystem(2)
 
-        binding_model = Langmuir(component_system, name='test')
+        binding_model = Langmuir(component_system, name="test")
 
         binding_model.adsorption_rate = [0.02, 0.03]
         binding_model.desorption_rate = [1, 1]
@@ -23,7 +26,7 @@ class Test_Binding(unittest.TestCase):
 
         self.langmuir = binding_model
 
-        binding_model = BiLangmuir(component_system, name='test')
+        binding_model = BiLangmuir(component_system, name="test")
 
         binding_model.adsorption_rate = [0.02, 0.03, 0.001, 0.002]
         binding_model.desorption_rate = [1, 1, 2, 2]
@@ -31,13 +34,11 @@ class Test_Binding(unittest.TestCase):
 
         self.bi_langmuir = binding_model
 
-        binding_model = MultistateStericMassAction(
-            component_system, name='test'
-        )
+        binding_model = MultistateStericMassAction(component_system, name="test")
 
         self.multi_state_sma = binding_model
 
-        binding_model = StericMassAction(component_system, name='test')
+        binding_model = StericMassAction(component_system, name="test")
 
         binding_model.adsorption_rate = [0.02, 0.03]
         binding_model.desorption_rate = [1, 1]
@@ -48,7 +49,7 @@ class Test_Binding(unittest.TestCase):
         binding_model.reference_solid_phase_conc = 100
         self.sma = binding_model
 
-        binding_model = MobilePhaseModulator(component_system, name='test')
+        binding_model = MobilePhaseModulator(component_system, name="test")
 
         binding_model.adsorption_rate = [0.02, 0.03]
         binding_model.desorption_rate = [1, 1]
@@ -62,42 +63,56 @@ class Test_Binding(unittest.TestCase):
         adsorption_rate = numpy.array(self.sma.adsorption_rate)
         desorption_rate = numpy.array(self.sma.desorption_rate)
         characteristic_charge = numpy.array(self.sma.characteristic_charge)
-        expected_untransformed_adsorption_rate = adsorption_rate * (self.sma.reference_solid_phase_conc
-                                                                    ** -characteristic_charge)
-        expected_untransformed_desorption_rate = desorption_rate * (self.sma.reference_liquid_phase_conc
-                                                                    ** -characteristic_charge)
-        assert (numpy.allclose(expected_untransformed_adsorption_rate, self.sma.adsorption_rate_untransformed))
-        assert (numpy.allclose(expected_untransformed_desorption_rate, self.sma.desorption_rate_untransformed))
+        expected_untransformed_adsorption_rate = adsorption_rate * (
+            self.sma.reference_solid_phase_conc**-characteristic_charge
+        )
+        expected_untransformed_desorption_rate = desorption_rate * (
+            self.sma.reference_liquid_phase_conc**-characteristic_charge
+        )
+        assert numpy.allclose(
+            expected_untransformed_adsorption_rate,
+            self.sma.adsorption_rate_untransformed,
+        )
+        assert numpy.allclose(
+            expected_untransformed_desorption_rate,
+            self.sma.desorption_rate_untransformed,
+        )
 
         with self.assertRaises(ValueError):
             component_system = ComponentSystem(2)
-            binding_model = StericMassAction(component_system, name='test')
+            binding_model = StericMassAction(component_system, name="test")
             binding_model.adsorption_rate_untransformed = [0.02, 0.03]
 
     def test_in_cadetAdapter(self):
-        binding_classes = {name: cls for name, cls in binding.__dict__.items() if (isinstance(cls, type) and
-                                                                                   issubclass(cls, BindingBaseClass))}
+        binding_classes = {
+            name: cls
+            for name, cls in binding.__dict__.items()
+            if (isinstance(cls, type) and issubclass(cls, BindingBaseClass))
+        }
         binding_classes.pop("BindingBaseClass")
 
         for name, cls in binding_classes.items():
             self.assertIn(name, adsorption_parameters_map)
             map = adsorption_parameters_map[name]
             try:
-                assert set(cls._parameters) == set(map["parameters"].values())  # This needs to compare to .values
+                assert set(cls._parameters) == set(
+                    map["parameters"].values()
+                )  # This needs to compare to .values
             except AssertionError:
-                raise AssertionError(f"Isotherm '{name}' has these parameters in cadetAdapter.py missing: "
-                                     f"{set(cls._parameters) - set(map['parameters'].values())} "
-                                     "and these parameters in binding.py missing: "
-                                     f"{set(map['parameters'].values()) - set(cls._parameters)}")
-
+                raise AssertionError(
+                    f"Isotherm '{name}' has these parameters in cadetAdapter.py missing: "
+                    f"{set(cls._parameters) - set(map['parameters'].values())} "
+                    "and these parameters in binding.py missing: "
+                    f"{set(map['parameters'].values()) - set(cls._parameters)}"
+                )
 
     def test_get_parameters(self):
         parameters_expected = {
-                'is_kinetic': True,
-                'adsorption_rate': [0.02, 0.03],
-                'desorption_rate': [1.0, 1.0],
-                'capacity': [100.0, 100.0]
-                }
+            "is_kinetic": True,
+            "adsorption_rate": [0.02, 0.03],
+            "desorption_rate": [1.0, 1.0],
+            "capacity": [100.0, 100.0],
+        }
         parameters = self.langmuir.parameters
         self.assertDictEqual(parameters_expected, parameters)
 
@@ -125,5 +140,5 @@ class Test_Binding(unittest.TestCase):
             self.langmuir.bound_states = [2, 2]
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_buffer_capacity.py
+++ b/tests/test_buffer_capacity.py
@@ -1,130 +1,96 @@
 import unittest
 
 import numpy as np
-
-from CADETProcess.processModel import ComponentSystem
-from CADETProcess.processModel import MassActionLaw
 from CADETProcess import equilibria
+from CADETProcess.processModel import ComponentSystem, MassActionLaw
 
 enable_plot = False
 
 
 class TestBufferCapacity(unittest.TestCase):
-
     def setUp(self):
         self.components_simple = ComponentSystem(2, charges=[1, 2])
 
         # Ammonia
         self.components_ammonia = ComponentSystem()
         self.components_ammonia.add_component(
-            'Ammonia',
-            species=['NH4+', 'NH3'],
-            charge=[1, 0]
+            "Ammonia", species=["NH4+", "NH3"], charge=[1, 0]
         )
-        self.components_ammonia.add_component(
-            'H+',
-            charge=1
-        )
+        self.components_ammonia.add_component("H+", charge=1)
 
         self.reaction_ammonia = MassActionLaw(self.components_ammonia)
         self.reaction_ammonia.add_reaction(
-            [0, 1, 2], [-1, 1, 1], 10**(-9.2)*1e3, is_kinetic=False
+            [0, 1, 2], [-1, 1, 1], 10 ** (-9.2) * 1e3, is_kinetic=False
         )
 
         # Ammonia, component order switched
         self.components_ammonia_switched = ComponentSystem()
+        self.components_ammonia_switched.add_component("H+", charge=1)
         self.components_ammonia_switched.add_component(
-            'H+',
-            charge=1
-        )
-        self.components_ammonia_switched.add_component(
-            'Ammonia',
-            species=['NH4+', 'NH3'],
-            charge=[1, 0]
+            "Ammonia", species=["NH4+", "NH3"], charge=[1, 0]
         )
 
-        self.reaction_ammonia_switched = MassActionLaw(
-            self.components_ammonia_switched
-        )
+        self.reaction_ammonia_switched = MassActionLaw(self.components_ammonia_switched)
         self.reaction_ammonia_switched.add_reaction(
-            [1, 2, 0], [-1, 1, 1], 10**(-9.2)*1e3, is_kinetic=False
+            [1, 2, 0], [-1, 1, 1], 10 ** (-9.2) * 1e3, is_kinetic=False
         )
 
         # Lysine
         self.components_lys = ComponentSystem()
         self.components_lys.add_component(
-            'Lysine',
-            species=['Lys2+', 'Lys+', 'Lys', 'Lys-'],
-            charge=[2, 1, 0, -1]
+            "Lysine", species=["Lys2+", "Lys+", "Lys", "Lys-"], charge=[2, 1, 0, -1]
         )
-        self.components_lys.add_component(
-            'H+',
-            charge=1
-        )
+        self.components_lys.add_component("H+", charge=1)
         self.reaction_lys = MassActionLaw(self.components_lys)
         self.reaction_lys.add_reaction(
-            [0, 1, -1], [-1, 1, 1], 10**(-2.20)*1e3, is_kinetic=False
+            [0, 1, -1], [-1, 1, 1], 10 ** (-2.20) * 1e3, is_kinetic=False
         )
         self.reaction_lys.add_reaction(
-            [1, 2, -1], [-1, 1, 1], 10**(-8.90)*1e3, is_kinetic=False
+            [1, 2, -1], [-1, 1, 1], 10 ** (-8.90) * 1e3, is_kinetic=False
         )
         self.reaction_lys.add_reaction(
-            [2, 3, -1], [-1, 1, 1], 10**(-10.28)*1e3, is_kinetic=False
+            [2, 3, -1], [-1, 1, 1], 10 ** (-10.28) * 1e3, is_kinetic=False
         )
 
         # Lysine, component order switched
         self.components_lys_switched = ComponentSystem()
+        self.components_lys_switched.add_component("H+", charge=1)
         self.components_lys_switched.add_component(
-            'H+',
-            charge=1
-        )
-        self.components_lys_switched.add_component(
-            'Lysine',
-            species=['Lys2+', 'Lys+', 'Lys', 'Lys-'],
-            charge=[2, 1, 0, -1]
+            "Lysine", species=["Lys2+", "Lys+", "Lys", "Lys-"], charge=[2, 1, 0, -1]
         )
 
-        self.reaction_lys_switched = MassActionLaw(
-            self.components_lys_switched
+        self.reaction_lys_switched = MassActionLaw(self.components_lys_switched)
+        self.reaction_lys_switched.add_reaction(
+            [1, 2, 0], [-1, 1, 1], 10 ** (-2.20) * 1e3, is_kinetic=False
         )
         self.reaction_lys_switched.add_reaction(
-            [1, 2, 0], [-1, 1, 1], 10**(-2.20)*1e3, is_kinetic=False
+            [2, 3, 0], [-1, 1, 1], 10 ** (-8.90) * 1e3, is_kinetic=False
         )
         self.reaction_lys_switched.add_reaction(
-            [2, 3, 0], [-1, 1, 1], 10**(-8.90)*1e3, is_kinetic=False
-        )
-        self.reaction_lys_switched.add_reaction(
-            [3, 4, 0], [-1, 1, 1], 10**(-10.28)*1e3, is_kinetic=False
+            [3, 4, 0], [-1, 1, 1], 10 ** (-10.28) * 1e3, is_kinetic=False
         )
 
         # Ammonia and Lysine
         self.components_ammonia_lys = ComponentSystem()
         self.components_ammonia_lys.add_component(
-            'Ammonia',
-            species=['NH4+', 'NH3'],
-            charge=[1, 0]
+            "Ammonia", species=["NH4+", "NH3"], charge=[1, 0]
         )
         self.components_ammonia_lys.add_component(
-            'Lysine',
-            species=['Lys2+', 'Lys+', 'Lys', 'Lys-'],
-            charge=[2, 1, 0, -1]
+            "Lysine", species=["Lys2+", "Lys+", "Lys", "Lys-"], charge=[2, 1, 0, -1]
         )
-        self.components_ammonia_lys.add_component(
-            'H+',
-            charge=1
-        )
+        self.components_ammonia_lys.add_component("H+", charge=1)
         self.reaction_ammonia_lys = MassActionLaw(self.components_ammonia_lys)
         self.reaction_ammonia_lys.add_reaction(
-            [0, 1, -1], [-1, 1, 1], 10**(-9.2)*1e3, is_kinetic=False
+            [0, 1, -1], [-1, 1, 1], 10 ** (-9.2) * 1e3, is_kinetic=False
         )
         self.reaction_ammonia_lys.add_reaction(
-            [2, 3, -1], [-1, 1, 1], 10**(-2.20)*1e3, is_kinetic=False
+            [2, 3, -1], [-1, 1, 1], 10 ** (-2.20) * 1e3, is_kinetic=False
         )
         self.reaction_ammonia_lys.add_reaction(
-            [3, 4, -1], [-1, 1, 1], 10**(-8.90)*1e3, is_kinetic=False
+            [3, 4, -1], [-1, 1, 1], 10 ** (-8.90) * 1e3, is_kinetic=False
         )
         self.reaction_ammonia_lys.add_reaction(
-            [4, 5, -1], [-1, 1, 1], 10**(-10.28)*1e3, is_kinetic=False
+            [4, 5, -1], [-1, 1, 1], 10 ** (-10.28) * 1e3, is_kinetic=False
         )
 
     def test_ionic_strength(self):
@@ -179,9 +145,7 @@ class TestBufferCapacity(unittest.TestCase):
 
         pH = 0
         b_expected = np.array([1.4528329738818527e-06, 2302.585092994069])
-        b = equilibria.buffer_capacity(
-            self.reaction_ammonia_switched, buffer, pH
-        )
+        b = equilibria.buffer_capacity(self.reaction_ammonia_switched, buffer, pH)
         np.testing.assert_almost_equal(b_expected, b)
 
     def test_charge_distribution(self):
@@ -207,17 +171,13 @@ class TestBufferCapacity(unittest.TestCase):
 
         pH = 0
         eta_expected = np.array([0.9999999993690426, 6.30957344082087e-10])
-        eta = equilibria.charge_distribution(
-            self.reaction_ammonia_switched, pH
-        )
+        eta = equilibria.charge_distribution(self.reaction_ammonia_switched, pH)
         np.testing.assert_almost_equal(eta_expected, eta)
 
     def test_plot(self):
         if enable_plot:
             _ = equilibria.plot_charge_distribution(self.reaction_ammonia)
-            _ = equilibria.plot_charge_distribution(
-                self.reaction_ammonia_switched
-            )
+            _ = equilibria.plot_charge_distribution(self.reaction_ammonia_switched)
             _ = equilibria.plot_charge_distribution(
                 self.reaction_lys_switched, plot_cumulative=True
             )
@@ -226,6 +186,6 @@ class TestBufferCapacity(unittest.TestCase):
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     enable_plot = True
     unittest.main()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -4,27 +4,26 @@ from CADETProcess.optimization import ResultsCache
 
 
 class TestCache(unittest.TestCase):
-
     def setUp(self):
         self.cache_dict = ResultsCache(use_diskcache=False)
         self.cache_disk = ResultsCache(use_diskcache=True)
 
-        key = (None, 'objective', str([1, 2, 3]))
-        result = 'important result'
+        key = (None, "objective", str([1, 2, 3]))
+        result = "important result"
         self.cache_dict.set(key, result)
         self.cache_disk.set(key, result)
 
-        key = (None, 'intermediate', str([1, 2, 3]))
-        result = 'temporary result'
-        self.cache_dict.set(key, result, 'temp')
-        self.cache_disk.set(key, result, 'temp')
+        key = (None, "intermediate", str([1, 2, 3]))
+        result = "temporary result"
+        self.cache_dict.set(key, result, "temp")
+        self.cache_disk.set(key, result, "temp")
 
     def tearDown(self):
         self.cache_disk.delete_database()
 
     def test_set(self):
-        new_result = 'new'
-        key = (None, 'other', str([1, 2, 3]))
+        new_result = "new"
+        key = (None, "other", str([1, 2, 3]))
 
         self.cache_dict.set(key, new_result)
         cached_result = self.cache_dict.get(key)
@@ -35,17 +34,17 @@ class TestCache(unittest.TestCase):
         self.assertEqual(cached_result, new_result)
 
     def test_get(self):
-        key = (None, 'intermediate', str([1, 2, 3]))
-        result_expected = 'temporary result'
+        key = (None, "intermediate", str([1, 2, 3]))
+        result_expected = "temporary result"
         cached_result = self.cache_dict.get(key)
         self.assertEqual(result_expected, cached_result)
 
-        key = (None, 'intermediate', str([1, 2, 3]))
-        result_expected = 'temporary result'
+        key = (None, "intermediate", str([1, 2, 3]))
+        result_expected = "temporary result"
         cached_result = self.cache_disk.get(key)
         self.assertEqual(result_expected, cached_result)
 
-        key = (None, 'false', str([1, 2, 3]))
+        key = (None, "false", str([1, 2, 3]))
         with self.assertRaises(KeyError):
             cached_result = self.cache_dict.get(key)
 
@@ -53,7 +52,7 @@ class TestCache(unittest.TestCase):
             cached_result = self.cache_disk.get(key)
 
     def test_delete(self):
-        key = (None, 'intermediate', str([1, 2, 3]))
+        key = (None, "intermediate", str([1, 2, 3]))
         self.cache_dict.delete(key)
         with self.assertRaises(KeyError):
             cached_result = self.cache_dict.get(key)
@@ -63,34 +62,34 @@ class TestCache(unittest.TestCase):
             cached_result = self.cache_disk.get(key)
 
     def test_tags(self):
-        tags_expected = ['temp']
+        tags_expected = ["temp"]
         tags = list(self.cache_dict.tags.keys())
         self.assertEqual(tags_expected, tags)
 
-        key = (None, 'other', str([1, 2, 4]))
-        self.cache_dict.set(key, 'new', 'foo')
-        tags_expected = ['temp', 'foo']
+        key = (None, "other", str([1, 2, 4]))
+        self.cache_dict.set(key, "new", "foo")
+        tags_expected = ["temp", "foo"]
         tags = list(self.cache_dict.tags.keys())
         self.assertEqual(tags_expected, tags)
 
     def test_prune(self):
-        key = (None, 'intermediate', str([1, 2, 3]))
-        self.cache_dict.prune('temp')
+        key = (None, "intermediate", str([1, 2, 3]))
+        self.cache_dict.prune("temp")
         with self.assertRaises(KeyError):
             cached_result = self.cache_dict.get(key)
 
-        key = (None, 'objective', str([1, 2, 3]))
-        result_expected = 'important result'
+        key = (None, "objective", str([1, 2, 3]))
+        result_expected = "important result"
         cached_result = self.cache_dict.get(key)
         self.assertEqual(result_expected, cached_result)
 
-        key = (None, 'intermediate', str([1, 2, 3]))
-        self.cache_disk.prune('temp')
+        key = (None, "intermediate", str([1, 2, 3]))
+        self.cache_disk.prune("temp")
         with self.assertRaises(KeyError):
             cached_result = self.cache_disk.get(key)
 
-        key = (None, 'objective', str([1, 2, 3]))
-        result_expected = 'important result'
+        key = (None, "objective", str([1, 2, 3]))
+        result_expected = "important result"
         cached_result = self.cache_disk.get(key)
         self.assertEqual(result_expected, cached_result)
 
@@ -98,5 +97,5 @@ class TestCache(unittest.TestCase):
         pass
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -1,17 +1,15 @@
-from pathlib import Path
 import shutil
-from typing import Optional
 import unittest
+from pathlib import Path
+from typing import Optional
 
-import pytest
 import numpy as np
 import numpy.testing as npt
-
-from CADETProcess import CADETProcessError
+import pytest
+from CADETProcess import CADETProcessError, SimulationResults
 from CADETProcess.processModel import Process
 from CADETProcess.processModel.discretization import NoDiscretization
 from CADETProcess.simulator import Cadet
-from CADETProcess import SimulationResults
 
 from tests.create_LWE import create_lwe
 
@@ -32,7 +30,6 @@ found_cadet, install_path = detect_cadet()
 
 
 class Test_Adapter(unittest.TestCase):
-
     @unittest.skipIf(found_cadet is False, "Skip if CADET is not installed.")
     def test_check_cadet(self):
         simulator = Cadet(install_path)
@@ -78,28 +75,31 @@ class Test_Adapter(unittest.TestCase):
         )
 
     def tearDown(self):
-        shutil.rmtree('./tmp', ignore_errors=True)
+        shutil.rmtree("./tmp", ignore_errors=True)
 
 
 unit_types = [
-    'Cstr', 'GeneralRateModel', 'TubularReactor',
-    'LumpedRateModelWithoutPores', 'LumpedRateModelWithPores', 'MCT'
+    "Cstr",
+    "GeneralRateModel",
+    "TubularReactor",
+    "LumpedRateModelWithoutPores",
+    "LumpedRateModelWithPores",
+    "MCT",
 ]
 
 parameter_combinations = [
-    {},               # Default parameters
+    {},  # Default parameters
     {"n_par": 1},
     {"n_col": 1},
 ]
 
 # Parameters to skip for specific unit types
 exclude_rules = {
-    'Cstr': [{"n_col": 1}, {"n_par": 1}],
-    'TubularReactor': [{"n_par": 1}],
-    'LumpedRateModelWithoutPores': [{"n_par": 1}],
-    'LumpedRateModelWithPores': [{"n_par": 1}],
-    'MCT': [{"n_par": 1}],
-
+    "Cstr": [{"n_col": 1}, {"n_par": 1}],
+    "TubularReactor": [{"n_par": 1}],
+    "LumpedRateModelWithoutPores": [{"n_par": 1}],
+    "LumpedRateModelWithPores": [{"n_par": 1}],
+    "MCT": [{"n_par": 1}],
 }
 
 
@@ -107,7 +107,7 @@ exclude_rules = {
 def format_params(params):
     if not params:
         return "default"
-    return '-'.join(f"{k}={v}" for k, v in params.items())
+    return "-".join(f"{k}={v}" for k, v in params.items())
 
 
 process_test_cases = [
@@ -135,9 +135,7 @@ simulation_test_cases = [
 
 
 def run_simulation(
-        process: Process,
-        install_path: Optional[str] = None,
-        use_dll: bool = False
+    process: Process, install_path: Optional[str] = None, use_dll: bool = False
 ) -> SimulationResults:
     """
     Run the CADET simulation for the given process and handle potential issues.
@@ -192,16 +190,13 @@ def simulation_results(request: pytest.FixtureRequest):
     """
     unit_type, kwargs, use_dll = request.param  # Extract `use_dll`
     process = create_lwe(unit_type, **kwargs)  # Process remains unchanged
-    simulation_results = run_simulation(
-        process, install_path, use_dll=use_dll
-    )
+    simulation_results = run_simulation(process, install_path, use_dll=use_dll)
     return simulation_results
 
 
 @pytest.mark.parametrize("process", process_test_cases, indirect=True)
 @pytest.mark.slow
 class TestProcessWithLWE:
-
     def return_process_config(self, process: Process) -> dict:
         """
         Returns the process configuration.
@@ -244,41 +239,37 @@ class TestProcessWithLWE:
         cx_lwe = [[1.0], [0.0], [0.0]]
 
         expected_input_config = {
-            'UNIT_TYPE': 'INLET',
-            'NCOMP': n_comp,
-            'INLET_TYPE': 'PIECEWISE_CUBIC_POLY',
-            'discretization': {
-                'nbound': n_comp * [0]
+            "UNIT_TYPE": "INLET",
+            "NCOMP": n_comp,
+            "INLET_TYPE": "PIECEWISE_CUBIC_POLY",
+            "discretization": {"nbound": n_comp * [0]},
+            "sec_000": {
+                "const_coeff": np.array(c1_lwe[0] + cx_lwe[0] * (n_comp - 1)),
+                "lin_coeff": np.array([0.0] * n_comp),
+                "quad_coeff": np.array([0.0] * n_comp),
+                "cube_coeff": np.array([0.0] * n_comp),
             },
-            'sec_000': {
-                'const_coeff': np.array(c1_lwe[0] + cx_lwe[0] * (n_comp - 1)),
-                'lin_coeff': np.array([0.] * n_comp),
-                'quad_coeff': np.array([0.] * n_comp),
-                'cube_coeff': np.array([0.] * n_comp)
+            "sec_001": {
+                "const_coeff": np.array(c1_lwe[1] + cx_lwe[1] * (n_comp - 1)),
+                "lin_coeff": np.array([0.0] * n_comp),
+                "quad_coeff": np.array([0.0] * n_comp),
+                "cube_coeff": np.array([0.0] * n_comp),
             },
-            'sec_001': {
-                'const_coeff': np.array(c1_lwe[1] + cx_lwe[1] * (n_comp - 1)),
-                'lin_coeff': np.array([0.] * n_comp),
-                'quad_coeff': np.array([0.] * n_comp),
-                'cube_coeff': np.array([0.] * n_comp)
+            "sec_002": {
+                "const_coeff": np.array([c1_lwe[2][0][0]] + cx_lwe[2] * (n_comp - 1)),
+                "lin_coeff": np.array([c1_lwe[2][0][1]] + cx_lwe[2] * (n_comp - 1)),
+                "quad_coeff": np.array([0.0] * n_comp),
+                "cube_coeff": np.array([0.0] * n_comp),
             },
-            'sec_002': {
-                'const_coeff': np.array([c1_lwe[2][0][0]] + cx_lwe[2] * (n_comp - 1)),
-                'lin_coeff': np.array([c1_lwe[2][0][1]] + cx_lwe[2] * (n_comp - 1)),
-                'quad_coeff': np.array([0.] * n_comp),
-                'cube_coeff': np.array([0.] * n_comp)
-            }
         }
 
         npt.assert_equal(input_config, expected_input_config)
 
         # ASSERT OUTPUT CONFIGURATION
         expected_output_config = {
-            'UNIT_TYPE': 'OUTLET',
-            'NCOMP': n_comp,
-            'discretization': {
-                'nbound': n_comp * [0]
-            }
+            "UNIT_TYPE": "OUTLET",
+            "NCOMP": n_comp,
+            "discretization": {"nbound": n_comp * [0]},
         }
 
         npt.assert_equal(output_config, expected_output_config)
@@ -287,17 +278,17 @@ class TestProcessWithLWE:
         assert unit_config.NCOMP == n_comp
         assert model_config.nunits == 3
 
-        if unit.name == 'Cstr':
+        if unit.name == "Cstr":
             self.check_cstr(unit, unit_config)
-        elif unit.name == 'GeneralRateModel':
+        elif unit.name == "GeneralRateModel":
             self.check_general_rate_model(unit, unit_config)
-        elif unit.name == 'TubularReactor':
+        elif unit.name == "TubularReactor":
             self.check_tubular_reactor(unit, unit_config)
-        elif unit.name == 'LumpedRateModelWithoutPores':
+        elif unit.name == "LumpedRateModelWithoutPores":
             self.check_lumped_rate_model_without_pores(unit, unit_config)
-        elif unit.name == 'LumpedRateModelWithPores':
+        elif unit.name == "LumpedRateModelWithPores":
             self.check_lumped_rate_model_with_pores(unit, unit_config)
-        elif unit.name == 'MCT':
+        elif unit.name == "MCT":
             self.check_mct(unit, unit_config)
 
     def check_cstr(self, unit, unit_config):
@@ -313,7 +304,7 @@ class TestProcessWithLWE:
         """
         n_comp = unit.component_system.n_comp
 
-        assert unit_config.UNIT_TYPE == 'CSTR'
+        assert unit_config.UNIT_TYPE == "CSTR"
         assert unit_config.INIT_Q == n_comp * [0]
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.INIT_LIQUID_VOLUME == 0.0008425
@@ -336,13 +327,13 @@ class TestProcessWithLWE:
         """
         n_comp = unit.component_system.n_comp
 
-        assert unit_config.UNIT_TYPE == 'GENERAL_RATE_MODEL'
+        assert unit_config.UNIT_TYPE == "GENERAL_RATE_MODEL"
         assert unit_config.INIT_Q == n_comp * [0]
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.INIT_CP == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
         assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
-        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
+        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01**2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.COL_POROSITY == 0.37
         assert unit_config.FILM_DIFFUSION == [6.9e-6] * n_comp
@@ -364,11 +355,11 @@ class TestProcessWithLWE:
         """
         n_comp = unit.component_system.n_comp
 
-        assert unit_config.UNIT_TYPE == 'LUMPED_RATE_MODEL_WITHOUT_PORES'
+        assert unit_config.UNIT_TYPE == "LUMPED_RATE_MODEL_WITHOUT_PORES"
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
         assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
-        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
+        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01**2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.TOTAL_POROSITY == 1
 
@@ -387,11 +378,11 @@ class TestProcessWithLWE:
         """
         n_comp = unit.component_system.n_comp
 
-        assert unit_config.UNIT_TYPE == 'LUMPED_RATE_MODEL_WITHOUT_PORES'
+        assert unit_config.UNIT_TYPE == "LUMPED_RATE_MODEL_WITHOUT_PORES"
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
         assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
-        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
+        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01**2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.TOTAL_POROSITY == 0.8425
 
@@ -411,13 +402,13 @@ class TestProcessWithLWE:
         """
         n_comp = unit.component_system.n_comp
 
-        assert unit_config.UNIT_TYPE == 'LUMPED_RATE_MODEL_WITH_PORES'
+        assert unit_config.UNIT_TYPE == "LUMPED_RATE_MODEL_WITH_PORES"
         assert unit_config.INIT_C == n_comp * [0]
         assert unit_config.INIT_Q == n_comp * [0]
         assert unit_config.INIT_CP == n_comp * [0]
         assert unit_config.VELOCITY == unit.flow_direction
         assert unit_config.COL_DISPERSION == n_comp * [5.75e-08]
-        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01 ** 2
+        assert unit_config.CROSS_SECTION_AREA == np.pi * 0.01**2
         assert unit_config.COL_LENGTH == 0.014
         assert unit_config.COL_POROSITY == 0.37
         assert unit_config.FILM_DIFFUSION == [6.9e-6] * n_comp
@@ -440,21 +431,22 @@ class TestProcessWithLWE:
         n_comp = unit.component_system.n_comp
         n_channel = unit.nchannel
 
-        assert unit_config.UNIT_TYPE == 'MULTI_CHANNEL_TRANSPORT'
+        assert unit_config.UNIT_TYPE == "MULTI_CHANNEL_TRANSPORT"
         npt.assert_equal(unit_config.INIT_C, n_comp * [(n_channel * [0])])
         assert unit_config.VELOCITY == unit.flow_direction
         npt.assert_equal(
             unit_config.EXCHANGE_MATRIX,
-            np.array([
-                [n_comp * [0.0], n_comp * [0.001], n_comp * [0.0]],
-                [n_comp * [0.002], n_comp * [0.0], n_comp * [0.003]],
-                [n_comp * [0.0], n_comp * [0.0], n_comp * [0.0]]
-            ])
+            np.array(
+                [
+                    [n_comp * [0.0], n_comp * [0.001], n_comp * [0.0]],
+                    [n_comp * [0.002], n_comp * [0.0], n_comp * [0.003]],
+                    [n_comp * [0.0], n_comp * [0.0], n_comp * [0.0]],
+                ]
+            ),
         )
-        assert unit_config.COL_DISPERSION == n_comp * n_channel  * [5.75e-08]
+        assert unit_config.COL_DISPERSION == n_comp * n_channel * [5.75e-08]
         assert unit_config.NCHANNEL == 3
-        assert unit_config.CHANNEL_CROSS_SECTION_AREAS == 3 * \
-            [2 * np.pi * (0.01 ** 2)]
+        assert unit_config.CHANNEL_CROSS_SECTION_AREAS == 3 * [2 * np.pi * (0.01**2)]
 
         self.check_discretization(unit, unit_config)
 
@@ -472,18 +464,18 @@ class TestProcessWithLWE:
         n_comp = unit.component_system.n_comp
 
         expected_adsorption_config = {
-            'ADSORPTION_MODEL': 'STERIC_MASS_ACTION',
-            'IS_KINETIC': True,
-            'SMA_KA': n_comp * [35.5],
-            'SMA_KD': n_comp * [1000.0],
-            'SMA_LAMBDA': 1200.0,
-            'SMA_NU': n_comp * [4.7],
-            'SMA_SIGMA': n_comp * [11.83],
-            'SMA_REFC0': 1.0,
-            'SMA_REFQ': 1.0
+            "ADSORPTION_MODEL": "STERIC_MASS_ACTION",
+            "IS_KINETIC": True,
+            "SMA_KA": n_comp * [35.5],
+            "SMA_KD": n_comp * [1000.0],
+            "SMA_LAMBDA": 1200.0,
+            "SMA_NU": n_comp * [4.7],
+            "SMA_SIGMA": n_comp * [11.83],
+            "SMA_REFC0": 1.0,
+            "SMA_REFQ": 1.0,
         }
 
-        assert unit_config.adsorption_model == 'STERIC_MASS_ACTION'
+        assert unit_config.adsorption_model == "STERIC_MASS_ACTION"
         npt.assert_equal(unit_config.adsorption, expected_adsorption_config)
 
     def check_particle_config(self, unit_config):
@@ -497,7 +489,7 @@ class TestProcessWithLWE:
         """
         assert unit_config.PAR_POROSITY == 0.75
         assert unit_config.PAR_RADIUS == 4.5e-05
-        assert unit_config.discretization.par_geom == 'SPHERE'
+        assert unit_config.discretization.par_geom == "SPHERE"
 
     def check_discretization(self, unit, unit_config):
         """
@@ -511,33 +503,37 @@ class TestProcessWithLWE:
             The configuration of the unit.
         """
         assert unit_config.discretization.ncol == unit.discretization.ncol
-        assert unit_config.discretization.use_analytic_jacobian == unit.discretization.use_analytic_jacobian
-        assert unit_config.discretization.reconstruction == 'WENO'
+        assert (
+            unit_config.discretization.use_analytic_jacobian
+            == unit.discretization.use_analytic_jacobian
+        )
+        assert unit_config.discretization.reconstruction == "WENO"
 
         npt.assert_equal(
-            unit_config.discretization.weno, {
-                'boundary_model': 0,
-                'weno_eps': 1e-10,
-                'weno_order': 3
-            }
+            unit_config.discretization.weno,
+            {"boundary_model": 0, "weno_eps": 1e-10, "weno_order": 3},
         )
 
         npt.assert_equal(
-            unit_config.discretization.consistency_solver, {
-                'solver_name': 'LEVMAR',
-                'init_damping': 0.01,
-                'min_damping': 0.0001,
-                'max_iterations': 50,
-                'subsolvers': 'LEVMAR'
-            }
+            unit_config.discretization.consistency_solver,
+            {
+                "solver_name": "LEVMAR",
+                "init_damping": 0.01,
+                "min_damping": 0.0001,
+                "max_iterations": 50,
+                "subsolvers": "LEVMAR",
+            },
         )
 
-        if 'spatial_method' in unit.discretization.parameters:
-            assert unit_config.discretization.spatial_method == unit.discretization.spatial_method
+        if "spatial_method" in unit.discretization.parameters:
+            assert (
+                unit_config.discretization.spatial_method
+                == unit.discretization.spatial_method
+            )
 
-        if 'npar' in unit.discretization.parameters:
+        if "npar" in unit.discretization.parameters:
             assert unit_config.discretization.npar == unit.discretization.npar
-            assert unit_config.discretization.par_disc_type == 'EQUIDISTANT_PAR'
+            assert unit_config.discretization.par_disc_type == "EQUIDISTANT_PAR"
 
     def test_solver_config(self, process: Process):
         """
@@ -552,29 +548,29 @@ class TestProcessWithLWE:
         solver_config = process_config.solver
 
         expected_solver_config = {
-            'nthreads': 1,
-            'consistent_init_mode': 1,
-            'consistent_init_mode_sens': 1,
-            'user_solution_times': np.arange(0.0, 120 * 60 + 1),
-            'sections': {
-                'nsec': 3,
-                'section_times': [0.0, 10.0, 90.0, 7200.0],
-                'section_continuity': [0, 0]
+            "nthreads": 1,
+            "consistent_init_mode": 1,
+            "consistent_init_mode_sens": 1,
+            "user_solution_times": np.arange(0.0, 120 * 60 + 1),
+            "sections": {
+                "nsec": 3,
+                "section_times": [0.0, 10.0, 90.0, 7200.0],
+                "section_continuity": [0, 0],
             },
-            'time_integrator': {
-                'abstol': 1e-08,
-                'algtol': 1e-12,
-                'reltol': 1e-06,
-                'reltol_sens': 1e-12,
-                'init_step_size': 1e-06,
-                'max_steps': 1000000,
-                'max_step_size': 0.0,
-                'errortest_sens': False,
-                'max_newton_iter': 1000000,
-                'max_errtest_fail': 1000000,
-                'max_convtest_fail': 1000000,
-                'max_newton_iter_sens': 1000000
-            }
+            "time_integrator": {
+                "abstol": 1e-08,
+                "algtol": 1e-12,
+                "reltol": 1e-06,
+                "reltol_sens": 1e-12,
+                "init_step_size": 1e-06,
+                "max_steps": 1000000,
+                "max_step_size": 0.0,
+                "errortest_sens": False,
+                "max_newton_iter": 1000000,
+                "max_errtest_fail": 1000000,
+                "max_convtest_fail": 1000000,
+                "max_newton_iter_sens": 1000000,
+            },
         }
 
         npt.assert_equal(solver_config, expected_solver_config)
@@ -589,10 +585,10 @@ class TestProcessWithLWE:
             The process object.
         """
         process_config = self.return_process_config(process)
-        return_config = process_config['return']
+        return_config = process_config["return"]
 
         # Assert that all values in return_config.unit_001 (model unit operation) are True
-        for key, value in return_config['unit_001'].items():
+        for key, value in return_config["unit_001"].items():
             assert value, f"The value for key '{key}' is not True. Found: {value}"
 
     def test_sensitivity_config(self, process: Process):
@@ -607,7 +603,7 @@ class TestProcessWithLWE:
         process_config = self.return_process_config(process)
         sensitivity_config = process_config.sensitivity
 
-        expected_sensitivity_config = {'sens_method': 'ad1', 'nsens': 0}
+        expected_sensitivity_config = {"sens_method": "ad1", "nsens": 0}
         npt.assert_equal(sensitivity_config, expected_sensitivity_config)
 
 
@@ -633,74 +629,87 @@ class TestResultsWithLWE:
         if not unit.has_ports:
             # assert solution inlet has shape (t, n_comp)
             assert simulation_results.solution[unit.name].inlet.solution_shape == (
-                int(process.cycle_time+1), process.component_system.n_comp
+                int(process.cycle_time + 1),
+                process.component_system.n_comp,
             )
             # assert solution outlet has shape (t, n_comp)
             assert simulation_results.solution[unit.name].outlet.solution_shape == (
-                int(process.cycle_time+1), process.component_system.n_comp
+                int(process.cycle_time + 1),
+                process.component_system.n_comp,
             )
             # assert solution bulk has shape (t, n_col, n_comp)
             if not isinstance(unit.discretization, NoDiscretization):
                 assert simulation_results.solution[unit.name].bulk.solution_shape == (
-                    int(process.cycle_time+1),
+                    int(process.cycle_time + 1),
                     unit.discretization.ncol,
-                    process.component_system.n_comp
+                    process.component_system.n_comp,
                 )
 
         # for units with ports
         else:
             # assert solution inlet is given for each port
-            assert len(
-                simulation_results.solution[unit.name].inlet) == unit.n_ports
+            assert len(simulation_results.solution[unit.name].inlet) == unit.n_ports
             # assert solution for channel 0 has shape (t, n_comp)
-            assert simulation_results.solution[unit.name].inlet.channel_0.solution_shape == (
-                int(process.cycle_time+1), process.component_system.n_comp
+            assert simulation_results.solution[
+                unit.name
+            ].inlet.channel_0.solution_shape == (
+                int(process.cycle_time + 1),
+                process.component_system.n_comp,
             )
             # assert solution bulk has shape (t, n_col, n_ports, n_comp)
             assert simulation_results.solution[unit.name].bulk.solution_shape == (
-                int(process.cycle_time+1),
+                int(process.cycle_time + 1),
                 unit.discretization.ncol,
                 unit.n_ports,
-                process.component_system.n_comp
+                process.component_system.n_comp,
             )
 
         # for units with particles
-        if unit.supports_binding and not isinstance(unit.discretization, NoDiscretization):
+        if unit.supports_binding and not isinstance(
+            unit.discretization, NoDiscretization
+        ):
             # for units with solid phase and particle discretization
-            if 'npar' in unit.discretization.parameters:
+            if "npar" in unit.discretization.parameters:
                 # assert solution solid has shape (t, n_col, n_par, n_comp)
                 assert simulation_results.solution[unit.name].solid.solution_shape == (
-                    int(process.cycle_time+1),
+                    int(process.cycle_time + 1),
                     unit.discretization.ncol,
                     unit.discretization.npar,
-                    process.component_system.n_comp
+                    process.component_system.n_comp,
                 )
             # for units with solid phase and without particle discretization
             else:
                 # assert solution solid has shape (t, ncol, n_comp)
                 assert simulation_results.solution[unit.name].solid.solution_shape == (
-                    int(process.cycle_time+1),
+                    int(process.cycle_time + 1),
                     unit.discretization.ncol,
-                    process.component_system.n_comp
+                    process.component_system.n_comp,
                 )
 
         # for units with particle mobile phase and particle discretization
-        if unit.supports_particle_reaction and unit.name != "LumpedRateModelWithoutPores":
+        if (
+            unit.supports_particle_reaction
+            and unit.name != "LumpedRateModelWithoutPores"
+        ):
             # assert soluction particle has shape (t, n_col, n_par, n_comp)
-            if 'npar' in unit.discretization.parameters:
-                assert simulation_results.solution[unit.name].particle.solution_shape == (
-                    int(process.cycle_time+1),
+            if "npar" in unit.discretization.parameters:
+                assert simulation_results.solution[
+                    unit.name
+                ].particle.solution_shape == (
+                    int(process.cycle_time + 1),
                     unit.discretization.ncol,
                     unit.discretization.npar,
-                    process.component_system.n_comp
+                    process.component_system.n_comp,
                 )
             # for units with particle mobiles phase and without particle discretization
             else:
                 # assert solution particle has shape (t, n_col, n_comp)
-                assert simulation_results.solution[unit.name].particle.solution_shape == (
-                    int(process.cycle_time+1),
+                assert simulation_results.solution[
+                    unit.name
+                ].particle.solution_shape == (
+                    int(process.cycle_time + 1),
                     unit.discretization.ncol,
-                    process.component_system.n_comp
+                    process.component_system.n_comp,
                 )
 
 

--- a/tests/test_carousel.py
+++ b/tests/test_carousel.py
@@ -1,17 +1,18 @@
 import unittest
+
 import numpy as np
-
-from CADETProcess.processModel import ComponentSystem
-from CADETProcess.processModel import Linear
-from CADETProcess.processModel import Inlet, Outlet, LumpedRateModelWithoutPores
-
-from CADETProcess.modelBuilder import CarouselBuilder, SerialZone, ParallelZone
-
+from CADETProcess.modelBuilder import CarouselBuilder, ParallelZone, SerialZone
+from CADETProcess.processModel import (
+    ComponentSystem,
+    Inlet,
+    Linear,
+    LumpedRateModelWithoutPores,
+    Outlet,
+)
 from CADETProcess.simulator import Cadet
 
 
 class Test_Carousel(unittest.TestCase):
-
     def setUp(self):
         self.component_system = ComponentSystem(2)
 
@@ -20,7 +21,7 @@ class Test_Carousel(unittest.TestCase):
         self.binding_model.desorption_rate = [1, 1]
 
         self.column = LumpedRateModelWithoutPores(
-            self.component_system, name='master_column'
+            self.component_system, name="master_column"
         )
         self.column.length = 0.6
         self.column.diameter = 0.024
@@ -30,17 +31,15 @@ class Test_Carousel(unittest.TestCase):
         self.column.binding_model = self.binding_model
 
     def create_serial(self):
-        source = Inlet(self.component_system, name='source')
+        source = Inlet(self.component_system, name="source")
         source.c = [10, 10]
         source.flow_rate = 2e-7
 
-        sink = Outlet(self.component_system, name='sink')
+        sink = Outlet(self.component_system, name="sink")
 
-        serial_zone = SerialZone(
-            self.component_system, 'serial', 2, flow_direction=1
-        )
+        serial_zone = SerialZone(self.component_system, "serial", 2, flow_direction=1)
 
-        builder = CarouselBuilder(self.component_system, 'serial')
+        builder = CarouselBuilder(self.component_system, "serial")
         builder.column = self.column
 
         builder.add_unit(source)
@@ -55,17 +54,17 @@ class Test_Carousel(unittest.TestCase):
         return builder
 
     def create_parallel(self):
-        source = Inlet(self.component_system, name='source')
+        source = Inlet(self.component_system, name="source")
         source.c = [10, 10]
         source.flow_rate = 2e-7
 
-        sink = Outlet(self.component_system, name='sink')
+        sink = Outlet(self.component_system, name="sink")
 
         parallel_zone = ParallelZone(
-            self.component_system, 'parallel', 2, flow_direction=1
+            self.component_system, "parallel", 2, flow_direction=1
         )
 
-        builder = CarouselBuilder(self.component_system, 'parallel')
+        builder = CarouselBuilder(self.component_system, "parallel")
         builder.column = self.column
 
         builder.add_unit(source)
@@ -80,23 +79,23 @@ class Test_Carousel(unittest.TestCase):
         return builder
 
     def create_smb(self):
-        feed = Inlet(self.component_system, name='feed')
+        feed = Inlet(self.component_system, name="feed")
         feed.c = [10, 10]
         feed.flow_rate = 2e-7
 
-        eluent = Inlet(self.component_system, name='eluent')
+        eluent = Inlet(self.component_system, name="eluent")
         eluent.c = [0, 0]
         eluent.flow_rate = 6e-7
 
-        raffinate = Outlet(self.component_system, name='raffinate')
-        extract = Outlet(self.component_system, name='extract')
+        raffinate = Outlet(self.component_system, name="raffinate")
+        extract = Outlet(self.component_system, name="extract")
 
-        zone_I = SerialZone(self.component_system, 'zone_I', 1)
-        zone_II = SerialZone(self.component_system, 'zone_II', 1)
-        zone_III = SerialZone(self.component_system, 'zone_III', 1)
-        zone_IV = SerialZone(self.component_system, 'zone_IV', 1)
+        zone_I = SerialZone(self.component_system, "zone_I", 1)
+        zone_II = SerialZone(self.component_system, "zone_II", 1)
+        zone_III = SerialZone(self.component_system, "zone_III", 1)
+        zone_IV = SerialZone(self.component_system, "zone_IV", 1)
 
-        builder = CarouselBuilder(self.component_system, 'smb')
+        builder = CarouselBuilder(self.component_system, "smb")
         builder.column = self.column
         builder.add_unit(feed)
         builder.add_unit(eluent)
@@ -114,7 +113,7 @@ class Test_Carousel(unittest.TestCase):
         builder.add_connection(zone_I, extract)
         builder.add_connection(zone_I, zone_II)
         w_e = 0.15
-        builder.set_output_state(zone_I, [w_e, 1-w_e])
+        builder.set_output_state(zone_I, [w_e, 1 - w_e])
 
         builder.add_connection(zone_II, zone_III)
 
@@ -123,7 +122,7 @@ class Test_Carousel(unittest.TestCase):
         builder.add_connection(zone_III, raffinate)
         builder.add_connection(zone_III, zone_IV)
         w_r = 0.15
-        builder.set_output_state(zone_III, [w_r, 1-w_r])
+        builder.set_output_state(zone_III, [w_r, 1 - w_r])
 
         builder.add_connection(zone_IV, zone_I)
 
@@ -132,27 +131,25 @@ class Test_Carousel(unittest.TestCase):
         return builder
 
     def create_multi_zone(self):
-        source_serial = Inlet(self.component_system, name='source_serial')
+        source_serial = Inlet(self.component_system, name="source_serial")
         source_serial.c = [10, 10]
         source_serial.flow_rate = 2e-7
 
-        sink_serial = Outlet(self.component_system, name='sink_serial')
+        sink_serial = Outlet(self.component_system, name="sink_serial")
 
-        serial_zone = SerialZone(
-            self.component_system, 'serial', 2, flow_direction=1
-        )
+        serial_zone = SerialZone(self.component_system, "serial", 2, flow_direction=1)
 
-        source_parallel = Inlet(self.component_system, name='source_parallel')
+        source_parallel = Inlet(self.component_system, name="source_parallel")
         source_parallel.c = [10, 10]
         source_parallel.flow_rate = 2e-7
 
-        sink_parallel = Outlet(self.component_system, name='sink_parallel')
+        sink_parallel = Outlet(self.component_system, name="sink_parallel")
 
         parallel_zone = ParallelZone(
-            self.component_system, 'parallel', 2, flow_direction=-1
+            self.component_system, "parallel", 2, flow_direction=-1
         )
 
-        builder = CarouselBuilder(self.component_system, 'multi_zone')
+        builder = CarouselBuilder(self.component_system, "multi_zone")
         builder.column = self.column
         builder.add_unit(source_serial)
         builder.add_unit(source_parallel)
@@ -182,9 +179,12 @@ class Test_Carousel(unittest.TestCase):
         flow_sheet = builder.build_flow_sheet()
 
         units_expected = [
-            'source', 'sink',
-            'serial_inlet', 'serial_outlet',
-            'column_0', 'column_1'
+            "source",
+            "sink",
+            "serial_inlet",
+            "serial_outlet",
+            "column_0",
+            "column_1",
         ]
 
         self.assertEqual(units_expected, flow_sheet.unit_names)
@@ -194,9 +194,12 @@ class Test_Carousel(unittest.TestCase):
         flow_sheet = builder.build_flow_sheet()
 
         units_expected = [
-            'source', 'sink',
-            'parallel_inlet', 'parallel_outlet',
-            'column_0', 'column_1'
+            "source",
+            "sink",
+            "parallel_inlet",
+            "parallel_outlet",
+            "column_0",
+            "column_1",
         ]
 
         self.assertEqual(units_expected, flow_sheet.unit_names)
@@ -206,16 +209,22 @@ class Test_Carousel(unittest.TestCase):
         flow_sheet = builder.build_flow_sheet()
 
         units_expected = [
-            'feed', 'eluent',
-            'raffinate', 'extract',
-            'zone_I_inlet', 'zone_I_outlet',
-            'column_0',
-            'zone_II_inlet', 'zone_II_outlet',
-            'column_1',
-            'zone_III_inlet', 'zone_III_outlet',
-            'column_2',
-            'zone_IV_inlet', 'zone_IV_outlet',
-            'column_3'
+            "feed",
+            "eluent",
+            "raffinate",
+            "extract",
+            "zone_I_inlet",
+            "zone_I_outlet",
+            "column_0",
+            "zone_II_inlet",
+            "zone_II_outlet",
+            "column_1",
+            "zone_III_inlet",
+            "zone_III_outlet",
+            "column_2",
+            "zone_IV_inlet",
+            "zone_IV_outlet",
+            "column_3",
         ]
 
         self.assertEqual(units_expected, flow_sheet.unit_names)
@@ -226,181 +235,91 @@ class Test_Carousel(unittest.TestCase):
         builder = self.create_serial()
         flow_sheet = builder.build_flow_sheet()
 
-        self.assertTrue(flow_sheet.connection_exists('source', 'serial_inlet'))
+        self.assertTrue(flow_sheet.connection_exists("source", "serial_inlet"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('serial_inlet', 'column_0')
-        )
-        self.assertTrue(
-            flow_sheet.connection_exists('serial_inlet', 'column_1')
-        )
+        self.assertTrue(flow_sheet.connection_exists("serial_inlet", "column_0"))
+        self.assertTrue(flow_sheet.connection_exists("serial_inlet", "column_1"))
 
-        self.assertTrue(flow_sheet.connection_exists('column_0', 'column_1'))
-        self.assertTrue(
-            flow_sheet.connection_exists('column_0', 'serial_outlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_0", "column_1"))
+        self.assertTrue(flow_sheet.connection_exists("column_0", "serial_outlet"))
 
-        self.assertTrue(flow_sheet.connection_exists('column_1', 'column_0'))
-        self.assertTrue(
-            flow_sheet.connection_exists('column_1', 'serial_outlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_1", "column_0"))
+        self.assertTrue(flow_sheet.connection_exists("column_1", "serial_outlet"))
 
         # Parallel
         builder = self.create_parallel()
         flow_sheet = builder.build_flow_sheet()
 
-        self.assertTrue(
-            flow_sheet.connection_exists('source', 'parallel_inlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("source", "parallel_inlet"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('parallel_inlet', 'column_0')
-        )
+        self.assertTrue(flow_sheet.connection_exists("parallel_inlet", "column_0"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('parallel_inlet', 'column_1')
-        )
+        self.assertTrue(flow_sheet.connection_exists("parallel_inlet", "column_1"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('column_0', 'parallel_outlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_0", "parallel_outlet"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('column_1', 'parallel_outlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_1", "parallel_outlet"))
 
         # SMB
         builder = self.create_smb()
         flow_sheet = builder.build_flow_sheet()
 
-        self.assertTrue(flow_sheet.connection_exists('eluent', 'zone_I_inlet'))
-        self.assertTrue(flow_sheet.connection_exists('feed', 'zone_III_inlet'))
+        self.assertTrue(flow_sheet.connection_exists("eluent", "zone_I_inlet"))
+        self.assertTrue(flow_sheet.connection_exists("feed", "zone_III_inlet"))
+
+        self.assertTrue(flow_sheet.connection_exists("zone_I_outlet", "extract"))
+        self.assertTrue(flow_sheet.connection_exists("zone_I_outlet", "zone_II_inlet"))
 
         self.assertTrue(
-            flow_sheet.connection_exists('zone_I_outlet', 'extract')
+            flow_sheet.connection_exists("zone_II_outlet", "zone_III_inlet")
         )
+
+        self.assertTrue(flow_sheet.connection_exists("zone_III_outlet", "raffinate"))
         self.assertTrue(
-            flow_sheet.connection_exists('zone_I_outlet', 'zone_II_inlet')
+            flow_sheet.connection_exists("zone_III_outlet", "zone_IV_inlet")
         )
 
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_II_outlet', 'zone_III_inlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("zone_IV_outlet", "zone_I_inlet"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_III_outlet', 'raffinate')
-        )
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_III_outlet', 'zone_IV_inlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("zone_I_inlet", "column_0"))
+        self.assertTrue(flow_sheet.connection_exists("zone_I_inlet", "column_1"))
+        self.assertTrue(flow_sheet.connection_exists("zone_I_inlet", "column_2"))
+        self.assertTrue(flow_sheet.connection_exists("zone_I_inlet", "column_3"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_IV_outlet', 'zone_I_inlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("zone_II_inlet", "column_0"))
+        self.assertTrue(flow_sheet.connection_exists("zone_II_inlet", "column_1"))
+        self.assertTrue(flow_sheet.connection_exists("zone_II_inlet", "column_2"))
+        self.assertTrue(flow_sheet.connection_exists("zone_II_inlet", "column_3"))
 
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_I_inlet', 'column_0')
-        )
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_I_inlet', 'column_1')
-        )
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_I_inlet', 'column_2')
-        )
-        self.assertTrue(
-            flow_sheet.connection_exists('zone_I_inlet', 'column_3')
-        )
+        self.assertTrue(flow_sheet.connection_exists("zone_III_inlet", "column_0"))
+        self.assertTrue(flow_sheet.connection_exists("zone_III_inlet", "column_1"))
+        self.assertTrue(flow_sheet.connection_exists("zone_III_inlet", "column_2"))
+        self.assertTrue(flow_sheet.connection_exists("zone_III_inlet", "column_3"))
 
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_II_inlet', 'column_0')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_II_inlet', 'column_1')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_II_inlet', 'column_2')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_II_inlet', 'column_3')
-        )
+        self.assertTrue(flow_sheet.connection_exists("zone_IV_inlet", "column_0"))
+        self.assertTrue(flow_sheet.connection_exists("zone_IV_inlet", "column_1"))
+        self.assertTrue(flow_sheet.connection_exists("zone_IV_inlet", "column_2"))
+        self.assertTrue(flow_sheet.connection_exists("zone_IV_inlet", "column_3"))
 
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_III_inlet', 'column_0')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_III_inlet', 'column_1')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_III_inlet', 'column_2')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_III_inlet', 'column_3')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_0", "zone_I_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_0", "zone_II_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_0", "zone_III_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_0", "zone_IV_outlet"))
 
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_IV_inlet', 'column_0')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_IV_inlet', 'column_1')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_IV_inlet', 'column_2')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'zone_IV_inlet', 'column_3')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_1", "zone_I_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_1", "zone_II_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_1", "zone_III_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_1", "zone_IV_outlet"))
 
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_0', 'zone_I_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_0', 'zone_II_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_0', 'zone_III_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_0', 'zone_IV_outlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_2", "zone_I_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_2", "zone_II_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_2", "zone_III_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_2", "zone_IV_outlet"))
 
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_1', 'zone_I_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_1', 'zone_II_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_1', 'zone_III_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_1', 'zone_IV_outlet')
-        )
-
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_2', 'zone_I_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_2', 'zone_II_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_2', 'zone_III_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_2', 'zone_IV_outlet')
-        )
-
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_3', 'zone_I_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_3', 'zone_II_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_3', 'zone_III_outlet')
-        )
-        self.assertTrue(flow_sheet.connection_exists(
-            'column_3', 'zone_IV_outlet')
-        )
+        self.assertTrue(flow_sheet.connection_exists("column_3", "zone_I_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_3", "zone_II_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_3", "zone_III_outlet"))
+        self.assertTrue(flow_sheet.connection_exists("column_3", "zone_IV_outlet"))
 
     def test_column_position_indices(self):
         """Test column position indices."""
@@ -411,9 +330,7 @@ class Test_Carousel(unittest.TestCase):
         carousel_state = 0
         indices_expected = 0
 
-        indices = builder.column_indices_at_state(
-            carousel_position, carousel_state
-        )
+        indices = builder.column_indices_at_state(carousel_position, carousel_state)
         self.assertEqual(indices_expected, indices)
 
         time = carousel_state * builder.switch_time
@@ -425,9 +342,7 @@ class Test_Carousel(unittest.TestCase):
         carousel_state = 0
         indices_expected = 1
 
-        indices = builder.column_indices_at_state(
-            carousel_position, carousel_state
-        )
+        indices = builder.column_indices_at_state(carousel_position, carousel_state)
         self.assertEqual(indices_expected, indices)
 
         time = carousel_state * builder.switch_time
@@ -439,9 +354,7 @@ class Test_Carousel(unittest.TestCase):
         carousel_state = 1
         indices_expected = 1
 
-        indices = builder.column_indices_at_state(
-            carousel_position, carousel_state
-        )
+        indices = builder.column_indices_at_state(carousel_position, carousel_state)
         self.assertEqual(indices_expected, indices)
 
         time = carousel_state * builder.switch_time
@@ -453,9 +366,7 @@ class Test_Carousel(unittest.TestCase):
         carousel_state = 1
         indices_expected = 2
 
-        indices = builder.column_indices_at_state(
-            carousel_position, carousel_state
-        )
+        indices = builder.column_indices_at_state(carousel_position, carousel_state)
         self.assertEqual(indices_expected, indices)
 
         time = carousel_state * builder.switch_time
@@ -467,9 +378,7 @@ class Test_Carousel(unittest.TestCase):
         carousel_state = 4
         indices_expected = 0
 
-        indices = builder.column_indices_at_state(
-            carousel_position, carousel_state
-        )
+        indices = builder.column_indices_at_state(carousel_position, carousel_state)
         self.assertEqual(indices_expected, indices)
 
         time = carousel_state * builder.switch_time
@@ -490,7 +399,7 @@ class Test_Carousel(unittest.TestCase):
         self.assertEqual(state_expected, state)
 
         # Position 0
-        time = builder.switch_time/2
+        time = builder.switch_time / 2
         state_expected = 0
 
         state = builder.carousel_state(time)
@@ -506,7 +415,7 @@ class Test_Carousel(unittest.TestCase):
         self.assertEqual(state_expected, state)
 
         # Back to initial state; position 0
-        time = 4*builder.switch_time
+        time = 4 * builder.switch_time
         state_expected = 0
 
         state = builder.carousel_state(time)
@@ -518,10 +427,10 @@ class Test_Carousel(unittest.TestCase):
         builder = self.create_serial()
         process = builder.build_process()
 
-        serial_inlet = process.flow_rate_timelines['serial_inlet']
-        serial_outlet = process.flow_rate_timelines['serial_outlet']
-        column_0 = process.flow_rate_timelines['column_0']
-        column_1 = process.flow_rate_timelines['column_1']
+        serial_inlet = process.flow_rate_timelines["serial_inlet"]
+        serial_outlet = process.flow_rate_timelines["serial_outlet"]
+        column_0 = process.flow_rate_timelines["column_0"]
+        column_1 = process.flow_rate_timelines["column_1"]
 
         flow_rate = serial_inlet.total_in[None].value(0)
         flow_rate_expected = 2e-7
@@ -543,9 +452,9 @@ class Test_Carousel(unittest.TestCase):
         builder = self.create_parallel()
         process = builder.build_process()
 
-        parallel_inlet = process.flow_rate_timelines['parallel_inlet']
-        column_0 = process.flow_rate_timelines['column_0']
-        column_1 = process.flow_rate_timelines['column_1']
+        parallel_inlet = process.flow_rate_timelines["parallel_inlet"]
+        column_0 = process.flow_rate_timelines["column_0"]
+        column_1 = process.flow_rate_timelines["column_1"]
 
         flow_rate = parallel_inlet.total_in[None].value(0)
         flow_rate_expected = 2e-7
@@ -555,7 +464,7 @@ class Test_Carousel(unittest.TestCase):
         flow_rate_expected = 2e-7
         np.testing.assert_almost_equal(flow_rate, flow_rate_expected)
 
-        flow_rate = column_0 .total_in[None].value(0)
+        flow_rate = column_0.total_in[None].value(0)
         flow_rate_expected = 1e-7
         np.testing.assert_almost_equal(flow_rate, flow_rate_expected)
 
@@ -567,10 +476,10 @@ class Test_Carousel(unittest.TestCase):
         builder = self.create_multi_zone()
         process = builder.build_process()
 
-        serial_inlet = process.flow_rate_timelines['serial_inlet']
-        parallel_inlet = process.flow_rate_timelines['parallel_inlet']
-        column_0 = process.flow_rate_timelines['column_0']
-        column_2 = process.flow_rate_timelines['column_2']
+        serial_inlet = process.flow_rate_timelines["serial_inlet"]
+        parallel_inlet = process.flow_rate_timelines["parallel_inlet"]
+        column_0 = process.flow_rate_timelines["column_0"]
+        column_2 = process.flow_rate_timelines["column_2"]
 
         flow_rate = serial_inlet.total_in[None].value(0)
         flow_rate_expected = 2e-7
@@ -608,12 +517,12 @@ class Test_Carousel(unittest.TestCase):
         # Initial state
         t = 0
 
-        tl = process.parameter_timelines['flow_sheet.column_0.flow_direction']
+        tl = process.parameter_timelines["flow_sheet.column_0.flow_direction"]
         flow_direction = tl.value(t)
         flow_direction_expected = 1
         np.testing.assert_almost_equal(flow_direction, flow_direction_expected)
 
-        tl = process.parameter_timelines['flow_sheet.column_2.flow_direction']
+        tl = process.parameter_timelines["flow_sheet.column_2.flow_direction"]
         flow_direction = tl.value(t)
         flow_direction_expected = -1
         np.testing.assert_almost_equal(flow_direction, flow_direction_expected)
@@ -621,12 +530,12 @@ class Test_Carousel(unittest.TestCase):
         # First position
         t = builder.switch_time
 
-        tl = process.parameter_timelines['flow_sheet.column_0.flow_direction']
+        tl = process.parameter_timelines["flow_sheet.column_0.flow_direction"]
         flow_direction = tl.value(t)
         flow_direction_expected = -1
         np.testing.assert_almost_equal(flow_direction, flow_direction_expected)
 
-        tl = process.parameter_timelines['flow_sheet.column_2.flow_direction']
+        tl = process.parameter_timelines["flow_sheet.column_2.flow_direction"]
         flow_direction = tl.value(t)
         flow_direction_expected = 1
         np.testing.assert_almost_equal(flow_direction, flow_direction_expected)
@@ -641,5 +550,5 @@ class Test_Carousel(unittest.TestCase):
         self.assertEqual(simulation_results.exit_flag, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_compartment.py
+++ b/tests/test_compartment.py
@@ -1,14 +1,12 @@
 import unittest
-import numpy as np
 
+import numpy as np
 from CADETProcess import CADETProcessError
-from CADETProcess.processModel import ComponentSystem
-from CADETProcess.processModel import Langmuir
 from CADETProcess.modelBuilder import CompartmentBuilder
+from CADETProcess.processModel import ComponentSystem, Langmuir
 
 
 class Test_CompartmentBuilder(unittest.TestCase):
-
     def setUp(self):
         self.component_system = ComponentSystem(2)
 
@@ -16,37 +14,41 @@ class Test_CompartmentBuilder(unittest.TestCase):
 
         self.volume_simple = [1, 2, 3, 4, 5]
         self.matrix_simple = [
-            0,   0.1, 0.2, 0.3, 0.4,
-            0.1, 0,   0,   0,   0,
-            0.2, 0,   0,   0,   0,
-            0.3, 0,   0,   0,   0,
-            0.4, 0,   0,   0,   0,
+            0,   0.1, 0.2, 0.3, 0.4,  # noqa: E241
+            0.1, 0,   0,   0,   0,    # noqa: E241
+            0.2, 0,   0,   0,   0,    # noqa: E241
+            0.3, 0,   0,   0,   0,    # noqa: E241
+            0.4, 0,   0,   0,   0,    # noqa: E241
         ]
 
         self.builder_simple = CompartmentBuilder(
             self.component_system,
-            self.volume_simple, self.matrix_simple,
+            self.volume_simple,
+            self.matrix_simple,
         )
         self.builder_simple.cycle_time = 1000
 
-        self.volume_complex = ['inlet', 2, 1, 3, 1, 2, 1, 4, 1, 'outlet']
+        self.volume_complex = ["inlet", 2, 1, 3, 1, 2, 1, 4, 1, "outlet"]
+        # fmt: off
         self.matrix_complex = [
         #   0    1    2    3    4    5    6    7    8    9
-            0,   0.1, 0,   0,   0,   0,   0,   0,   0,   0,    # 0
-            0,   0,   0.3, 0,   0,   0,   0,   0.1, 0,   0,    # 1
-            0,   0.1, 0,   0.1, 0,   0,   0,   0.1, 0,   0,    # 2
-            0,   0.2, 0,   0,   0,   0.5, 0,   0,   0.1, 0,    # 3
-            0,   0,   0,   0.1, 0,   0.1, 0,   0.1, 0,   0,    # 4
-            0,   0,   0,   0,   0.3, 0,   0.2, 0.1, 0,   0,    # 5
-            0,   0,   0,   0,   0,   0,   0,   0.1, 0,   0.1,  # 6
-            0,   0,   0,   0.5, 0,   0,   0,   0,   0,   0,    # 7
-            0,   0,   0,   0.1, 0,   0,   0,   0,   0,   0,    # 8
-            0,   0,   0,   0,   0,   0,   0,   0,   0,   0,    # 9
+            0,   0.1, 0,   0,   0,   0,   0,   0,   0,   0,    # 0 #noqa: E241
+            0,   0,   0.3, 0,   0,   0,   0,   0.1, 0,   0,    # 1 #noqa: E241
+            0,   0.1, 0,   0.1, 0,   0,   0,   0.1, 0,   0,    # 2 #noqa: E241
+            0,   0.2, 0,   0,   0,   0.5, 0,   0,   0.1, 0,    # 3 #noqa: E241
+            0,   0,   0,   0.1, 0,   0.1, 0,   0.1, 0,   0,    # 4 #noqa: E241
+            0,   0,   0,   0,   0.3, 0,   0.2, 0.1, 0,   0,    # 5 #noqa: E241
+            0,   0,   0,   0,   0,   0,   0,   0.1, 0,   0.1,  # 6 #noqa: E241
+            0,   0,   0,   0.5, 0,   0,   0,   0,   0,   0,    # 7 #noqa: E241
+            0,   0,   0,   0.1, 0,   0,   0,   0,   0,   0,    # 8 #noqa: E241
+            0,   0,   0,   0,   0,   0,   0,   0,   0,   0,    # 9 #noqa: E241
         ]
+        # fmt: on
 
         self.builder_complex = CompartmentBuilder(
             self.component_system,
-            self.volume_complex, self.matrix_complex,
+            self.volume_complex,
+            self.matrix_complex,
             init_c=1,
         )
         self.builder_complex.cycle_time = 1000
@@ -62,134 +64,66 @@ class Test_CompartmentBuilder(unittest.TestCase):
 
     def test_connections(self):
         flow_rates_expected = {
-            'compartment_0': {
-                'total_in': {
-                    None: np.array([1., 0., 0., 0.])
-                },
-                'total_out': {
-                    None: np.array([1., 0., 0., 0.])
-                },
-                'origins': {
+            "compartment_0": {
+                "total_in": {None: np.array([1.0, 0.0, 0.0, 0.0])},
+                "total_out": {None: np.array([1.0, 0.0, 0.0, 0.0])},
+                "origins": {
                     None: {
-                        'compartment_1': {
-                            None: np.array([0.1, 0., 0., 0.])
-                        },
-                        'compartment_2': {
-                            None: np.array([0.2, 0., 0., 0.])
-                        },
-                        'compartment_3': {
-                            None: np.array([0.3, 0., 0., 0.])
-                        },
-                        'compartment_4': {
-                            None: np.array([0.4, 0., 0., 0.])
-                        }
+                        "compartment_1": {None: np.array([0.1, 0.0, 0.0, 0.0])},
+                        "compartment_2": {None: np.array([0.2, 0.0, 0.0, 0.0])},
+                        "compartment_3": {None: np.array([0.3, 0.0, 0.0, 0.0])},
+                        "compartment_4": {None: np.array([0.4, 0.0, 0.0, 0.0])},
                     }
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'compartment_1': {
-                            None: np.array([0.1, 0., 0., 0.])
-                        },
-                        'compartment_2': {
-                            None: np.array([0.2, 0., 0., 0.])
-                        },
-                        'compartment_3': {
-                            None: np.array([0.3, 0., 0., 0.])
-                        },
-                        'compartment_4': {
-                            None: np.array([0.4, 0., 0., 0.])
-                        }
+                        "compartment_1": {None: np.array([0.1, 0.0, 0.0, 0.0])},
+                        "compartment_2": {None: np.array([0.2, 0.0, 0.0, 0.0])},
+                        "compartment_3": {None: np.array([0.3, 0.0, 0.0, 0.0])},
+                        "compartment_4": {None: np.array([0.4, 0.0, 0.0, 0.0])},
                     }
                 },
             },
-            'compartment_1': {
-                'total_in': {
-                    None: np.array([0.1, 0., 0., 0.])
+            "compartment_1": {
+                "total_in": {None: np.array([0.1, 0.0, 0.0, 0.0])},
+                "total_out": {None: np.array([0.1, 0.0, 0.0, 0.0])},
+                "origins": {
+                    None: {"compartment_0": {None: np.array([0.1, 0.0, 0.0, 0.0])}}
                 },
-                'total_out': {
-                    None: np.array([0.1, 0., 0., 0.])
-                },
-                'origins': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.1, 0., 0., 0.])
-                        }
-                    }
-                },
-                'destinations': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.1, 0., 0., 0.])
-                        }
-                    }
+                "destinations": {
+                    None: {"compartment_0": {None: np.array([0.1, 0.0, 0.0, 0.0])}}
                 },
             },
-            'compartment_2': {
-                'total_in': {
-                    None: np.array([0.2, 0., 0., 0.])
+            "compartment_2": {
+                "total_in": {None: np.array([0.2, 0.0, 0.0, 0.0])},
+                "total_out": {None: np.array([0.2, 0.0, 0.0, 0.0])},
+                "origins": {
+                    None: {"compartment_0": {None: np.array([0.2, 0.0, 0.0, 0.0])}}
                 },
-                'total_out': {
-                    None: np.array([0.2, 0., 0., 0.])
+                "destinations": {
+                    None: {"compartment_0": {None: np.array([0.2, 0.0, 0.0, 0.0])}}
                 },
-                'origins': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.2, 0., 0., 0.])
-                        }
-                    }
-                },
-                'destinations': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.2, 0., 0., 0.])
-                        }
-                    }
-                }
             },
-            'compartment_3': {
-                'total_in': {
-                    None: np.array([0.3, 0., 0., 0.])
+            "compartment_3": {
+                "total_in": {None: np.array([0.3, 0.0, 0.0, 0.0])},
+                "total_out": {None: np.array([0.3, 0.0, 0.0, 0.0])},
+                "origins": {
+                    None: {"compartment_0": {None: np.array([0.3, 0.0, 0.0, 0.0])}}
                 },
-                'total_out': {
-                    None: np.array([0.3, 0., 0., 0.])
+                "destinations": {
+                    None: {"compartment_0": {None: np.array([0.3, 0.0, 0.0, 0.0])}}
                 },
-                'origins': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.3, 0., 0., 0.])
-                        }
-                    }
-                },
-                'destinations': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.3, 0., 0., 0.])
-                        }
-                    }
-                }
             },
-            'compartment_4': {
-                'total_in': {
-                    None: np.array([0.4, 0., 0., 0.])
+            "compartment_4": {
+                "total_in": {None: np.array([0.4, 0.0, 0.0, 0.0])},
+                "total_out": {None: np.array([0.4, 0.0, 0.0, 0.0])},
+                "origins": {
+                    None: {"compartment_0": {None: np.array([0.4, 0.0, 0.0, 0.0])}}
                 },
-                'total_out': {
-                    None: np.array([0.4, 0., 0., 0.])
+                "destinations": {
+                    None: {"compartment_0": {None: np.array([0.4, 0.0, 0.0, 0.0])}}
                 },
-                'origins': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.4, 0., 0., 0.])
-                        }
-                    }
-                },
-                'destinations': {
-                    None: {
-                        'compartment_0': {
-                            None: np.array([0.4, 0., 0., 0.])
-                        }
-                    }
-                }
-            }
+            },
         }
         flow_rates = self.builder_simple.flow_sheet.get_flow_rates().to_dict()
         np.testing.assert_equal(flow_rates, flow_rates_expected)
@@ -204,7 +138,8 @@ class Test_CompartmentBuilder(unittest.TestCase):
         # All to zero (default)
         builder = CompartmentBuilder(
             self.component_system,
-            self.volume_complex, self.matrix_complex,
+            self.volume_complex,
+            self.matrix_complex,
         )
         c_expected = [0, 0]
         c = builder.flow_sheet.compartment_2.c
@@ -213,7 +148,8 @@ class Test_CompartmentBuilder(unittest.TestCase):
         # All components, all compartments same value
         builder = CompartmentBuilder(
             self.component_system,
-            self.volume_complex, self.matrix_complex,
+            self.volume_complex,
+            self.matrix_complex,
             init_c=1,
         )
         c_expected = [1, 1]
@@ -223,7 +159,8 @@ class Test_CompartmentBuilder(unittest.TestCase):
         # All compartments same value
         builder = CompartmentBuilder(
             self.component_system,
-            self.volume_complex, self.matrix_complex,
+            self.volume_complex,
+            self.matrix_complex,
             init_c=[1, 2],
         )
         c_expected = [1, 2]
@@ -231,17 +168,12 @@ class Test_CompartmentBuilder(unittest.TestCase):
         np.testing.assert_almost_equal(c, c_expected)
 
         # Different per zone
-        init_c = np.array([
-            [0, 0],
-            [1, 1],
-            [2, 2],
-            [3, 3],
-            [4, 4]
-        ])
+        init_c = np.array([[0, 0], [1, 1], [2, 2], [3, 3], [4, 4]])
 
         builder = CompartmentBuilder(
             self.component_system,
-            self.volume_simple, self.matrix_simple,
+            self.volume_simple,
+            self.matrix_simple,
             init_c=init_c,
         )
         c = builder.flow_sheet.compartment_2.c
@@ -260,10 +192,11 @@ class Test_CompartmentBuilder(unittest.TestCase):
         self.builder_complex.add_tracer(4, [1, 1], 10, 0.1)
 
         from CADETProcess.simulator import Cadet
+
         process_simulator = Cadet()
 
         proc_results = process_simulator.simulate(self.builder_complex.process)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,7 +1,6 @@
-
 import unittest
-import numpy as np
 
+import numpy as np
 from CADETProcess import CADETProcessError
 from CADETProcess.processModel import ComponentSystem
 
@@ -10,98 +9,88 @@ class TestComponents(unittest.TestCase):
     def setUp(self):
         self.component_system_0 = ComponentSystem(2)
 
-        self.component_system_1 = ComponentSystem(['A', 'B'])
+        self.component_system_1 = ComponentSystem(["A", "B"])
 
         self.component_system_2 = ComponentSystem()
-        self.component_system_2.add_component('A')
-        self.component_system_2.add_component('B', species=['B+', 'B-'])
+        self.component_system_2.add_component("A")
+        self.component_system_2.add_component("B", species=["B+", "B-"])
 
         self.component_system_3 = ComponentSystem()
         self.component_system_3.add_component(
-            'Ammonia',
-            species=['NH4+', 'NH3'],
+            "Ammonia",
+            species=["NH4+", "NH3"],
             charge=[1, 0],
         )
         self.component_system_3.add_component(
-            'Lysine',
-            ['Lys2+', 'Lys+', 'Lys', 'Lys'],
-            [2, 1, 0, -1]
+            "Lysine", ["Lys2+", "Lys+", "Lys", "Lys"], [2, 1, 0, -1]
         )
         self.component_system_3.add_component(
-            'H+',
+            "H+",
             charge=1,
         )
 
         self.component_system_4 = ComponentSystem(2)
-        self.component_system_4.add_component('manual_label')
+        self.component_system_4.add_component("manual_label")
 
         self.component_system_5 = ComponentSystem()
         self.component_system_5.add_component(
-            'A',
-            species=['A+', 'A-'],
-            molecular_weight=[1, 0]
+            "A", species=["A+", "A-"], molecular_weight=[1, 0]
         )
 
         self.component_system_6 = ComponentSystem()
-        self.component_system_6.add_component(
-            'A',
-            species=['A+', 'A-'],
-            density=[1, 0]
-        )
+        self.component_system_6.add_component("A", species=["A+", "A-"], density=[1, 0])
 
     def test_names(self):
-        names_expected = ['0', '1']
+        names_expected = ["0", "1"]
         names = self.component_system_0.names
         np.testing.assert_equal(names, names_expected)
 
-        names_expected = ['A', 'B']
+        names_expected = ["A", "B"]
         names = self.component_system_1.names
         np.testing.assert_equal(names, names_expected)
 
-        names_expected = ['A', 'B']
+        names_expected = ["A", "B"]
         names = self.component_system_2.names
         np.testing.assert_equal(names, names_expected)
 
-        names_expected = ['Ammonia', 'Lysine', 'H+']
+        names_expected = ["Ammonia", "Lysine", "H+"]
         names = self.component_system_3.names
         np.testing.assert_equal(names, names_expected)
 
-        names_expected = ['0', '1', 'manual_label']
+        names_expected = ["0", "1", "manual_label"]
         names = self.component_system_4.names
         np.testing.assert_equal(names, names_expected)
 
     def test_duplicate_name(self):
         with self.assertRaises(CADETProcessError):
-            self.component_system_1.add_component('A')
+            self.component_system_1.add_component("A")
 
     def test_species(self):
-        species_expected = ['0', '1']
+        species_expected = ["0", "1"]
         species = self.component_system_0.species
         np.testing.assert_equal(species, species_expected)
 
-        species_expected = ['A', 'B']
+        species_expected = ["A", "B"]
         species = self.component_system_1.species
         np.testing.assert_equal(species, species_expected)
 
-        species_expected = ['A', 'B+', 'B-']
+        species_expected = ["A", "B+", "B-"]
         species = self.component_system_2.species
         np.testing.assert_equal(species, species_expected)
 
-        species_expected = [
-            'NH4+', 'NH3', 'Lys2+', 'Lys+', 'Lys', 'Lys', 'H+'
-        ]
+        species_expected = ["NH4+", "NH3", "Lys2+", "Lys+", "Lys", "Lys", "H+"]
         species = self.component_system_3.species
         np.testing.assert_equal(species, species_expected)
 
-        species_expected = ['0', '1', 'manual_label']
+        species_expected = ["0", "1", "manual_label"]
         species = self.component_system_4.species
         np.testing.assert_equal(species, species_expected)
 
     def test_indices(self):
         indices_expected = {
-            'Ammonia': [0, 1],
-            'Lysine': [2, 3, 4, 5],
-            'H+': [6],
+            "Ammonia": [0, 1],
+            "Lysine": [2, 3, 4, 5],
+            "H+": [6],
         }
         indices = self.component_system_3.indices
         np.testing.assert_equal(indices, indices_expected)
@@ -138,5 +127,6 @@ class TestComponents(unittest.TestCase):
         densities = self.component_system_6.densities
         np.testing.assert_equal(densities_expected, densities)
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_deprecation.py
+++ b/tests/test_deprecation.py
@@ -3,10 +3,10 @@ import unittest
 # Import the functions to test
 from CADETProcess.dataStructure import deprecated_alias, rename_kwargs
 
-class TestDeprecatedAlias(unittest.TestCase):
 
+class TestDeprecatedAlias(unittest.TestCase):
     def test_basic_functionality(self):
-        @deprecated_alias(old_arg='new_arg')
+        @deprecated_alias(old_arg="new_arg")
         def example_func(new_arg):
             return new_arg
 
@@ -23,10 +23,10 @@ class TestDeprecatedAlias(unittest.TestCase):
         self.assertIn("`old_arg` is deprecated", warning_message)
         self.assertIn("use `new_arg` instead", warning_message)
 
-
     def test_argument_conflict(self):
         """Test error when both old and new argument names are used."""
-        @deprecated_alias(old_arg='new_arg')
+
+        @deprecated_alias(old_arg="new_arg")
         def example_func(new_arg):
             return new_arg
 
@@ -34,24 +34,26 @@ class TestDeprecatedAlias(unittest.TestCase):
         with self.assertRaises(TypeError) as context:
             example_func(old_arg=1, new_arg=2)
 
-        self.assertIn("received both old_arg and new_arg as arguments",
-                     str(context.exception))
+        self.assertIn(
+            "received both old_arg and new_arg as arguments", str(context.exception)
+        )
 
     def test_rename_kwargs_direct(self):
         """Test rename_kwargs function directly."""
-        kwargs = {'old_arg': 42}
-        aliases = {'old_arg': 'new_arg'}
+        kwargs = {"old_arg": 42}
+        aliases = {"old_arg": "new_arg"}
 
         with self.assertWarns(DeprecationWarning):
-            rename_kwargs('test_func', kwargs, aliases)
+            rename_kwargs("test_func", kwargs, aliases)
 
-        self.assertIn('new_arg', kwargs)
-        self.assertNotIn('old_arg', kwargs)
-        self.assertEqual(kwargs['new_arg'], 42)
+        self.assertIn("new_arg", kwargs)
+        self.assertNotIn("old_arg", kwargs)
+        self.assertEqual(kwargs["new_arg"], 42)
 
     def test_positional_args(self):
         """Test that positional arguments work normally with the decorator."""
-        @deprecated_alias(old_kwarg='new_kwarg')
+
+        @deprecated_alias(old_kwarg="new_kwarg")
         def example_func(pos_arg, new_kwarg=None):
             return f"{pos_arg}-{new_kwarg}"
 
@@ -64,11 +66,13 @@ class TestDeprecatedAlias(unittest.TestCase):
 
     def test_no_arguments(self):
         """Test function with no arguments still works with decorator."""
-        @deprecated_alias(old_arg='new_arg')
+
+        @deprecated_alias(old_arg="new_arg")
         def example_func():
             return "success"
 
         self.assertEqual(example_func(), "success")
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -1,15 +1,13 @@
 import unittest
 
 import numpy as np
-from scipy import stats
-
 from CADETProcess import CADETProcessError
 from CADETProcess.processModel import ComponentSystem
 from CADETProcess.reference import ReferenceIO
 from CADETProcess.solution import SolutionIO
+from scipy import stats
 
-
-comp_2 = ComponentSystem(['A', 'B'])
+comp_2 = ComponentSystem(["A", "B"])
 
 time = np.linspace(0, 100, 1001)
 
@@ -39,14 +37,17 @@ q_const = np.ones(time.shape)
 
 
 from CADETProcess.comparison import SSE
-class TestSSE(unittest.TestCase):
 
+
+class TestSSE(unittest.TestCase):
     def test_metric(self):
         # Compare with itself
         component_system = ComponentSystem(1)
         reference = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [0]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [0]],
+            component_system=component_system,
         )
 
         difference = SSE(reference)
@@ -57,8 +58,10 @@ class TestSSE(unittest.TestCase):
         # Compare with other Gaussian Peak
         component_system = ComponentSystem(1)
         solution = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [1]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [1]],
+            component_system=component_system,
         )
 
         difference = SSE(reference, resample=False)
@@ -73,14 +76,17 @@ class TestSSE(unittest.TestCase):
 
 
 from CADETProcess.comparison import NRMSE
-class TestNRMSE(unittest.TestCase):
 
+
+class TestNRMSE(unittest.TestCase):
     def test_metric(self):
         # Compare with itself
         component_system = ComponentSystem(1)
         reference = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [0]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [0]],
+            component_system=component_system,
         )
 
         difference = NRMSE(reference)
@@ -91,8 +97,10 @@ class TestNRMSE(unittest.TestCase):
         # Compare with other Gaussian Peak
         component_system = ComponentSystem(1)
         solution = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [1]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [1]],
+            component_system=component_system,
         )
 
         difference = NRMSE(reference, resample=False)
@@ -107,45 +115,44 @@ class TestNRMSE(unittest.TestCase):
 
 
 from CADETProcess.comparison import PeakHeight
-class TestPeakHeight(unittest.TestCase):
 
+
+class TestPeakHeight(unittest.TestCase):
     def setUp(self):
         # 2 Components, gaussian peaks, constant flow
         component_system = ComponentSystem(1)
         self.reference_single = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [0]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [0]],
+            component_system=component_system,
         )
 
         self.reference = ReferenceIO(
-            'simple', time, solution_2_gaussian,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian, component_system=comp_2
         )
 
         self.reference_switched = ReferenceIO(
-            'simple', time, solution_2_gaussian_switched,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian_switched, component_system=comp_2
         )
 
         self.reference_different_height = ReferenceIO(
-            'simple', time, solution_2_gaussian_different_height,
-            component_system=comp_2
+            "simple",
+            time,
+            solution_2_gaussian_different_height,
+            component_system=comp_2,
         )
 
     def test_metric(self):
         # Compare with itself
-        difference = PeakHeight(
-            self.reference, components=['A']
-        )
+        difference = PeakHeight(self.reference, components=["A"])
         metrics_expected = [0]
         metrics = difference.evaluate(self.reference)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
         # Compare with other Gauss Peak
         difference = PeakHeight(
-            self.reference_switched,
-            components=['A'],
-            normalize_metrics=False
+            self.reference_switched, components=["A"], normalize_metrics=False
         )
         metrics_expected = [0]
         metrics = difference.evaluate(self.reference)
@@ -153,9 +160,7 @@ class TestPeakHeight(unittest.TestCase):
 
         # Compare with other Gauss Peak, normalize_metrics
         difference = PeakHeight(
-            self.reference_switched,
-            components=['A'],
-            normalize_metrics=True
+            self.reference_switched, components=["A"], normalize_metrics=True
         )
         metrics_expected = [0]
         metrics = difference.evaluate(self.reference)
@@ -168,67 +173,55 @@ class TestPeakHeight(unittest.TestCase):
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
         # Swich components
-        difference = PeakHeight(
-            self.reference,
-            normalize_metrics=False
-        )
+        difference = PeakHeight(self.reference, normalize_metrics=False)
         metrics_expected = [0, 0]
         metrics = difference.evaluate(self.reference_switched)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
         # Different Peaks
-        difference = PeakHeight(
-            self.reference,
-            normalize_metrics=False
-        )
+        difference = PeakHeight(self.reference, normalize_metrics=False)
         metrics_expected = [0.0531923, 0.0]
         metrics = difference.evaluate(self.reference_different_height)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
-        difference = PeakHeight(
-            self.reference,
-            normalize_metrics=True
-        )
+        difference = PeakHeight(self.reference, normalize_metrics=True)
         metrics_expected = [0.3215127, 0.0]
         metrics = difference.evaluate(self.reference_different_height)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
 
 from CADETProcess.comparison import PeakPosition
-class TestPeakPosition(unittest.TestCase):
 
+
+class TestPeakPosition(unittest.TestCase):
     def setUp(self):
         # 2 Components, gaussian peaks, constant flow
         component_system = ComponentSystem(1)
         self.reference_single = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [0]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [0]],
+            component_system=component_system,
         )
 
         self.reference = ReferenceIO(
-            'simple', time, solution_2_gaussian,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian, component_system=comp_2
         )
 
         self.reference_switched = ReferenceIO(
-            'simple', time, solution_2_gaussian_switched,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian_switched, component_system=comp_2
         )
 
     def test_metric(self):
         # Compare with itself
-        difference = PeakPosition(
-            self.reference, components=['A']
-        )
+        difference = PeakPosition(self.reference, components=["A"])
         metrics_expected = [0]
         metrics = difference.evaluate(self.reference)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
         # Compare with other Gauss Peak
         difference = PeakPosition(
-            self.reference_switched,
-            components=['A'],
-            normalize_metrics=False
+            self.reference_switched, components=["A"], normalize_metrics=False
         )
         metrics_expected = [10]
         metrics = difference.evaluate(self.reference)
@@ -236,9 +229,7 @@ class TestPeakPosition(unittest.TestCase):
 
         # Compare with other Gauss Peak, normalize_metrics
         difference = PeakPosition(
-            self.reference_switched,
-            components=['B'],
-            normalize_metrics=True
+            self.reference_switched, components=["B"], normalize_metrics=True
         )
         metrics_expected = [0.1651404]
         metrics = difference.evaluate(self.reference)
@@ -251,10 +242,7 @@ class TestPeakPosition(unittest.TestCase):
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
         # Swich components
-        difference = PeakPosition(
-            self.reference,
-            normalize_metrics=False
-            )
+        difference = PeakPosition(self.reference, normalize_metrics=False)
         metrics_expected = [10, 10]
         metrics = difference.evaluate(self.reference_switched)
         np.testing.assert_almost_equal(metrics, metrics_expected)
@@ -266,24 +254,25 @@ class TestPeakPosition(unittest.TestCase):
 
 
 from CADETProcess.comparison import Shape
-class TestShape(unittest.TestCase):
 
+
+class TestShape(unittest.TestCase):
     def setUp(self):
         # 2 Components, gaussian peaks, constant flow
         component_system = ComponentSystem(1)
         self.reference_single = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [0]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [0]],
+            component_system=component_system,
         )
 
         self.reference = ReferenceIO(
-            'simple', time, solution_2_gaussian,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian, component_system=comp_2
         )
 
         self.reference_switched = ReferenceIO(
-            'simple', time, solution_2_gaussian_switched,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian_switched, component_system=comp_2
         )
 
     def test_metric(self):
@@ -291,7 +280,7 @@ class TestShape(unittest.TestCase):
         difference = Shape(
             self.reference,
             use_derivative=False,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 0]
@@ -302,7 +291,7 @@ class TestShape(unittest.TestCase):
         difference = Shape(
             self.reference_switched,
             use_derivative=False,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [5.5511151e-16, 10]
@@ -313,7 +302,7 @@ class TestShape(unittest.TestCase):
         difference = Shape(
             self.reference_switched,
             use_derivative=False,
-            components=['A'],
+            components=["A"],
             normalize_metrics=True,
         )
         metrics_expected = [0, 4.6211716e-01]
@@ -324,7 +313,7 @@ class TestShape(unittest.TestCase):
         difference = Shape(
             self.reference_switched,
             use_derivative=True,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 10, 0]
@@ -335,7 +324,7 @@ class TestShape(unittest.TestCase):
         difference = Shape(
             self.reference_switched,
             use_derivative=True,
-            components=['A'],
+            components=["A"],
             normalize_metrics=True,
         )
         metrics_expected = [0, 4.6211716e-01, 0]
@@ -352,24 +341,25 @@ class TestShape(unittest.TestCase):
 
 
 from CADETProcess.comparison import ShapeFront
-class TestShapeFront(unittest.TestCase):
 
+
+class TestShapeFront(unittest.TestCase):
     def setUp(self):
         # 2 Components, gaussian peaks, constant flow
         component_system = ComponentSystem(1)
         self.reference_single = ReferenceIO(
-            'simple', time, solution_2_gaussian[:, [0]],
-            component_system=component_system
+            "simple",
+            time,
+            solution_2_gaussian[:, [0]],
+            component_system=component_system,
         )
 
         self.reference = ReferenceIO(
-            'simple', time, solution_2_gaussian,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian, component_system=comp_2
         )
 
         self.reference_switched = ReferenceIO(
-            'simple', time, solution_2_gaussian_switched,
-            component_system=comp_2
+            "simple", time, solution_2_gaussian_switched, component_system=comp_2
         )
 
     def test_metric(self):
@@ -377,7 +367,7 @@ class TestShapeFront(unittest.TestCase):
         difference = ShapeFront(
             self.reference,
             use_derivative=False,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 0]
@@ -388,7 +378,7 @@ class TestShapeFront(unittest.TestCase):
         difference = ShapeFront(
             self.reference_switched,
             use_derivative=False,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 10]
@@ -399,7 +389,7 @@ class TestShapeFront(unittest.TestCase):
         difference = ShapeFront(
             self.reference_switched,
             use_derivative=False,
-            components=['A'],
+            components=["A"],
             normalize_metrics=True,
         )
         metrics_expected = [0, 4.6211716e-01]
@@ -410,7 +400,7 @@ class TestShapeFront(unittest.TestCase):
         difference = ShapeFront(
             self.reference_switched,
             use_derivative=True,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 10, 0]
@@ -421,7 +411,7 @@ class TestShapeFront(unittest.TestCase):
         difference = ShapeFront(
             self.reference_switched,
             use_derivative=True,
-            components=['A'],
+            components=["A"],
             normalize_metrics=True,
         )
         metrics_expected = [0, 4.6211716e-01, 0]
@@ -433,7 +423,7 @@ class TestShapeFront(unittest.TestCase):
             self.reference,
             use_derivative=False,
             use_max_slope=True,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 0]
@@ -444,7 +434,7 @@ class TestShapeFront(unittest.TestCase):
             self.reference_switched,
             use_derivative=False,
             use_max_slope=True,
-            components=['A'],
+            components=["A"],
             normalize_metrics=False,
         )
         metrics_expected = [0, 10]
@@ -460,13 +450,12 @@ class TestShapeFront(unittest.TestCase):
             metrics = difference.evaluate(self.reference)
 
 
+from CADETProcess.comparison import FractionationSSE
 from CADETProcess.fractionation import Fraction
 from CADETProcess.reference import FractionationReference
-from CADETProcess.comparison import FractionationSSE
 
 
 class TestFractionation(unittest.TestCase):
-
     def setUp(self):
         fraction_1 = Fraction(
             start=15,
@@ -482,26 +471,25 @@ class TestFractionation(unittest.TestCase):
         )
         self.fractions = [fraction_1, fraction_2]
 
-        component_system = ComponentSystem(['A', 'B'])
+        component_system = ComponentSystem(["A", "B"])
         self.reference = FractionationReference(
-            'fractions', [fraction_1, fraction_2],
-            component_system=component_system
+            "fractions", [fraction_1, fraction_2], component_system=component_system
         )
 
         self.solution = SolutionIO(
-            'simple', comp_2, time, solution_2_gaussian, flow_rate=q_const
+            "simple", comp_2, time, solution_2_gaussian, flow_rate=q_const
         )
 
     def test_metric(self):
         # Compare with itself
         difference = FractionationSSE(
             self.reference,
-            components=['A'],
+            components=["A"],
         )
         metrics_expected = [1.30315857e-19]
         metrics = difference.evaluate(self.solution)
         np.testing.assert_almost_equal(metrics, metrics_expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -1,60 +1,51 @@
 import unittest
 
 import numpy as np
-
-from CADETProcess.processModel import Linear, Langmuir, StericMassAction
-from CADETProcess.processModel import MassActionLaw
-from CADETProcess.processModel import ComponentSystem
-
 from CADETProcess import equilibria
+from CADETProcess.processModel import (
+    ComponentSystem,
+    Langmuir,
+    Linear,
+    MassActionLaw,
+    StericMassAction,
+)
 
 
 class TestReactionEquilibrium(unittest.TestCase):
-
     def setUp(self):
         component_system = ComponentSystem(2)
 
-        self.single_0 = MassActionLaw(component_system, name='simple')
-        self.single_0.add_reaction(
-            [0, 1], [-1, 1], 2, k_bwd=2
-        )
+        self.single_0 = MassActionLaw(component_system, name="simple")
+        self.single_0.add_reaction([0, 1], [-1, 1], 2, k_bwd=2)
 
-        self.single_1 = MassActionLaw(component_system, name='simple')
-        self.single_1.add_reaction(
-            [0, 1], [-1, 1], 1, k_bwd=1
-        )
+        self.single_1 = MassActionLaw(component_system, name="simple")
+        self.single_1.add_reaction([0, 1], [-1, 1], 1, k_bwd=1)
 
         component_system = ComponentSystem(3)
-        self.single_2 = MassActionLaw(component_system, name='simple')
-        self.single_2.add_reaction(
-            [0, 1], [-1, 1], 1, k_bwd=1
-        )
+        self.single_2 = MassActionLaw(component_system, name="simple")
+        self.single_2.add_reaction([0, 1], [-1, 1], 1, k_bwd=1)
 
-        self.multi = MassActionLaw(component_system, name='simple')
-        self.multi.add_reaction(
-            [0, 1], [-1, 1], 1, k_bwd=1
-        )
-        self.multi.add_reaction(
-            [1, 2], [-1, 1], 1, k_bwd=1
-        )
+        self.multi = MassActionLaw(component_system, name="simple")
+        self.multi.add_reaction([0, 1], [-1, 1], 1, k_bwd=1)
+        self.multi.add_reaction([1, 2], [-1, 1], 1, k_bwd=1)
 
         component_system_lysine = ComponentSystem()
         component_system_lysine.add_component(
-            'Lysine',
-            species=['Lys2+', 'Lys+', 'Lys', 'Lys-'],
+            "Lysine",
+            species=["Lys2+", "Lys+", "Lys", "Lys-"],
         )
         component_system_lysine.add_component(
-            'H+',
+            "H+",
         )
-        self.lysine = MassActionLaw(component_system_lysine, name='Lysine')
+        self.lysine = MassActionLaw(component_system_lysine, name="Lysine")
         self.lysine.add_reaction(
-            [0, 1, -1], [-1, 1, 1], 10**(-2.20)*1e3, is_kinetic=False
-        )
-        self.lysine.add_reaction(
-            [1, 2, -1], [-1, 1, 1], 10**(-8.90)*1e3, is_kinetic=False
+            [0, 1, -1], [-1, 1, 1], 10 ** (-2.20) * 1e3, is_kinetic=False
         )
         self.lysine.add_reaction(
-            [2, 3, -1], [-1, 1, 1], 10**(-10.28)*1e3, is_kinetic=False
+            [1, 2, -1], [-1, 1, 1], 10 ** (-8.90) * 1e3, is_kinetic=False
+        )
+        self.lysine.add_reaction(
+            [2, 3, -1], [-1, 1, 1], 10 ** (-10.28) * 1e3, is_kinetic=False
         )
 
     def test_dydx(self):
@@ -76,7 +67,8 @@ class TestReactionEquilibrium(unittest.TestCase):
         buffer = [1, 0, 0]
         buffer_init = [2, 0, 0]
         dydx = equilibria.dydx_mal(
-            buffer, self.single_2, constant_indices=[0], c_init=buffer_init)
+            buffer, self.single_2, constant_indices=[0], c_init=buffer_init
+        )
         dydx_expected = [0, 2, 0]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
@@ -103,10 +95,7 @@ class TestReactionEquilibrium(unittest.TestCase):
     def test_jac(self):
         buffer = [1, 0]
         jac = equilibria.jac_mal(buffer, self.single_0)
-        jac_expected = [
-            [-2,  2],
-            [ 2, -2]
-        ]
+        jac_expected = [[-2, 2], [2, -2]]
         np.testing.assert_almost_equal(jac, jac_expected)
 
     def test_reaction_equilibrium(self):
@@ -119,75 +108,77 @@ class TestReactionEquilibrium(unittest.TestCase):
         buffer = [0, 0, 0, 1, 0]
 
         pH = 0
-        buffer[-1] = 10**(-pH+3)
+        buffer[-1] = 10 ** (-pH + 3)
         eq = equilibria.calculate_buffer_equilibrium(
             buffer, self.lysine, constant_indices=[-1]
         )
-        eq_expected = [
-            0.99373000042703, 0.006270012422, 7.89e-12, 0.0,
-            buffer[-1]
-        ]
+        eq_expected = [0.99373000042703, 0.006270012422, 7.89e-12, 0.0, buffer[-1]]
         pH = 3
-        buffer[-1] = 10**(-pH+3)
+        buffer[-1] = 10 ** (-pH + 3)
         eq = equilibria.calculate_buffer_equilibrium(
             buffer, self.lysine, constant_indices=[-1]
         )
         eq_expected = [
-            0.13680673998909, 0.86319217370507, 1.08669456e-06, 6e-14,
-            buffer[-1]
+            0.13680673998909,
+            0.86319217370507,
+            1.08669456e-06,
+            6e-14,
+            buffer[-1],
         ]
         np.testing.assert_almost_equal(eq, eq_expected)
         pH = 7
-        buffer[-1] = 10**(-pH+3)
+        buffer[-1] = 10 ** (-pH + 3)
         eq = equilibria.calculate_buffer_equilibrium(
             buffer, self.lysine, constant_indices=[-1]
         )
         eq_expected = [
-            1.565153925e-05, 0.98754536426943, 0.01243245954378, 6.52464752e-06,
-            buffer[-1]
+            1.565153925e-05,
+            0.98754536426943,
+            0.01243245954378,
+            6.52464752e-06,
+            buffer[-1],
         ]
         np.testing.assert_almost_equal(eq, eq_expected)
         pH = 11
-        buffer[-1] = 10**(-pH+3)
+        buffer[-1] = 10 ** (-pH + 3)
         eq = equilibria.calculate_buffer_equilibrium(
             buffer, self.lysine, constant_indices=[-1]
         )
         eq_expected = [
-            2.01e-12, 0.00126970262768, 0.15984609034134, 0.83888420702896,
-            buffer[-1]
+            2.01e-12,
+            0.00126970262768,
+            0.15984609034134,
+            0.83888420702896,
+            buffer[-1],
         ]
         np.testing.assert_almost_equal(eq, eq_expected)
         pH = 14
-        buffer[-1] = 10**(-pH+3)
+        buffer[-1] = 10 ** (-pH + 3)
         eq = equilibria.calculate_buffer_equilibrium(
             buffer, self.lysine, constant_indices=[-1]
         )
-        eq_expected = [
-            0.0, 0.0, 1e-11, 0.99999999999,
-            buffer[-1]
-        ]
+        eq_expected = [0.0, 0.0, 1e-11, 0.99999999999, buffer[-1]]
 
 
 class TestAdsorptionEquilibrium(unittest.TestCase):
-
     def setUp(self):
         component_system_mono = ComponentSystem()
-        component_system_mono.add_component('A')
+        component_system_mono.add_component("A")
 
         component_system_di = ComponentSystem()
-        component_system_di.add_component('A')
-        component_system_di.add_component('B')
+        component_system_di.add_component("A")
+        component_system_di.add_component("B")
 
-        self.linear = Linear(component_system_mono, 'linear')
+        self.linear = Linear(component_system_mono, "linear")
         self.linear.adsorption_rate = [1]
         self.linear.desorption_rate = [1]
 
-        self.langmuir = Langmuir(component_system_di, 'langmuir')
+        self.langmuir = Langmuir(component_system_di, "langmuir")
         self.langmuir.adsorption_rate = [2, 1]
         self.langmuir.desorption_rate = [1, 1]
         self.langmuir.capacity = [10, 10]
 
-        self.sma = StericMassAction(component_system_di, 'SMA')
+        self.sma = StericMassAction(component_system_di, "SMA")
         self.sma.adsorption_rate = [1, 2]
         self.sma.desorption_rate = [1, 1]
         self.sma.characteristic_charge = [1, 1]
@@ -207,9 +198,9 @@ class TestAdsorptionEquilibrium(unittest.TestCase):
 
         buffer = [1, 1]
         eq = equilibria.simulate_solid_equilibria(self.sma, buffer)
-        eq_expected = [10/3, 2*10/3]
+        eq_expected = [10 / 3, 2 * 10 / 3]
         np.testing.assert_almost_equal(eq, eq_expected, decimal=4)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -18,21 +18,24 @@ Maybe this is too complicated, just use Process instead?
 
 import unittest
 
-from addict import Dict
-import numpy as np
-
 import CADETProcess
-from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Structure
+import numpy as np
+from addict import Dict
 from CADETProcess.dataStructure import (
-    Float, Switch, SizedTuple, SizedList, SizedNdArray, Polynomial, NdPolynomial,
+    Float,
+    NdPolynomial,
+    Polynomial,
+    SizedList,
+    SizedNdArray,
+    SizedTuple,
+    Structure,
+    Switch,
 )
 
 plot = True
 
 
 class PerformerFixture(Structure):
-
     n_entries = 4
     n_coeff = 4
 
@@ -45,43 +48,41 @@ class PerformerFixture(Structure):
     ndarray_no_default = SizedNdArray(size=(2, 4))
     array_1d_poly = Polynomial(n_coeff=4, default=0)
     ndarray_poly = NdPolynomial(n_entries=2, n_coeff=4, default=0)
-    ndarray_poly_dep = NdPolynomial(size=('n_entries', 'n_coeff'), default=0)
+    ndarray_poly_dep = NdPolynomial(size=("n_entries", "n_coeff"), default=0)
 
     _parameters = [
-        'scalar_float',
-        'sized_tuple',
-        'switch',
-        'array_1d',
-        'array_1d_single',
-        'ndarray',
-        'ndarray_no_default',
-        'array_1d_poly',
-        'ndarray_poly',
-        'ndarray_poly_dep',
+        "scalar_float",
+        "sized_tuple",
+        "switch",
+        "array_1d",
+        "array_1d_single",
+        "ndarray",
+        "ndarray_no_default",
+        "array_1d_poly",
+        "ndarray_poly",
+        "ndarray_poly_dep",
     ]
     _section_dependent_parameters = [
-        'scalar_float',
-        'sized_tuple',
-        'array_1d',
-        'array_1d_single',
-        'ndarray',
-        'ndarray_no_default',
-        'array_1d_poly',
-        'ndarray_poly',
-        'ndarray_poly_dep',
+        "scalar_float",
+        "sized_tuple",
+        "array_1d",
+        "array_1d_single",
+        "ndarray",
+        "ndarray_no_default",
+        "array_1d_poly",
+        "ndarray_poly",
+        "ndarray_poly_dep",
     ]
 
     @property
     def section_dependent_parameters(self):
         parameters = {
-            param: getattr(self, param)
-            for param in self._section_dependent_parameters
+            param: getattr(self, param) for param in self._section_dependent_parameters
         }
         return parameters
 
 
 class HandlerFixture(CADETProcess.dynamicEvents.EventHandler):
-
     def __init__(self):
         self.name = None
         self.performer = PerformerFixture()
@@ -91,14 +92,14 @@ class HandlerFixture(CADETProcess.dynamicEvents.EventHandler):
     def parameters(self):
         parameters = super().parameters
 
-        parameters['performer'] = self.performer.parameters
+        parameters["performer"] = self.performer.parameters
 
         return Dict(parameters)
 
     @parameters.setter
     def parameters(self, parameters):
         try:
-            self.performer.parameters = parameters.pop('performer')
+            self.performer.parameters = parameters.pop("performer")
         except KeyError:
             pass
 
@@ -107,28 +108,27 @@ class HandlerFixture(CADETProcess.dynamicEvents.EventHandler):
     @property
     def section_dependent_parameters(self):
         parameters = Dict()
-        parameters['performer'] = self.performer.section_dependent_parameters
+        parameters["performer"] = self.performer.section_dependent_parameters
         return parameters
 
     @property
     def polynomial_parameters(self):
         parameters = Dict()
-        parameters['performer'] = self.performer.polynomial_parameters
+        parameters["performer"] = self.performer.polynomial_parameters
         return parameters
 
 
 class Test_Events(unittest.TestCase):
-
     def setup_event_handler(self, add_events=False):
         event_handler = HandlerFixture()
         event_handler.cycle_time = 20
 
         if add_events:
-            evt = event_handler.add_event('evt0', 'performer.scalar_float', 0)
-            evt = event_handler.add_event('evt1', 'performer.scalar_float', 1)
-            evt = event_handler.add_event('evt2', 'performer.sized_tuple', (2, 1))
-            evt = event_handler.add_event('evt3', 'performer.sized_tuple', (3, 2))
-            evt = event_handler.add_event('evt4', 'performer.sized_tuple', (3, 3))
+            evt = event_handler.add_event("evt0", "performer.scalar_float", 0)
+            evt = event_handler.add_event("evt1", "performer.scalar_float", 1)
+            evt = event_handler.add_event("evt2", "performer.sized_tuple", (2, 1))
+            evt = event_handler.add_event("evt3", "performer.sized_tuple", (3, 2))
+            evt = event_handler.add_event("evt4", "performer.sized_tuple", (3, 3))
 
         return event_handler
 
@@ -140,29 +140,25 @@ class Test_Events(unittest.TestCase):
 
         # Invalid path
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event('wrong_path', 'performer.wrong', 1)
+            event_handler.add_event("wrong_path", "performer.wrong", 1)
 
         # Invalid state
         with self.assertRaises(TypeError):
-            event_handler.add_event(
-                'wrong_value', 'performer.scalar_float', 'wrong'
-            )
+            event_handler.add_event("wrong_value", "performer.scalar_float", "wrong")
 
         # Duplicate name
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event('duplicate', 'performer.scalar_float', 1)
-            event_handler.add_event('duplicate', 'performer.scalar_float', 1)
+            event_handler.add_event("duplicate", "performer.scalar_float", 1)
+            event_handler.add_event("duplicate", "performer.scalar_float", 1)
 
         # Not section dependent
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event(
-                'not_sec_dependent', 'performer.switch', 1
-            )
+            event_handler.add_event("not_sec_dependent", "performer.switch", 1)
 
     def test_event_scalar(self):
         event_handler = self.event_handler
 
-        evt = event_handler.add_event('trivial', 'performer.scalar_float', 1, time=0)
+        evt = event_handler.add_event("trivial", "performer.scalar_float", 1, time=0)
         self.assertEqual(evt.state, 1)
         self.assertEqual(evt.full_state, 1)
         self.assertEqual(evt.n_entries, 1)
@@ -174,7 +170,7 @@ class Test_Events(unittest.TestCase):
         # Raise Error for indices
         with self.assertRaises(IndexError):
             evt = event_handler.add_event(
-                'param_has_no_indices', 'performer.scalar_float', 1, time=0, indices=1
+                "param_has_no_indices", "performer.scalar_float", 1, time=0, indices=1
             )
 
     def test_event_array_1d_single(self):
@@ -186,7 +182,7 @@ class Test_Events(unittest.TestCase):
         event_handler = self.event_handler
 
         # No index
-        evt = event_handler.add_event('trivial', 'performer.array_1d_single', 1, time=0)
+        evt = event_handler.add_event("trivial", "performer.array_1d_single", 1, time=0)
         self.assertEqual(evt.state, 1)
         self.assertEqual(evt.full_state, [1])
         self.assertEqual(evt.n_entries, 1)
@@ -197,12 +193,12 @@ class Test_Events(unittest.TestCase):
 
         # Explicit Index
         evt = event_handler.add_event(
-            'trivial_1', 'performer.array_1d_single', 2, time=0, indices=0
+            "trivial_1", "performer.array_1d_single", 2, time=0, indices=0
         )
         self.assertEqual(evt.state, 2)
         self.assertEqual(evt.full_state, [2])
         self.assertEqual(evt.n_entries, 1)
-        self.assertEqual(evt.indices, [(0, )])
+        self.assertEqual(evt.indices, [(0,)])
         self.assertEqual(evt.full_indices, [(0,)])
         self.assertEqual(evt.n_indices, 1)
         self.assertEqual(event_handler.performer.array_1d_single, [2])
@@ -210,7 +206,11 @@ class Test_Events(unittest.TestCase):
         # Raise Error for exceeding indices
         with self.assertRaises(IndexError):
             evt = event_handler.add_event(
-                'param_has_no_indices', 'performer.array_1d_single', 1, time=0, indices=1
+                "param_has_no_indices",
+                "performer.array_1d_single",
+                1,
+                time=0,
+                indices=1,
             )
 
     def test_event_1D(self):
@@ -220,7 +220,7 @@ class Test_Events(unittest.TestCase):
         # Add event for single entry in 1D list / array
         event_handler.performer.array_1d
         evt = event_handler.add_event(
-            '1D_single', 'performer.array_1d', 1, indices=0, time=0
+            "1D_single", "performer.array_1d", 1, indices=0, time=0
         )
         self.assertEqual(evt.state, 1)
         self.assertEqual(evt.full_state, [1])
@@ -233,7 +233,7 @@ class Test_Events(unittest.TestCase):
         # Add event for multiple entries in 1D list / array
         # TODO: When creating section, missing parameters must be read at that time!
         evt = event_handler.add_event(
-            '1D_multi', 'performer.array_1d', [0, 1], indices=[0, 1], time=1
+            "1D_multi", "performer.array_1d", [0, 1], indices=[0, 1], time=1
         )
         np.testing.assert_equal(evt.state, [0, 1])
         self.assertEqual(evt.full_state, [0, 1])
@@ -245,7 +245,7 @@ class Test_Events(unittest.TestCase):
 
         # Add event for multiple entries in 1D list / array with custom order
         evt = event_handler.add_event(
-            '1D_multi_order', 'performer.array_1d', [2, 3], indices=[1, 2], time=2
+            "1D_multi_order", "performer.array_1d", [2, 3], indices=[1, 2], time=2
         )
         np.testing.assert_equal(evt.state, [2, 3])
         np.testing.assert_equal(evt.full_state, [2, 3])
@@ -257,7 +257,7 @@ class Test_Events(unittest.TestCase):
 
         # Add event for all entries in 1D list / array
         evt = event_handler.add_event(
-            '1D_all', 'performer.array_1d', [0, 0, 1], indices=[0, 1, 2], time=3
+            "1D_all", "performer.array_1d", [0, 0, 1], indices=[0, 1, 2], time=3
         )
         np.testing.assert_equal(evt.state, [0, 0, 1])
         np.testing.assert_equal(evt.full_state, [0, 0, 1])
@@ -269,8 +269,7 @@ class Test_Events(unittest.TestCase):
 
         # Set all values without indices
         evt = event_handler.add_event(
-            '1D_all_slice_all_no_indices', 'performer.array_1d',
-            [0, 1, 2, 3], time=4
+            "1D_all_slice_all_no_indices", "performer.array_1d", [0, 1, 2, 3], time=4
         )
         np.testing.assert_equal(evt.state, [0, 1, 2, 3])
         np.testing.assert_equal(evt.full_state, [0, 1, 2, 3])
@@ -282,8 +281,7 @@ class Test_Events(unittest.TestCase):
 
         # Set all values using slicing notation.
         evt = event_handler.add_event(
-            '1D_all_slice', 'performer.array_1d',
-            [2, 3, 4, 5], indices=np.s_[:], time=5
+            "1D_all_slice", "performer.array_1d", [2, 3, 4, 5], indices=np.s_[:], time=5
         )
         np.testing.assert_equal(evt.state, [2, 3, 4, 5])
         np.testing.assert_equal(evt.full_state, [2, 3, 4, 5])
@@ -295,7 +293,7 @@ class Test_Events(unittest.TestCase):
 
         # Set all values to one value using slicing notation
         evt = event_handler.add_event(
-            '1D_all_slice_one_value', 'performer.array_1d', 1, indices=np.s_[:], time=6
+            "1D_all_slice_one_value", "performer.array_1d", 1, indices=np.s_[:], time=6
         )
         np.testing.assert_equal(evt.state, 1)
         np.testing.assert_equal(evt.full_state, [1, 1, 1, 1])
@@ -307,7 +305,7 @@ class Test_Events(unittest.TestCase):
 
         # Set all values from starting_index to one value using slice
         evt = event_handler.add_event(
-            '1D_partial_slice', 'performer.array_1d', 2, indices=np.s_[1:], time=7
+            "1D_partial_slice", "performer.array_1d", 2, indices=np.s_[1:], time=7
         )
         np.testing.assert_equal(evt.state, 2)
         np.testing.assert_equal(evt.full_state, [2, 2, 2])
@@ -323,23 +321,23 @@ class Test_Events(unittest.TestCase):
         # Number of indices
         with self.assertRaises(ValueError):
             event_handler.add_event(
-                'not_enough_entries', 'performer.array_1d', [1, 2], indices=[2]
+                "not_enough_entries", "performer.array_1d", [1, 2], indices=[2]
             )
         with self.assertRaises(ValueError):
             event_handler.add_event(
-                'too_many_indices', 'performer.array_1d', [1, 2], indices=[1, 2, 2]
+                "too_many_indices", "performer.array_1d", [1, 2], indices=[1, 2, 2]
             )
 
         # Index exceeds shape
         with self.assertRaises(IndexError):
             event_handler.add_event(
-                'index_exceeds_shape', 'performer.array_1d', [1, 2], indices=[1, 4]
+                "index_exceeds_shape", "performer.array_1d", [1, 2], indices=[1, 4]
             )
 
         # Duplicate entries for indices
         with self.assertRaises(ValueError):
             event_handler.add_event(
-                'duplicate_entries', 'performer.array_1d', [1, 2], indices=[1, 1]
+                "duplicate_entries", "performer.array_1d", [1, 2], indices=[1, 1]
             )
 
     def test_event_ndarray(self):
@@ -350,7 +348,7 @@ class Test_Events(unittest.TestCase):
         # Add event for single entry in ndarray
         t += 1
         evt = event_handler.add_event(
-            'ndarray_single', 'performer.ndarray', 1, indices=(0, 0), time=t
+            "ndarray_single", "performer.ndarray", 1, indices=(0, 0), time=t
         )
         np.testing.assert_equal(evt.state, 1)
         self.assertEqual(evt.n_entries, 1)
@@ -364,8 +362,11 @@ class Test_Events(unittest.TestCase):
         # Add event for multiple entries in array
         t += 1
         evt = event_handler.add_event(
-            'ndarray_multiple', 'performer.ndarray',
-            [0, 1], indices=[(0, 0), (0, 1)], time=t
+            "ndarray_multiple",
+            "performer.ndarray",
+            [0, 1],
+            indices=[(0, 0), (0, 1)],
+            time=t,
         )
         np.testing.assert_equal(evt.state, [0, 1])
         np.testing.assert_equal(evt.full_state, [0, 1])
@@ -380,8 +381,11 @@ class Test_Events(unittest.TestCase):
         # Add event for multiple entries in array with custom order
         t += 1
         evt = event_handler.add_event(
-            'ndarray_multiple_order', 'performer.ndarray',
-            [1, 0], indices=[(1, 0), (0, 1)], time=t
+            "ndarray_multiple_order",
+            "performer.ndarray",
+            [1, 0],
+            indices=[(1, 0), (0, 1)],
+            time=t,
         )
         np.testing.assert_equal(evt.state, [1, 0])
         np.testing.assert_equal(evt.full_state, [1, 0])
@@ -396,20 +400,21 @@ class Test_Events(unittest.TestCase):
         # Add event for all entries in array
         t += 1
         evt = event_handler.add_event(
-            'ndarray_all', 'performer.ndarray',
+            "ndarray_all",
+            "performer.ndarray",
             [0, 1, 2, 3, 4, 5, 6, 7],
             indices=[(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
-            time=t
+            time=t,
         )
         np.testing.assert_equal(evt.state, [0, 1, 2, 3, 4, 5, 6, 7])
         self.assertEqual(evt.n_entries, 8)
         np.testing.assert_equal(
             evt.indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 8)
         np.testing.assert_equal(
@@ -419,9 +424,10 @@ class Test_Events(unittest.TestCase):
         # Set all values without indices
         t += 1
         evt = event_handler.add_event(
-            'ndarray_all_no_indices', 'performer.ndarray',
+            "ndarray_all_no_indices",
+            "performer.ndarray",
             [[8, 7, 6, 5], [4, 3, 2, 1]],
-            time=t
+            time=t,
         )
         np.testing.assert_equal(evt.state, [[8, 7, 6, 5], [4, 3, 2, 1]])
         np.testing.assert_equal(evt.full_state, [8, 7, 6, 5, 4, 3, 2, 1])
@@ -429,7 +435,7 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 8)
         np.testing.assert_equal(
@@ -439,8 +445,11 @@ class Test_Events(unittest.TestCase):
         # Set all values using slicing notation.
         t += 1
         evt = event_handler.add_event(
-            'ndarray_all_slice', 'performer.ndarray',
-            [[0, 0, 0, 0], [1, 1, 1, 1]], indices=np.s_[:], time=t
+            "ndarray_all_slice",
+            "performer.ndarray",
+            [[0, 0, 0, 0], [1, 1, 1, 1]],
+            indices=np.s_[:],
+            time=t,
         )
         np.testing.assert_equal(evt.state, [[0, 0, 0, 0], [1, 1, 1, 1]])
         np.testing.assert_equal(evt.full_state, [0, 0, 0, 0, 1, 1, 1, 1])
@@ -448,7 +457,7 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 8)
         np.testing.assert_equal(
@@ -458,8 +467,11 @@ class Test_Events(unittest.TestCase):
         # Set all values to one value using slicing notation
         t += 1
         evt = event_handler.add_event(
-            'ndarray_all_slice_one_value', 'performer.ndarray',
-            1, indices=np.s_[:], time=t
+            "ndarray_all_slice_one_value",
+            "performer.ndarray",
+            1,
+            indices=np.s_[:],
+            time=t,
         )
         np.testing.assert_equal(evt.state, 1)
         np.testing.assert_equal(evt.full_state, [1, 1, 1, 1, 1, 1, 1, 1])
@@ -467,7 +479,7 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 8)
         np.testing.assert_equal(
@@ -478,16 +490,18 @@ class Test_Events(unittest.TestCase):
         # Set all values of one row using slicing notation
         t += 1
         evt = event_handler.add_event(
-            'ndarray_row_slice', 'performer.ndarray',
-            [0, 0, 0, 0], indices=np.s_[0, :], time=t
+            "ndarray_row_slice",
+            "performer.ndarray",
+            [0, 0, 0, 0],
+            indices=np.s_[0, :],
+            time=t,
         )
         np.testing.assert_equal(evt.state, [0, 0, 0, 0])
         np.testing.assert_equal(evt.full_state, [0, 0, 0, 0])
         self.assertEqual(evt.n_entries, 4)
-        np.testing.assert_equal(evt.indices, [(0, slice(None, None, None),)])
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3)],
         )
         self.assertEqual(evt.n_indices, 4)
         np.testing.assert_equal(
@@ -497,27 +511,37 @@ class Test_Events(unittest.TestCase):
         # Set all values of one row to one value using slicing notation
         t += 1
         evt = event_handler.add_event(
-            'ndarray_row_slice_one_value', 'performer.ndarray',
-            2, indices=np.s_[0, :], time=t
+            "ndarray_row_slice_one_value",
+            "performer.ndarray",
+            2,
+            indices=np.s_[0, :],
+            time=t,
         )
         np.testing.assert_equal(evt.state, 2)
         np.testing.assert_equal(evt.full_state, [2, 2, 2, 2])
         self.assertEqual(evt.n_entries, 4)
-        np.testing.assert_equal(evt.indices, [(0, slice(None, None, None),)])
+        np.testing.assert_equal(
+            evt.indices,
+            [(0, slice(None, None, None))],
+        )
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 0), (0, 1), (0, 2), (0, 3)]
+            [(0, 0), (0, 1), (0, 2), (0, 3)],
         )
         self.assertEqual(evt.n_indices, 4)
         np.testing.assert_equal(
-            event_handler.performer.ndarray, [[2, 2, 2, 2], [1, 1, 1, 1]]
+            event_handler.performer.ndarray,
+            [[2, 2, 2, 2], [1, 1, 1, 1]],
         )
 
         # Set all values of one column from starting_index to one value using slice
         t += 1
         evt = event_handler.add_event(
-            'ndarray_column_partial_slice', 'performer.ndarray',
-            3, indices=np.s_[1:, 1], time=t
+            "ndarray_column_partial_slice",
+            "performer.ndarray",
+            3,
+            indices=np.s_[1:, 1],
+            time=t,
         )
         np.testing.assert_equal(evt.state, 3)
         np.testing.assert_equal(evt.full_state, [3])
@@ -526,28 +550,34 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.full_indices, [(1, 1)])
         self.assertEqual(evt.n_indices, 1)
         np.testing.assert_equal(
-            event_handler.performer.ndarray, [[2, 2, 2, 2], [1, 3, 1, 1]]
+            event_handler.performer.ndarray,
+            [[2, 2, 2, 2], [1, 3, 1, 1]],
         )
 
         # Check multiple slices
         t += 1
         evt = event_handler.add_event(
-            'ndarray_multiple_slices', 'performer.ndarray',
-            [4, 5], indices=[np.s_[0, 1:], np.s_[1, :]], time=t
+            "ndarray_multiple_slices",
+            "performer.ndarray",
+            [4, 5],
+            indices=[np.s_[0, 1:], np.s_[1, :]],
+            time=t,
         )
         np.testing.assert_equal(evt.state, [4, 5])
         np.testing.assert_equal(evt.full_state, [4, 4, 4, 5, 5, 5, 5])
         self.assertEqual(evt.n_entries, 7)
         np.testing.assert_equal(
-            evt.indices, [(0, slice(1, None, None)), (1, slice(None, None, None))]
+            evt.indices,
+            [(0, slice(1, None, None)), (1, slice(None, None, None))],
         )
         np.testing.assert_equal(
             evt.full_indices,
-            [(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]
+            [(0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 7)
         np.testing.assert_equal(
-            event_handler.performer.ndarray, [[2, 4, 4, 4], [5, 5, 5, 5]]
+            event_handler.performer.ndarray,
+            [[2, 4, 4, 4], [5, 5, 5, 5]],
         )
 
         if plot:
@@ -558,7 +588,7 @@ class Test_Events(unittest.TestCase):
 
         # Add event relying on filling missing coefficients
         evt = event_handler.add_event(
-            '1D_single_fill', 'performer.array_1d_poly', 1, time=0
+            "1D_single_fill", "performer.array_1d_poly", 1, time=0
         )
         np.testing.assert_equal(evt.state, 1)
         np.testing.assert_equal(evt.full_state, [1, 0, 0, 0])
@@ -567,12 +597,13 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
         self.assertEqual(evt.n_indices, 4)
         np.testing.assert_equal(
-            event_handler.performer.array_1d_poly, [1, 0, 0, 0]
+            event_handler.performer.array_1d_poly,
+            [1, 0, 0, 0],
         )
 
         # Fill all values to specific value
         evt = event_handler.add_event(
-            '1D_multi_no_fill', 'performer.array_1d_poly', 2, indices=np.s_[:], time=1
+            "1D_multi_no_fill", "performer.array_1d_poly", 2, indices=np.s_[:], time=1
         )
         np.testing.assert_equal(evt.state, 2)
         np.testing.assert_equal(evt.full_state, [2, 2, 2, 2])
@@ -580,13 +611,11 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
         self.assertEqual(evt.n_indices, 4)
-        np.testing.assert_equal(
-            event_handler.performer.array_1d_poly, [2, 2, 2, 2]
-        )
+        np.testing.assert_equal(event_handler.performer.array_1d_poly, [2, 2, 2, 2])
 
         # Add event relying on filling missing coefficients
         evt = event_handler.add_event(
-            '1D_multi_fill', 'performer.array_1d_poly', [3, 3], time=2
+            "1D_multi_fill", "performer.array_1d_poly", [3, 3], time=2
         )
         np.testing.assert_equal(evt.state, [3, 3])
         np.testing.assert_equal(evt.full_state, [3, 3, 0, 0])
@@ -594,27 +623,23 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(evt.full_indices, [(0,), (1,), (2,), (3,)])
         self.assertEqual(evt.n_indices, 4)
-        np.testing.assert_equal(
-            event_handler.performer.array_1d_poly, [3, 3, 0, 0]
-        )
+        np.testing.assert_equal(event_handler.performer.array_1d_poly, [3, 3, 0, 0])
 
         # Add event for single entry in array
         evt = event_handler.add_event(
-            '1D_single', 'performer.array_1d_poly', 1, indices=0, time=3
+            "1D_single", "performer.array_1d_poly", 1, indices=0, time=3
         )
         np.testing.assert_equal(evt.state, 1)
         np.testing.assert_equal(evt.full_state, [1])
         self.assertEqual(evt.n_entries, 1)
-        np.testing.assert_equal(evt.indices, [(0, )])
+        np.testing.assert_equal(evt.indices, [(0,)])
         np.testing.assert_equal(evt.full_indices, [(0,)])
         self.assertEqual(evt.n_indices, 1)
-        np.testing.assert_equal(
-            event_handler.performer.array_1d_poly, [1, 3, 0, 0]
-        )
+        np.testing.assert_equal(event_handler.performer.array_1d_poly, [1, 3, 0, 0])
 
         # Add event for multiple entry in array
         evt = event_handler.add_event(
-            '1D_multi', 'performer.array_1d_poly', [2, 2], indices=[0, 1], time=4
+            "1D_multi", "performer.array_1d_poly", [2, 2], indices=[0, 1], time=4
         )
         np.testing.assert_equal(evt.state, [2, 2])
         np.testing.assert_equal(evt.full_state, [2, 2])
@@ -622,13 +647,11 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(0,), (1,)])
         np.testing.assert_equal(evt.full_indices, [(0,), (1,)])
         self.assertEqual(evt.n_indices, 2)
-        np.testing.assert_equal(
-            event_handler.performer.array_1d_poly, [2, 2, 0, 0]
-        )
+        np.testing.assert_equal(event_handler.performer.array_1d_poly, [2, 2, 0, 0])
 
         # Add event for single entry in array to check if list notation works
         evt = event_handler.add_event(
-            '1D_multi_flat', 'performer.array_1d_poly', [0], indices=[1], time=5
+            "1D_multi_flat", "performer.array_1d_poly", [0], indices=[1], time=5
         )
         np.testing.assert_equal(evt.state, [0])
         np.testing.assert_equal(evt.full_state, [0])
@@ -636,9 +659,7 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(1,)])
         np.testing.assert_equal(evt.full_indices, [(1,)])
         self.assertEqual(evt.n_indices, 1)
-        np.testing.assert_equal(
-            event_handler.performer.array_1d_poly, [2, 0, 0, 0]
-        )
+        np.testing.assert_equal(event_handler.performer.array_1d_poly, [2, 0, 0, 0])
 
         if plot:
             event_handler.plot_events()
@@ -651,7 +672,7 @@ class Test_Events(unittest.TestCase):
         # Add event relying for individual coefficient
         t += 1
         evt = event_handler.add_event(
-            'single_coeff', 'performer.ndarray_poly', 1, indices=(0, 1), time=t
+            "single_coeff", "performer.ndarray_poly", 1, indices=(0, 1), time=t
         )
         np.testing.assert_equal(evt.state, 1)
         np.testing.assert_equal(evt.full_state, [1])
@@ -664,14 +685,17 @@ class Test_Events(unittest.TestCase):
             [
                 [0, 1, 0, 0],
                 [0, 0, 0, 0],
-            ]
+            ],
         )
 
         # Add event for multiple coefficients / indices
         t += 1
         evt = event_handler.add_event(
-            'multi_coeffs', 'performer.ndarray_poly',
-            [1, 2], indices=[(0, 0), (1, 1)], time=t
+            "multi_coeffs",
+            "performer.ndarray_poly",
+            [1, 2],
+            indices=[(0, 0), (1, 1)],
+            time=t,
         )
         np.testing.assert_equal(evt.state, [1, 2])
         np.testing.assert_equal(evt.full_state, [1, 2])
@@ -684,30 +708,22 @@ class Test_Events(unittest.TestCase):
             [
                 [1, 1, 0, 0],
                 [0, 2, 0, 0],
-            ]
+            ],
         )
 
         # Add event relying on filling missing coefficients
         t += 1
-        evt = event_handler.add_event(
-            'fill_all', 'performer.ndarray_poly', 1, time=t
-        )
+        evt = event_handler.add_event("fill_all", "performer.ndarray_poly", 1, time=t)
         np.testing.assert_equal(evt.state, 1)
         np.testing.assert_equal(
             evt.full_state,
-            [
-                1, 0, 0, 0,
-                1, 0, 0, 0,
-            ]
+            [1, 0, 0, 0, 1, 0, 0, 0],
         )
         self.assertEqual(evt.n_entries, 8)
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(
             evt.full_indices,
-            [
-                (0, 0), (0, 1), (0, 2), (0, 3),
-                (1, 0), (1, 1), (1, 2), (1, 3),
-            ]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 8)
         np.testing.assert_equal(
@@ -715,27 +731,23 @@ class Test_Events(unittest.TestCase):
             [
                 [1, 0, 0, 0],
                 [1, 0, 0, 0],
-            ]
+            ],
         )
         # Add event relying on filling missing coefficients for single entry
         t += 1
         evt = event_handler.add_event(
-            'multi_fill_single', 'performer.ndarray_poly', 3, indices=0, time=t
+            "multi_fill_single", "performer.ndarray_poly", 3, indices=0, time=t
         )
         np.testing.assert_equal(evt.state, 3)
         np.testing.assert_equal(
             evt.full_state,
-            [
-                3, 0, 0, 0,
-            ]
+            [3, 0, 0, 0],
         )
         self.assertEqual(evt.n_entries, 4)
         np.testing.assert_equal(evt.indices, [(0,)])
         np.testing.assert_equal(
             evt.full_indices,
-            [
-                (0, 0), (0, 1), (0, 2), (0, 3),
-            ]
+            [(0, 0), (0, 1), (0, 2), (0, 3)],
         )
         self.assertEqual(evt.n_indices, 4)
         np.testing.assert_equal(
@@ -743,30 +755,24 @@ class Test_Events(unittest.TestCase):
             [
                 [3, 0, 0, 0],
                 [1, 0, 0, 0],
-            ]
+            ],
         )
 
         # Add event relying on filling missing coefficients with inhomogeneous shape
         t += 1
         evt = event_handler.add_event(
-            'multi_fill_inhomogeneous', 'performer.ndarray_poly', [2, [0, 1]], time=t
+            "multi_fill_inhomogeneous", "performer.ndarray_poly", [2, [0, 1]], time=t
         )
         np.testing.assert_equal(evt.state, [2, [0, 1]])
         np.testing.assert_equal(
             evt.full_state,
-            [
-                2, 0, 0, 0,
-                0, 1, 0, 0,
-            ]
+            [2, 0, 0, 0, 0, 1, 0, 0],
         )
         self.assertEqual(evt.n_entries, 8)
         np.testing.assert_equal(evt.indices, [(slice(None, None, None),)])
         np.testing.assert_equal(
             evt.full_indices,
-            [
-                (0, 0), (0, 1), (0, 2), (0, 3),
-                (1, 0), (1, 1), (1, 2), (1, 3),
-            ]
+            [(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)],
         )
         self.assertEqual(evt.n_indices, 8)
         np.testing.assert_equal(
@@ -774,13 +780,13 @@ class Test_Events(unittest.TestCase):
             [
                 [2, 0, 0, 0],
                 [0, 1, 0, 0],
-            ]
+            ],
         )
 
         # Add event using slicing (should work just like a regular ndarray)
         t += 1
         evt = event_handler.add_event(
-            'multi_slice', 'performer.ndarray_poly', [1], indices=[np.s_[0, :]], time=t
+            "multi_slice", "performer.ndarray_poly", [1], indices=[np.s_[0, :]], time=t
         )
 
         np.testing.assert_equal(evt.state, [1])
@@ -789,9 +795,7 @@ class Test_Events(unittest.TestCase):
         np.testing.assert_equal(evt.indices, [(0, slice(None, None, None))])
         np.testing.assert_equal(
             evt.full_indices,
-            [
-                (0, 0), (0, 1), (0, 2), (0, 3),
-            ]
+            [(0, 0), (0, 1), (0, 2), (0, 3)],
         )
         self.assertEqual(evt.n_indices, 4)
         np.testing.assert_equal(
@@ -799,7 +803,7 @@ class Test_Events(unittest.TestCase):
             [
                 [1, 1, 1, 1],
                 [0, 1, 0, 0],
-            ]
+            ],
         )
 
         if plot:
@@ -808,12 +812,12 @@ class Test_Events(unittest.TestCase):
     def test_lwe(self):
         """This reproduces the situation from the LWE / SMA model in the examples."""
         event_handler = self.setup_event_handler()
-        event_handler.name = 'LWE'
+        event_handler.name = "LWE"
 
-        cycle_time = 110*60
+        cycle_time = 110 * 60
         event_handler.cycle_time = cycle_time
 
-        t_flush = 20*60
+        t_flush = 20 * 60
 
         t_gradient_start = 90
         gradient_duration = cycle_time - t_gradient_start - t_flush
@@ -821,23 +825,26 @@ class Test_Events(unittest.TestCase):
         c_load = np.array([5, 1, 1, 1])
         c_wash = np.array([5, 0, 0, 0])
         c_elute = np.array([1000, 0, 0, 0])
-        gradient_slope = (c_elute - c_wash)/gradient_duration
+        gradient_slope = (c_elute - c_wash) / gradient_duration
         c_gradient_poly = np.array(list(zip(c_wash, gradient_slope)))
         c_gradient_poly[0][1] = 0.4
         c_gradient_poly = c_gradient_poly.tolist()
 
-        event_handler.add_event('load', 'performer.ndarray_poly_dep', c_load, time=0)
+        event_handler.add_event("load", "performer.ndarray_poly_dep", c_load, time=0)
         event_handler.add_event(
-            'wash', 'performer.ndarray_poly_dep',
-            c_wash, time=t_flush
+            "wash", "performer.ndarray_poly_dep", c_wash, time=t_flush
         )
         event_handler.add_event(
-            'grad_start', 'performer.ndarray_poly_dep',
-            c_gradient_poly, time=t_gradient_start
+            "grad_start",
+            "performer.ndarray_poly_dep",
+            c_gradient_poly,
+            time=t_gradient_start,
         )
         event_handler.add_event(
-            'Flush', 'performer.ndarray_poly_dep',
-            c_elute, time=t_gradient_start + gradient_duration
+            "Flush",
+            "performer.ndarray_poly_dep",
+            c_elute,
+            time=t_gradient_start + gradient_duration,
         )
 
         if plot:
@@ -858,16 +865,16 @@ class Test_Events(unittest.TestCase):
     def test_dependencies(self):
         event_handler = self.setup_event_handler(add_events=True)
 
-        event_handler.add_event_dependency('evt1', 'evt0')
+        event_handler.add_event_dependency("evt1", "evt0")
         self.assertEqual(event_handler.event_times, [0])
 
         event_handler.evt0.time = 1
         self.assertEqual(event_handler.event_times, [0, 1])
 
-        event_handler.add_event_dependency('evt2', 'evt1', 2)
+        event_handler.add_event_dependency("evt2", "evt1", 2)
         self.assertEqual(event_handler.event_times, [0, 1, 2])
 
-        event_handler.add_event_dependency('evt3', ['evt1', 'evt0'], [2, 1])
+        event_handler.add_event_dependency("evt3", ["evt1", "evt0"], [2, 1])
         self.assertEqual(event_handler.event_times, [0, 1, 2, 3])
 
         # Dependent event
@@ -876,15 +883,15 @@ class Test_Events(unittest.TestCase):
 
         # Event does not exist
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event_dependency('evt3', 'evt0')
+            event_handler.add_event_dependency("evt3", "evt0")
 
         # Duplicate dependency
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event_dependency('evt1', 'evt0')
+            event_handler.add_event_dependency("evt1", "evt0")
 
         # Linear factors not matching
         with self.assertRaises(CADETProcess.CADETProcessError):
-            event_handler.add_event_dependency('evt1', 'evt0', [1, 1])
+            event_handler.add_event_dependency("evt1", "evt0", [1, 1])
 
     def test_section_states(self):
         pass
@@ -895,8 +902,8 @@ class Test_Events(unittest.TestCase):
     def test_duplicate_event_times(self):
         event_handler = self.setup_event_handler()
 
-        event_handler.add_event('evt0', 'performer.scalar_float', 0, 0)
-        event_handler.add_event('evt1', 'performer.scalar_float', 1, 1)
+        event_handler.add_event("evt0", "performer.scalar_float", 0, 0)
+        event_handler.add_event("evt1", "performer.scalar_float", 1, 1)
 
         event_handler.check_config()
 
@@ -908,14 +915,15 @@ class Test_Events(unittest.TestCase):
         event_handler = self.setup_event_handler()
 
         event_handler.add_event(
-            'evt0', 'performer.ndarray_no_default', 0, indices=(0, 0)
+            "evt0", "performer.ndarray_no_default", 0, indices=(0, 0)
         )
 
         self.assertFalse(event_handler.check_uninitialized_indices())
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     plot = True
     import matplotlib.pyplot as plt
-    plt.close('all')
+
+    plt.close("all")
     unittest.main()

--- a/tests/test_flow_sheet.py
+++ b/tests/test_flow_sheet.py
@@ -40,10 +40,11 @@ def assert_almost_equal_dict(dict_actual, dict_expected, decimal=7, verbose=True
 
         else:
             np.testing.assert_almost_equal(
-                dict_actual[key], dict_expected[key],
+                dict_actual[key],
+                dict_expected[key],
                 decimal=decimal,
-                err_msg=f'Dicts are not equal in key {key}.',
-                verbose=verbose
+                err_msg=f"Dicts are not equal in key {key}.",
+                verbose=verbose,
             )
 
 
@@ -66,7 +67,7 @@ def setup_single_cstr_flow_sheet(component_system=None):
     if component_system is None:
         component_system = ComponentSystem(2)
 
-    cstr = Cstr(component_system, 'cstr')
+    cstr = Cstr(component_system, "cstr")
 
     flow_sheet = FlowSheet(component_system)
     flow_sheet.add_unit(cstr)
@@ -96,10 +97,10 @@ def setup_batch_elution_flow_sheet(component_system=None):
 
     flow_sheet = FlowSheet(component_system)
 
-    feed = Inlet(component_system, name='feed')
-    eluent = Inlet(component_system, name='eluent')
-    column = LumpedRateModelWithoutPores(component_system, name='column')
-    outlet = Outlet(component_system, name='outlet')
+    feed = Inlet(component_system, name="feed")
+    eluent = Inlet(component_system, name="eluent")
+    column = LumpedRateModelWithoutPores(component_system, name="column")
+    outlet = Outlet(component_system, name="outlet")
 
     flow_sheet.add_unit(feed)
     flow_sheet.add_unit(eluent)
@@ -135,11 +136,11 @@ def setup_ssr_flow_sheet(component_system=None):
 
     flow_sheet = FlowSheet(component_system)
 
-    feed = Inlet(component_system, name='feed')
-    eluent = Inlet(component_system, name='eluent')
-    cstr = Cstr(component_system, name='cstr')
-    column = LumpedRateModelWithoutPores(component_system, name='column')
-    outlet = Outlet(component_system, name='outlet')
+    feed = Inlet(component_system, name="feed")
+    eluent = Inlet(component_system, name="eluent")
+    cstr = Cstr(component_system, name="cstr")
+    column = LumpedRateModelWithoutPores(component_system, name="column")
+    outlet = Outlet(component_system, name="outlet")
 
     flow_sheet.add_unit(feed)
     flow_sheet.add_unit(eluent)
@@ -176,7 +177,7 @@ class TestFlowSheet(unittest.TestCase):
         self.ssr_flow_sheet = setup_ssr_flow_sheet(self.component_system)
 
     def test_unit_names(self):
-        unit_names_expected = ['feed', 'eluent', 'cstr', 'column', 'outlet']
+        unit_names_expected = ["feed", "eluent", "cstr", "column", "outlet"]
 
         unit_names = list(self.ssr_flow_sheet.units_dict.keys())
 
@@ -184,7 +185,7 @@ class TestFlowSheet(unittest.TestCase):
         self.assertEqual(unit_names, unit_names_expected)
 
         # Connection already exists
-        duplicate_unit_name = Inlet(self.component_system, 'feed')
+        duplicate_unit_name = Inlet(self.component_system, "feed")
         with self.assertRaises(CADETProcessError):
             self.batch_flow_sheet.add_unit(duplicate_unit_name)
 
@@ -199,72 +200,66 @@ class TestFlowSheet(unittest.TestCase):
         self.assertIn(self.ssr_flow_sheet.cstr, self.ssr_flow_sheet.cstrs)
 
     def test_connections(self):
-        feed = self.ssr_flow_sheet['feed']
-        eluent = self.ssr_flow_sheet['eluent']
-        cstr = self.ssr_flow_sheet['cstr']
-        column = self.ssr_flow_sheet['column']
-        outlet = self.ssr_flow_sheet['outlet']
+        feed = self.ssr_flow_sheet["feed"]
+        eluent = self.ssr_flow_sheet["eluent"]
+        cstr = self.ssr_flow_sheet["cstr"]
+        column = self.ssr_flow_sheet["column"]
+        outlet = self.ssr_flow_sheet["outlet"]
         expected_connections = {
             feed: {
-                'origins': None,
-                'destinations': {
+                "origins": None,
+                "destinations": {
                     None: {
                         cstr: [None],
                     },
                 },
             },
             eluent: {
-                'origins': None,
-                'destinations': {
+                "origins": None,
+                "destinations": {
                     None: {
                         column: [None],
                     },
                 },
             },
-
             cstr: {
-                'origins': {
+                "origins": {
                     None: {
                         feed: [None],
                         column: [None],
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
                         column: [None],
                     },
                 },
             },
-
             column: {
-                'origins': {
+                "origins": {
                     None: {
                         cstr: [None],
                         eluent: [None],
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
                         cstr: [None],
                         outlet: [None],
                     },
                 },
             },
-
             outlet: {
-                'origins': {
+                "origins": {
                     None: {
                         column: [None],
                     },
                 },
-
-                'destinations': None,
+                "destinations": None,
             },
         }
 
-        self.assertDictEqual(
-            self.ssr_flow_sheet.connections, expected_connections
-        )
+        self.assertDictEqual(self.ssr_flow_sheet.connections, expected_connections)
 
         self.assertTrue(self.ssr_flow_sheet.connection_exists(feed, cstr))
         self.assertTrue(self.ssr_flow_sheet.connection_exists(eluent, column))
@@ -273,13 +268,11 @@ class TestFlowSheet(unittest.TestCase):
         self.assertFalse(self.ssr_flow_sheet.connection_exists(feed, eluent))
 
     def test_name_decorator(self):
-        feed = Inlet(self.component_system, name='feed')
-        eluent = Inlet(self.component_system, name='eluent')
-        cstr = Cstr(self.component_system, name='cstr')
-        column = LumpedRateModelWithoutPores(
-            self.component_system, name='column'
-        )
-        outlet = Outlet(self.component_system, name='outlet')
+        feed = Inlet(self.component_system, name="feed")
+        eluent = Inlet(self.component_system, name="eluent")
+        cstr = Cstr(self.component_system, name="cstr")
+        column = LumpedRateModelWithoutPores(self.component_system, name="column")
+        outlet = Outlet(self.component_system, name="outlet")
 
         flow_sheet = FlowSheet(self.component_system)
 
@@ -289,181 +282,176 @@ class TestFlowSheet(unittest.TestCase):
         flow_sheet.add_unit(column)
         flow_sheet.add_unit(outlet)
 
-        flow_sheet.add_connection('feed', 'cstr')
+        flow_sheet.add_connection("feed", "cstr")
         flow_sheet.add_connection(cstr, column)
-        flow_sheet.add_connection(eluent, 'column')
+        flow_sheet.add_connection(eluent, "column")
         flow_sheet.add_connection(column, cstr)
-        flow_sheet.add_connection('column', outlet)
+        flow_sheet.add_connection("column", outlet)
 
         expected_connections = {
             feed: {
-                'origins': None,
-                'destinations': {
+                "origins": None,
+                "destinations": {
                     None: {
                         cstr: [None],
                     },
                 },
             },
             eluent: {
-                'origins': None,
-                'destinations': {
+                "origins": None,
+                "destinations": {
                     None: {
                         column: [None],
                     },
                 },
             },
-
             cstr: {
-                'origins': {
+                "origins": {
                     None: {
                         feed: [None],
                         column: [None],
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
                         column: [None],
                     },
                 },
             },
-
             column: {
-                'origins': {
+                "origins": {
                     None: {
                         cstr: [None],
                         eluent: [None],
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
                         outlet: [None],
                         cstr: [None],
                     },
                 },
             },
-
             outlet: {
-                'origins': {
+                "origins": {
                     None: {
                         column: [None],
                     },
                 },
-
-                'destinations': None,
+                "destinations": None,
             },
         }
         self.assertDictEqual(flow_sheet.connections, expected_connections)
 
         # Connection already exists
         with self.assertRaises(CADETProcessError):
-            flow_sheet.add_connection('column', 'outlet')
+            flow_sheet.add_connection("column", "outlet")
 
         # Origin not found
         with self.assertRaises(CADETProcessError):
-            flow_sheet.add_connection('wrong_origin', cstr)
+            flow_sheet.add_connection("wrong_origin", cstr)
 
         # Destination not found
         with self.assertRaises(CADETProcessError):
-            flow_sheet.add_connection(cstr, 'wrong_destination')
+            flow_sheet.add_connection(cstr, "wrong_destination")
 
     def test_flow_rates(self):
         # Injection
         self.ssr_flow_sheet.feed.flow_rate = 0
         self.ssr_flow_sheet.eluent.flow_rate = 0
         self.ssr_flow_sheet.cstr.flow_rate = 1
-        self.ssr_flow_sheet.set_output_state('column', 1)
+        self.ssr_flow_sheet.set_output_state("column", 1)
 
         expected_flow_rates = {
-            'feed': {
-                'total_out': {
+            "feed": {
+                "total_out": {
                     None: (0, 0, 0, 0),
-                    },
-
-                'destinations': {
+                },
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'eluent': {
-                'total_out': {
+            "eluent": {
+                "total_out": {
                     None: (0, 0, 0, 0),
-                    },
-                'destinations': {
+                },
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr': {
-                'total_in': {
+            "cstr": {
+                "total_in": {
                     None: (0, 0, 0, 0),
-                    },
-                'total_out': {
+                },
+                "total_out": {
                     None: (1.0, 0, 0, 0),
-                    },
-                'origins': {
+                },
+                "origins": {
                     None: {
-                        'feed': {
+                        "feed": {
                             None: (0, 0, 0, 0),
                         },
-                        'column': {
+                        "column": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1.0, 0, 0, 0),
                         },
                     }
                 },
             },
-            'column': {
-                'total_in': {
+            "column": {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (1.0, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (1.0, 0, 0, 0),
                         },
-                        'eluent': {
+                        "eluent": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
-                        'outlet': {
+                        "outlet": {
                             None: (1.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet': {
-                'origins': {
+            "outlet": {
+                "origins": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1.0, 0, 0, 0),
                         },
                     },
                 },
-                'total_in': {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
-                    },
                 },
+            },
         }
 
         np.testing.assert_equal(
@@ -474,95 +462,93 @@ class TestFlowSheet(unittest.TestCase):
         self.ssr_flow_sheet.feed.flow_rate = 1
         self.ssr_flow_sheet.eluent.flow_rate = 1
         self.ssr_flow_sheet.cstr.flow_rate = 0
-        self.ssr_flow_sheet.set_output_state('column', 1)
+        self.ssr_flow_sheet.set_output_state("column", 1)
 
         expected_flow_rates = {
-            'feed': {
-                'total_out': {
+            "feed": {
+                "total_out": {
                     None: (1, 0, 0, 0),
-                    },
-                'destinations': {
+                },
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (1, 0, 0, 0),
                         },
                     }
                 },
             },
-            'eluent': {
-                'total_out': {
-                    None: (1, 0, 0, 0)
-                    },
-                'destinations': {
+            "eluent": {
+                "total_out": {None: (1, 0, 0, 0)},
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr': {
-                'total_in': {
+            "cstr": {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
-                    },
-                'total_out': {
+                },
+                "total_out": {
                     None: (0.0, 0, 0, 0),
-                    },
-                'origins': {
+                },
+                "origins": {
                     None: {
-                        'feed': {
+                        "feed": {
                             None: (1, 0, 0, 0),
                         },
-                        'column': {
+                        "column": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (0.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'column': {
-                'total_in': {
+            "column": {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (1.0, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
-                        'eluent': {
+                        "eluent": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
-                        'outlet': {
+                        "outlet": {
                             None: (1.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet': {
-                'origins': {
+            "outlet": {
+                "origins": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1.0, 0, 0, 0),
                         },
                     },
                 },
-                'total_in': {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
                 },
             },
@@ -575,98 +561,98 @@ class TestFlowSheet(unittest.TestCase):
         self.ssr_flow_sheet.feed.flow_rate = 0
         self.ssr_flow_sheet.eluent.flow_rate = 1
         self.ssr_flow_sheet.cstr.flow_rate = 0
-        self.ssr_flow_sheet.set_output_state('column', 1)
+        self.ssr_flow_sheet.set_output_state("column", 1)
 
         expected_flow_rates = {
-            'feed': {
-                'total_out': {
+            "feed": {
+                "total_out": {
                     None: (0, 0, 0, 0),
-                    },
-                'destinations': {
+                },
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'eluent': {
-                'total_out': {
+            "eluent": {
+                "total_out": {
                     None: (1, 0, 0, 0),
-                    },
-                'destinations': {
+                },
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr': {
-                'total_in': {
+            "cstr": {
+                "total_in": {
                     None: (0, 0, 0, 0),
-                    },
-                'total_out': {
+                },
+                "total_out": {
                     None: (0, 0, 0, 0),
-                    },
-                'origins': {
+                },
+                "origins": {
                     None: {
-                        'feed': {
+                        "feed": {
                             None: (0, 0, 0, 0),
                         },
-                        'column': {
+                        "column": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (0.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'column': {
-                'total_in': {
+            "column": {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
-                    },
-                'total_out': {
+                },
+                "total_out": {
                     None: (1.0, 0, 0, 0),
-                    },
-                'origins': {
+                },
+                "origins": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
-                        'eluent': {
+                        "eluent": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
-                        'outlet': {
+                        "outlet": {
                             None: (1.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet': {
-                'origins': {
+            "outlet": {
+                "origins": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1.0, 0, 0, 0),
                         },
                     },
                 },
-                'total_in': {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
-                    },
                 },
+            },
         }
 
         np.testing.assert_equal(
@@ -677,95 +663,95 @@ class TestFlowSheet(unittest.TestCase):
         self.ssr_flow_sheet.feed.flow_rate = 0
         self.ssr_flow_sheet.eluent.flow_rate = 1
         self.ssr_flow_sheet.cstr.flow_rate = 0
-        self.ssr_flow_sheet.set_output_state('column', 0)
+        self.ssr_flow_sheet.set_output_state("column", 0)
 
         expected_flow_rates = {
-            'feed': {
-                'total_out': {
+            "feed": {
+                "total_out": {
                     None: (0, 0, 0, 0),
-                    },
-                'destinations': {
+                },
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'eluent': {
-                'total_out': {
+            "eluent": {
+                "total_out": {
                     None: (1, 0, 0, 0),
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr': {
-                'total_in': {
+            "cstr": {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (0.0, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'feed': {
+                        "feed": {
                             None: (0, 0, 0, 0),
                         },
-                        'column': {
+                        "column": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (0.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'column': {
-                'total_in': {
+            "column": {
+                "total_in": {
                     None: (1.0, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (1.0, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (0, 0, 0, 0),
                         },
-                        'eluent': {
+                        "eluent": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (1, 0, 0, 0),
                         },
-                        'outlet': {
+                        "outlet": {
                             None: (0.0, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet': {
-                'origins': {
+            "outlet": {
+                "origins": {
                     None: {
-                        'column': {
+                        "column": {
                             None: (0, 0, 0, 0),
                         },
                     },
                 },
-                'total_in': {
+                "total_in": {
                     None: (0.0, 0, 0, 0),
                 },
             },
@@ -777,15 +763,13 @@ class TestFlowSheet(unittest.TestCase):
 
         # Single Cstr
         expected_flow_rates = {
-            'cstr': {
-                'total_in': {
+            "cstr": {
+                "total_in": {
                     None: [0.0, 0.0, 0.0, 0.0],
-                    },
-                'total_out': {
-                    None: [0.0, 0.0, 0.0, 0.0]
-                    },
-                'origins': {},
-                'destinations': {}
+                },
+                "total_out": {None: [0.0, 0.0, 0.0, 0.0]},
+                "origins": {},
+                "destinations": {},
             }
         }
 
@@ -798,7 +782,7 @@ class TestFlowSheet(unittest.TestCase):
         self.assertTrue(self.batch_flow_sheet.check_connections())
         self.assertTrue(self.ssr_flow_sheet.check_connections())
 
-        self.batch_flow_sheet.remove_unit('outlet')
+        self.batch_flow_sheet.remove_unit("outlet")
 
         with self.assertWarns(Warning):
             self.batch_flow_sheet.check_connections()
@@ -832,18 +816,18 @@ class TestFlowSheet(unittest.TestCase):
         self.ssr_flow_sheet.set_output_state(
             column,
             {
-                'cstr': 0.1,
-                'outlet': {
+                "cstr": 0.1,
+                "outlet": {
                     None: 0.9,
-                }
-            }
+                },
+            },
         )
         output_state_expected = {None: [0.1, 0.9]}
         output_state = self.ssr_flow_sheet._output_states[column]
         np.testing.assert_equal(output_state, output_state_expected)
 
         with self.assertRaises(TypeError):
-            self.ssr_flow_sheet.set_output_state(column, 'unknown_type')
+            self.ssr_flow_sheet.set_output_state(column, "unknown_type")
 
         with self.assertRaises(CADETProcessError):
             self.ssr_flow_sheet.set_output_state(column, [1, 1])
@@ -852,21 +836,21 @@ class TestFlowSheet(unittest.TestCase):
             self.ssr_flow_sheet.set_output_state(
                 column,
                 {
-                    'column': 0.1,
-                    'outlet': {
+                    "column": 0.1,
+                    "outlet": {
                         0: 0.9,
-                    }
-                }
+                    },
+                },
             )
 
     def test_add_connection_error(self):
         """
         Test for all raised exceptions of add_connections.
         """
-        inlet = self.ssr_flow_sheet['eluent']
-        column = self.ssr_flow_sheet['column']
-        outlet = self.ssr_flow_sheet['outlet']
-        external_unit = Cstr(self.component_system, name='external_unit')
+        inlet = self.ssr_flow_sheet["eluent"]
+        column = self.ssr_flow_sheet["column"]
+        outlet = self.ssr_flow_sheet["outlet"]
+        external_unit = Cstr(self.component_system, name="external_unit")
 
         # Inlet can't be a destination
         with self.assertRaises(CADETProcessError):
@@ -889,7 +873,7 @@ class TestFlowSheet(unittest.TestCase):
             self.ssr_flow_sheet.add_connection(inlet, column)
 
         with self.assertRaisesRegex(CADETProcessError, "not a port of"):
-            self.ssr_flow_sheet.set_output_state(column, [0.5, 0.5], 'channel_5')
+            self.ssr_flow_sheet.set_output_state(column, [0.5, 0.5], "channel_5")
 
 
 class TestCstrFlowRate(unittest.TestCase):
@@ -908,9 +892,9 @@ class TestCstrFlowRate(unittest.TestCase):
 
         flow_sheet = FlowSheet(self.component_system)
 
-        inlet = Inlet(self.component_system, name='inlet')
-        cstr = Cstr(self.component_system, name='cstr')
-        outlet = Outlet(self.component_system, name='outlet')
+        inlet = Inlet(self.component_system, name="inlet")
+        cstr = Cstr(self.component_system, name="cstr")
+        outlet = Outlet(self.component_system, name="outlet")
 
         flow_sheet.add_unit(inlet)
         flow_sheet.add_unit(cstr)
@@ -926,12 +910,12 @@ class TestCstrFlowRate(unittest.TestCase):
 
         flow_rates = self.flow_sheet.get_flow_rates()
 
-        cstr_in = flow_rates['cstr']['total_in'][None]
-        cstr_in_expected = [1., 0., 0., 0.]
+        cstr_in = flow_rates["cstr"]["total_in"][None]
+        cstr_in_expected = [1.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
 
-        cstr_out = flow_rates['cstr']['total_out'][None]
-        cstr_out_expected = [1., 0., 0., 0.]
+        cstr_out = flow_rates["cstr"]["total_out"][None]
+        cstr_out_expected = [1.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
         # Test dynamic flow
@@ -939,12 +923,12 @@ class TestCstrFlowRate(unittest.TestCase):
 
         flow_rates = self.flow_sheet.get_flow_rates()
 
-        cstr_in = flow_rates['cstr']['total_in'][None]
-        cstr_in_expected = [1., 1., 0., 0.]
+        cstr_in = flow_rates["cstr"]["total_in"][None]
+        cstr_in_expected = [1.0, 1.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
 
-        cstr_out = flow_rates['cstr']['total_out'][None]
-        cstr_out_expected = [1., 1., 0., 0.]
+        cstr_out = flow_rates["cstr"]["total_out"][None]
+        cstr_out_expected = [1.0, 1.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
     def test_no_flow(self):
@@ -952,12 +936,12 @@ class TestCstrFlowRate(unittest.TestCase):
 
         flow_rates = self.flow_sheet.get_flow_rates()
 
-        cstr_in = flow_rates['cstr']['total_in'][None]
-        cstr_in_expected = [0., 0., 0., 0.]
+        cstr_in = flow_rates["cstr"]["total_in"][None]
+        cstr_in_expected = [0.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
 
-        cstr_out = flow_rates['cstr']['total_out'][None]
-        cstr_out_expected = [0., 0., 0., 0.]
+        cstr_out = flow_rates["cstr"]["total_out"][None]
+        cstr_out_expected = [0.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
         self.flow_sheet.inlet.flow_rate = 0
@@ -965,12 +949,12 @@ class TestCstrFlowRate(unittest.TestCase):
 
         flow_rates = self.flow_sheet.get_flow_rates()
 
-        cstr_in = flow_rates['cstr']['total_in'][None]
-        cstr_in_expected = [0., 0., 0., 0.]
+        cstr_in = flow_rates["cstr"]["total_in"][None]
+        cstr_in_expected = [0.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
 
-        cstr_out = flow_rates['cstr']['total_out'][None]
-        cstr_out_expected = [0., 0., 0., 0.]
+        cstr_out = flow_rates["cstr"]["total_out"][None]
+        cstr_out_expected = [0.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
     def test_holdup(self):
@@ -979,34 +963,31 @@ class TestCstrFlowRate(unittest.TestCase):
 
         flow_rates = self.flow_sheet.get_flow_rates()
 
-        cstr_in = flow_rates['cstr']['total_in'][None]
-        cstr_in_expected = [1., 0., 0., 0.]
+        cstr_in = flow_rates["cstr"]["total_in"][None]
+        cstr_in_expected = [1.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
 
-        cstr_out = flow_rates['cstr']['total_out'][None]
-        cstr_out_expected = [0., 0., 0., 0.]
+        cstr_out = flow_rates["cstr"]["total_out"][None]
+        cstr_out_expected = [0.0, 0.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
     def test_state_update(self):
         self.flow_sheet.inlet.flow_rate = [1, 1]
 
-        state = {
-            'flow_sheet.cstr.flow_rate': np.array([2, 2, 0, 0], ndmin=2)
-        }
+        state = {"flow_sheet.cstr.flow_rate": np.array([2, 2, 0, 0], ndmin=2)}
 
         flow_rates = self.flow_sheet.get_flow_rates(state)
 
-        cstr_in = flow_rates['cstr']['total_in'][None]
-        cstr_in_expected = [1., 1., 0., 0.]
+        cstr_in = flow_rates["cstr"]["total_in"][None]
+        cstr_in_expected = [1.0, 1.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_in, cstr_in_expected)
 
-        cstr_out = flow_rates['cstr']['total_out'][None]
-        cstr_out_expected = [2., 2., 0., 0.]
+        cstr_out = flow_rates["cstr"]["total_out"][None]
+        cstr_out_expected = [2.0, 2.0, 0.0, 0.0]
         np.testing.assert_almost_equal(cstr_out, cstr_out_expected)
 
 
 class TestPorts(unittest.TestCase):
-
     def setUp(self):
         self.setup_mct_flow_sheet()
 
@@ -1017,12 +998,12 @@ class TestPorts(unittest.TestCase):
 
         mct_flow_sheet = FlowSheet(self.component_system)
 
-        inlet = Inlet(self.component_system, name='inlet')
-        mct_3c = MCT(self.component_system, nchannel=3, name='mct_3c')
-        mct_2c1 = MCT(self.component_system, nchannel=2, name='mct_2c1')
-        mct_2c2 = MCT(self.component_system, nchannel=2, name='mct_2c2')
-        outlet1 = Outlet(self.component_system, name='outlet1')
-        outlet2 = Outlet(self.component_system, name='outlet2')
+        inlet = Inlet(self.component_system, name="inlet")
+        mct_3c = MCT(self.component_system, nchannel=3, name="mct_3c")
+        mct_2c1 = MCT(self.component_system, nchannel=2, name="mct_2c1")
+        mct_2c2 = MCT(self.component_system, nchannel=2, name="mct_2c2")
+        outlet1 = Outlet(self.component_system, name="outlet1")
+        outlet2 = Outlet(self.component_system, name="outlet2")
 
         mct_flow_sheet.add_unit(inlet)
         mct_flow_sheet.add_unit(mct_3c)
@@ -1031,19 +1012,19 @@ class TestPorts(unittest.TestCase):
         mct_flow_sheet.add_unit(outlet1)
         mct_flow_sheet.add_unit(outlet2)
 
-        mct_flow_sheet.add_connection(inlet, mct_3c, destination_port='channel_0')
+        mct_flow_sheet.add_connection(inlet, mct_3c, destination_port="channel_0")
         mct_flow_sheet.add_connection(
-            mct_3c, mct_2c1, origin_port='channel_0', destination_port='channel_0'
+            mct_3c, mct_2c1, origin_port="channel_0", destination_port="channel_0"
         )
         mct_flow_sheet.add_connection(
-            mct_3c, mct_2c1, origin_port='channel_0', destination_port='channel_1'
+            mct_3c, mct_2c1, origin_port="channel_0", destination_port="channel_1"
         )
         mct_flow_sheet.add_connection(
-            mct_3c, mct_2c2, origin_port='channel_1', destination_port='channel_0'
+            mct_3c, mct_2c2, origin_port="channel_1", destination_port="channel_0"
         )
-        mct_flow_sheet.add_connection(mct_2c1, outlet1, origin_port='channel_0')
-        mct_flow_sheet.add_connection(mct_2c1, outlet1, origin_port='channel_1')
-        mct_flow_sheet.add_connection(mct_2c2, outlet2, origin_port='channel_0')
+        mct_flow_sheet.add_connection(mct_2c1, outlet1, origin_port="channel_0")
+        mct_flow_sheet.add_connection(mct_2c1, outlet1, origin_port="channel_1")
+        mct_flow_sheet.add_connection(mct_2c2, outlet2, origin_port="channel_0")
 
         self.mct_flow_sheet = mct_flow_sheet
 
@@ -1052,11 +1033,11 @@ class TestPorts(unittest.TestCase):
 
         ccc_flow_sheet = FlowSheet(self.component_system)
 
-        inlet = Inlet(self.component_system, name='inlet')
-        ccc1 = MCT(self.component_system, nchannel=2, name='ccc1')
-        ccc2 = MCT(self.component_system, nchannel=2, name='ccc2')
-        ccc3 = MCT(self.component_system, nchannel=2, name='ccc3')
-        outlet = Outlet(self.component_system, name='outlet')
+        inlet = Inlet(self.component_system, name="inlet")
+        ccc1 = MCT(self.component_system, nchannel=2, name="ccc1")
+        ccc2 = MCT(self.component_system, nchannel=2, name="ccc2")
+        ccc3 = MCT(self.component_system, nchannel=2, name="ccc3")
+        outlet = Outlet(self.component_system, name="outlet")
 
         ccc_flow_sheet.add_unit(inlet)
         ccc_flow_sheet.add_unit(ccc1)
@@ -1064,376 +1045,296 @@ class TestPorts(unittest.TestCase):
         ccc_flow_sheet.add_unit(ccc3)
         ccc_flow_sheet.add_unit(outlet)
 
-        ccc_flow_sheet.add_connection(inlet, ccc1, destination_port='channel_0')
+        ccc_flow_sheet.add_connection(inlet, ccc1, destination_port="channel_0")
         ccc_flow_sheet.add_connection(
-            ccc1, ccc2, origin_port='channel_0', destination_port='channel_0'
+            ccc1, ccc2, origin_port="channel_0", destination_port="channel_0"
         )
         ccc_flow_sheet.add_connection(
-            ccc2, ccc3, origin_port='channel_0', destination_port='channel_0'
+            ccc2, ccc3, origin_port="channel_0", destination_port="channel_0"
         )
-        ccc_flow_sheet.add_connection(ccc3, outlet, origin_port='channel_0')
+        ccc_flow_sheet.add_connection(ccc3, outlet, origin_port="channel_0")
 
         self.ccc_flow_sheet = ccc_flow_sheet
 
     def test_mct_connections(self):
-        inlet = self.mct_flow_sheet['inlet']
-        mct_3c = self.mct_flow_sheet['mct_3c']
-        mct_2c1 = self.mct_flow_sheet['mct_2c1']
-        mct_2c2 = self.mct_flow_sheet['mct_2c2']
-        outlet1 = self.mct_flow_sheet['outlet1']
-        outlet2 = self.mct_flow_sheet['outlet2']
+        inlet = self.mct_flow_sheet["inlet"]
+        mct_3c = self.mct_flow_sheet["mct_3c"]
+        mct_2c1 = self.mct_flow_sheet["mct_2c1"]
+        mct_2c2 = self.mct_flow_sheet["mct_2c2"]
+        outlet1 = self.mct_flow_sheet["outlet1"]
+        outlet2 = self.mct_flow_sheet["outlet2"]
 
         expected_connections = {
             inlet: {
-                'origins': None,
-                'destinations': {
+                "origins": None,
+                "destinations": {
                     None: {
-                        mct_3c: ['channel_0'],
+                        mct_3c: ["channel_0"],
                     },
                 },
             },
             mct_3c: {
-                'origins': {
-                    'channel_0': {
+                "origins": {
+                    "channel_0": {
                         inlet: [None],
                     },
-                    'channel_1': {
-
-                    },
-                    'channel_2': {
-
-                    },
+                    "channel_1": {},
+                    "channel_2": {},
                 },
-                'destinations': {
-                    'channel_0': {
-                        mct_2c1: ['channel_0', 'channel_1'],
+                "destinations": {
+                    "channel_0": {
+                        mct_2c1: ["channel_0", "channel_1"],
                     },
-                    'channel_1': {
-                        mct_2c2: ['channel_0'],
+                    "channel_1": {
+                        mct_2c2: ["channel_0"],
                     },
-                    'channel_2': {
-
-                    },
+                    "channel_2": {},
                 },
             },
-
             mct_2c1: {
-                'origins': {
-                    'channel_0': {
-                        mct_3c: ['channel_0'],
+                "origins": {
+                    "channel_0": {
+                        mct_3c: ["channel_0"],
                     },
-
-                    'channel_1': {
-                        mct_3c: ['channel_0'],
+                    "channel_1": {
+                        mct_3c: ["channel_0"],
                     },
                 },
-                'destinations': {
-                    'channel_0': {
+                "destinations": {
+                    "channel_0": {
                         outlet1: [None],
                     },
-                    'channel_1': {
+                    "channel_1": {
                         outlet1: [None],
                     },
                 },
             },
-
             mct_2c2: {
-                'origins': {
-                    'channel_0': {
-                        mct_3c: ['channel_1'],
+                "origins": {
+                    "channel_0": {
+                        mct_3c: ["channel_1"],
                     },
-                    'channel_1': {
-
-                    },
+                    "channel_1": {},
                 },
-
-                'destinations': {
-                    'channel_0': {
+                "destinations": {
+                    "channel_0": {
                         outlet2: [None],
                     },
-                    'channel_1': {
-
-                    },
+                    "channel_1": {},
                 },
             },
-
             outlet1: {
-                'origins': {
+                "origins": {
                     None: {
-                        mct_2c1: ['channel_0', 'channel_1'],
+                        mct_2c1: ["channel_0", "channel_1"],
                     },
                 },
-
-                'destinations': None,
+                "destinations": None,
             },
-
             outlet2: {
-                'origins': {
+                "origins": {
                     None: {
-                        mct_2c2: ['channel_0'],
+                        mct_2c2: ["channel_0"],
                     },
                 },
-
-                'destinations': None,
+                "destinations": None,
             },
         }
 
-        self.assertDictEqual(
-            self.mct_flow_sheet.connections, expected_connections
-        )
+        self.assertDictEqual(self.mct_flow_sheet.connections, expected_connections)
 
         self.assertTrue(
+            self.mct_flow_sheet.connection_exists(inlet, mct_3c, destination_port="channel_0")
+        )
+        self.assertTrue(
+            self.mct_flow_sheet.connection_exists(mct_3c, mct_2c1, "channel_0", "channel_0")
+        )
+        self.assertTrue(
+            self.mct_flow_sheet.connection_exists(mct_3c, mct_2c1, "channel_0", "channel_1")
+        )
+        self.assertTrue(
+            self.mct_flow_sheet.connection_exists(mct_3c, mct_2c2, "channel_1", "channel_0")
+        )
+        self.assertTrue(
+            self.mct_flow_sheet.connection_exists(mct_2c1, outlet1, "channel_0")
+        )
+        self.assertTrue(
+            self.mct_flow_sheet.connection_exists(mct_2c1, outlet1, "channel_1")
+        )
+        self.assertTrue(
+            self.mct_flow_sheet.connection_exists(mct_2c2, outlet2, "channel_0")
+        )
+
+        self.assertFalse(
+            self.mct_flow_sheet.connection_exists(mct_2c2, outlet2, "channel_1")
+        )
+        self.assertFalse(
             self.mct_flow_sheet.connection_exists(
-                inlet, mct_3c, destination_port='channel_0'
+                inlet, mct_2c1, destination_port="channel_0"
             )
         )
-        self.assertTrue(self.mct_flow_sheet.connection_exists(mct_3c, mct_2c1, 'channel_0', 'channel_0'))
-        self.assertTrue(self.mct_flow_sheet.connection_exists(mct_3c, mct_2c1, 'channel_0', 'channel_1'))
-        self.assertTrue(self.mct_flow_sheet.connection_exists(mct_3c, mct_2c2, 'channel_1', 'channel_0'))
-        self.assertTrue(self.mct_flow_sheet.connection_exists(mct_2c1, outlet1, 'channel_0'))
-        self.assertTrue(self.mct_flow_sheet.connection_exists(mct_2c1, outlet1, 'channel_1'))
-        self.assertTrue(self.mct_flow_sheet.connection_exists(mct_2c2, outlet2, 'channel_0'))
-
-        self.assertFalse(self.mct_flow_sheet.connection_exists(mct_2c2, outlet2, 'channel_1'))
-        self.assertFalse(self.mct_flow_sheet.connection_exists(inlet, mct_2c1, destination_port='channel_0'))
 
     def test_ccc_connections(self):
-        inlet = self.ccc_flow_sheet['inlet']
-        ccc1 = self.ccc_flow_sheet['ccc1']
-        ccc2 = self.ccc_flow_sheet['ccc2']
-        ccc3 = self.ccc_flow_sheet['ccc3']
-        outlet = self.ccc_flow_sheet['outlet']
+        inlet = self.ccc_flow_sheet["inlet"]
+        ccc1 = self.ccc_flow_sheet["ccc1"]
+        ccc2 = self.ccc_flow_sheet["ccc2"]
+        ccc3 = self.ccc_flow_sheet["ccc3"]
+        outlet = self.ccc_flow_sheet["outlet"]
 
         expected_connections = {
             inlet: {
-                'origins': None,
-                'destinations': {
+                "origins": None,
+                "destinations": {
                     None: {
-                        ccc1: ['channel_0'],
+                        ccc1: ["channel_0"],
                     },
                 },
             },
             ccc1: {
-                'origins': {
-                    'channel_0': {
+                "origins": {
+                    "channel_0": {
                         inlet: [None],
                     },
-                    'channel_1': {
-
-                    }
+                    "channel_1": {},
                 },
-                'destinations': {
-                    'channel_0': {
-                        ccc2: ['channel_0'],
+                "destinations": {
+                    "channel_0": {
+                        ccc2: ["channel_0"],
                     },
-                    'channel_1': {
-
-                    }
+                    "channel_1": {},
                 },
             },
-
             ccc2: {
-                'origins': {
-                    'channel_0': {
-                        ccc1: ['channel_0'],
+                "origins": {
+                    "channel_0": {
+                        ccc1: ["channel_0"],
                     },
-                    'channel_1': {
-
-                    }
+                    "channel_1": {},
                 },
-                'destinations': {
-                    'channel_0': {
-                        ccc3: ['channel_0'],
+                "destinations": {
+                    "channel_0": {
+                        ccc3: ["channel_0"],
                     },
-                    'channel_1': {
-
-                    }
+                    "channel_1": {},
                 },
             },
-
             ccc3: {
-                'origins': {
-                    'channel_0': {
-                        ccc2: ['channel_0'],
+                "origins": {
+                    "channel_0": {
+                        ccc2: ["channel_0"],
                     },
-                    'channel_1': {
-
-                    }
+                    "channel_1": {},
                 },
-                'destinations': {
-                    'channel_0': {
+                "destinations": {
+                    "channel_0": {
                         outlet: [None],
                     },
-                    'channel_1': {
-
-                    }
+                    "channel_1": {},
                 },
             },
-
             outlet: {
-                'origins': {
+                "origins": {
                     None: {
-                        ccc3: ['channel_0'],
+                        ccc3: ["channel_0"],
                     },
                 },
-
-                'destinations': None,
+                "destinations": None,
             },
         }
 
-        self.assertDictEqual(
-            self.ccc_flow_sheet.connections, expected_connections
-        )
+        self.assertDictEqual(self.ccc_flow_sheet.connections, expected_connections)
 
-        self.assertTrue(self.ccc_flow_sheet.connection_exists(inlet, ccc1, destination_port='channel_0'))
-        self.assertTrue(self.ccc_flow_sheet.connection_exists(ccc1, ccc2, 'channel_0', 'channel_0'))
-        self.assertTrue(self.ccc_flow_sheet.connection_exists(ccc2, ccc3, 'channel_0', 'channel_0'))
-        self.assertTrue(self.ccc_flow_sheet.connection_exists(ccc3, outlet, 'channel_0'))
+        self.assertTrue(
+            self.ccc_flow_sheet.connection_exists(
+                inlet, ccc1, destination_port="channel_0"
+            )
+        )
+        self.assertTrue(
+            self.ccc_flow_sheet.connection_exists(ccc1, ccc2, "channel_0", "channel_0")
+        )
+        self.assertTrue(
+            self.ccc_flow_sheet.connection_exists(ccc2, ccc3, "channel_0", "channel_0")
+        )
+        self.assertTrue(
+            self.ccc_flow_sheet.connection_exists(ccc3, outlet, "channel_0")
+        )
 
         self.assertFalse(self.ccc_flow_sheet.connection_exists(inlet, outlet))
 
     def test_mct_flow_rate_calculation(self):
-
         mct_flow_sheet = self.mct_flow_sheet
 
         mct_flow_sheet.inlet.flow_rate = 1
 
-        inlet = self.mct_flow_sheet['inlet']
-        mct_3c = self.mct_flow_sheet['mct_3c']
-        mct_2c1 = self.mct_flow_sheet['mct_2c1']
-        mct_2c2 = self.mct_flow_sheet['mct_2c2']
+        inlet = self.mct_flow_sheet["inlet"]
+        mct_3c = self.mct_flow_sheet["mct_3c"]
+        mct_2c1 = self.mct_flow_sheet["mct_2c1"]
+        mct_2c2 = self.mct_flow_sheet["mct_2c2"]
 
-#        mct_flow_sheet.set_output_state(mct_3c, [0.5, 0.5], 0)
+        #        mct_flow_sheet.set_output_state(mct_3c, [0.5, 0.5], 0)
 
         expected_flow = {
-            'inlet': {
-                'total_out': {
-                    None: (1, 0, 0, 0)
+            "inlet": {
+                "total_out": {None: (1, 0, 0, 0)},
+                "destinations": {None: {"mct_3c": {"channel_0": (1, 0, 0, 0)}}},
+            },
+            "mct_3c": {
+                "total_in": {
+                    "channel_0": (1, 0, 0, 0),
+                    "channel_1": (0, 0, 0, 0),
+                    "channel_2": (0, 0, 0, 0),
                 },
-                'destinations': {
+                "origins": {"channel_0": {"inlet": {None: (1, 0, 0, 0)}}},
+                "total_out": {
+                    "channel_0": (1, 0, 0, 0),
+                    "channel_1": (0, 0, 0, 0),
+                    "channel_2": (0, 0, 0, 0),
+                },
+                "destinations": {
+                    "channel_0": {
+                        "mct_2c1": {
+                            "channel_0": (1, 0, 0, 0),
+                            "channel_1": (0, 0, 0, 0),
+                        }
+                    },
+                    "channel_1": {"mct_2c2": {"channel_0": (0, 0, 0, 0)}},
+                },
+            },
+            "mct_2c1": {
+                "total_in": {"channel_0": (1, 0, 0, 0), "channel_1": (0, 0, 0, 0)},
+                "origins": {
+                    "channel_0": {"mct_3c": {"channel_0": (1, 0, 0, 0)}},
+                    "channel_1": {"mct_3c": {"channel_0": (0, 0, 0, 0)}},
+                },
+                "total_out": {"channel_0": (1, 0, 0, 0), "channel_1": (0, 0, 0, 0)},
+                "destinations": {
+                    "channel_0": {"outlet1": {None: (1, 0, 0, 0)}},
+                    "channel_1": {"outlet1": {None: (0, 0, 0, 0)}},
+                },
+            },
+            "mct_2c2": {
+                "total_in": {"channel_0": (0, 0, 0, 0), "channel_1": (0, 0, 0, 0)},
+                "origins": {
+                    "channel_0": {"mct_3c": {"channel_1": (0, 0, 0, 0)}},
+                },
+                "total_out": {"channel_0": (0, 0, 0, 0), "channel_1": (0, 0, 0, 0)},
+                "destinations": {"channel_0": {"outlet2": {None: (0, 0, 0, 0)}}},
+            },
+            "outlet1": {
+                "total_in": {None: (1, 0, 0, 0)},
+                "origins": {
                     None: {
-                        'mct_3c': {
-                            'channel_0': (1, 0, 0, 0)
+                        "mct_2c1": {
+                            "channel_0": (1, 0, 0, 0),
+                            "channel_1": (0, 0, 0, 0),
                         }
                     }
-                }
+                },
             },
-            'mct_3c': {
-                'total_in': {
-                    'channel_0': (1, 0, 0, 0),
-                    'channel_1': (0, 0, 0, 0),
-                    'channel_2': (0, 0, 0, 0)
-                },
-                'origins': {
-                    'channel_0': {
-                        'inlet': {
-                            None: (1, 0, 0, 0)
-                        }
-                    }
-                },
-                'total_out': {
-                    'channel_0': (1, 0, 0, 0),
-                    'channel_1': (0, 0, 0, 0),
-                    'channel_2': (0, 0, 0, 0)
-                },
-                'destinations': {
-                    'channel_0': {
-                        'mct_2c1': {
-                            'channel_0': (1, 0, 0, 0),
-                            'channel_1': (0, 0, 0, 0)
-                        }
-                    },
-                    'channel_1': {
-                        'mct_2c2': {
-                            'channel_0': (0, 0, 0, 0)
-                        }
-                    }
-                }
+            "outlet2": {
+                "total_in": {None: (0, 0, 0, 0)},
+                "origins": {None: {"mct_2c2": {"channel_0": (0, 0, 0, 0)}}},
             },
-            'mct_2c1': {
-                'total_in': {
-                    'channel_0': (1, 0, 0, 0),
-                    'channel_1': (0, 0, 0, 0)
-                },
-                'origins': {
-                    'channel_0': {
-                        'mct_3c': {
-                            'channel_0': (1, 0, 0, 0)
-                        }
-                    },
-                    'channel_1': {
-                        'mct_3c': {
-                            'channel_0': (0, 0, 0, 0)
-                        }
-                    }
-                },
-                'total_out': {
-                    'channel_0': (1, 0, 0, 0),
-                    'channel_1': (0, 0, 0, 0)
-                },
-                'destinations': {
-                    'channel_0': {
-                        'outlet1': {
-                            None: (1, 0, 0, 0)
-                        }
-                    },
-                    'channel_1': {
-                        'outlet1': {
-                            None: (0, 0, 0, 0)
-                        }
-                    }
-                }
-            },
-
-            'mct_2c2': {
-                'total_in': {
-                    'channel_0': (0, 0, 0, 0),
-                    'channel_1': (0, 0, 0, 0)
-                },
-                'origins': {
-                    'channel_0': {
-                        'mct_3c': {
-                            'channel_1': (0, 0, 0, 0)
-                        }
-                    },
-                },
-                'total_out': {
-                    'channel_0': (0, 0, 0, 0),
-                    'channel_1': (0, 0, 0, 0)
-                },
-                'destinations': {
-                    'channel_0': {
-                        'outlet2': {
-                            None: (0, 0, 0, 0)
-                        }
-                    }
-                }
-            },
-            'outlet1': {
-                'total_in': {
-                    None: (1, 0, 0, 0)
-                },
-                'origins': {
-                    None: {
-                        'mct_2c1': {
-                            'channel_0': (1, 0, 0, 0),
-                            'channel_1': (0, 0, 0, 0)
-                        }
-                    }
-                }
-            },
-            'outlet2': {
-                'total_in': {
-                    None: (0, 0, 0, 0)
-                },
-                'origins': {
-                    None: {
-                        'mct_2c2': {
-                            'channel_0': (0, 0, 0, 0)
-                        }
-                    }
-                }
-            }
         }
 
         flow_rates = mct_flow_sheet.get_flow_rates()
@@ -1441,11 +1342,10 @@ class TestPorts(unittest.TestCase):
         assert_almost_equal_dict(flow_rates, expected_flow)
 
     def test_port_add_connection(self):
-
-        inlet = self.mct_flow_sheet['inlet']
-        mct_3c = self.mct_flow_sheet['mct_3c']
-        mct_2c2 = self.mct_flow_sheet['mct_2c2']
-        outlet1 = self.mct_flow_sheet['outlet1']
+        inlet = self.mct_flow_sheet["inlet"]
+        mct_3c = self.mct_flow_sheet["mct_3c"]
+        mct_2c2 = self.mct_flow_sheet["mct_2c2"]
+        outlet1 = self.mct_flow_sheet["outlet1"]
 
         with self.assertRaises(CADETProcessError):
             self.mct_flow_sheet.add_connection(
@@ -1463,18 +1363,17 @@ class TestPorts(unittest.TestCase):
             )
 
     def test_set_output_state(self):
-
-        mct_3c = self.mct_flow_sheet['mct_3c']
+        mct_3c = self.mct_flow_sheet["mct_3c"]
 
         with self.assertRaises(CADETProcessError):
             self.mct_flow_sheet.set_output_state(mct_3c, [0.5, 0.5])
 
         with self.assertRaises(CADETProcessError):
-            self.mct_flow_sheet.set_output_state(mct_3c, [0.5, 0.5], 'channel_5')
+            self.mct_flow_sheet.set_output_state(mct_3c, [0.5, 0.5], "channel_5")
 
         with self.assertRaises(CADETProcessError):
             self.mct_flow_sheet.set_output_state(
-                mct_3c, {'mct_2c1': {'channel_0': 0.5, 'channel_5': 0.5}}, 'channel_0'
+                mct_3c, {"mct_2c1": {"channel_0": 0.5, "channel_5": 0.5}}, "channel_0"
             )
 
 
@@ -1486,11 +1385,11 @@ class TestFlowRateMatrix(unittest.TestCase):
 
         flow_sheet = FlowSheet(self.component_system)
 
-        inlet = Inlet(self.component_system, name='inlet')
-        cstr1 = Cstr(self.component_system, name='cstr1')
-        cstr2 = Cstr(self.component_system, name='cstr2')
-        outlet1 = Outlet(self.component_system, name='outlet1')
-        outlet2 = Outlet(self.component_system, name='outlet2')
+        inlet = Inlet(self.component_system, name="inlet")
+        cstr1 = Cstr(self.component_system, name="cstr1")
+        cstr2 = Cstr(self.component_system, name="cstr2")
+        outlet1 = Outlet(self.component_system, name="outlet1")
+        outlet2 = Outlet(self.component_system, name="outlet2")
 
         flow_sheet.add_unit(inlet)
         flow_sheet.add_unit(cstr1)
@@ -1516,96 +1415,95 @@ class TestFlowRateMatrix(unittest.TestCase):
         self.flow_sheet.inlet.flow_rate = [1]
 
         expected_flow_rates = {
-            'inlet': {
-                'total_out': {
+            "inlet": {
+                "total_out": {
                     None: (1, 0, 0, 0),
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr1': {
+                        "cstr1": {
                             None: (0.3, 0, 0, 0),
                         },
-                        'cstr2': {
+                        "cstr2": {
                             None: (0.7, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr1': {
-                'total_in': {
+            "cstr1": {
+                "total_in": {
                     None: (0.65, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (0.65, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'inlet': {
+                        "inlet": {
                             None: (0.3, 0, 0, 0),
                         },
-                        'cstr2': {
+                        "cstr2": {
                             None: (0.35, 0, 0, 0),
                         },
                     }
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'outlet1': {
+                        "outlet1": {
                             None: (0.65, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr2': {
-                'total_in': {
+            "cstr2": {
+                "total_in": {
                     None: (0.7, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (0.7, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'inlet': {
+                        "inlet": {
                             None: (0.7, 0, 0, 0),
                         },
                     }
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr1': {
+                        "cstr1": {
                             None: (0.35, 0, 0, 0),
                         },
-                        'outlet2': {
+                        "outlet2": {
                             None: (0.35, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet1': {
-                'origins': {
+            "outlet1": {
+                "origins": {
                     None: {
-                        'cstr1': {
+                        "cstr1": {
                             None: (0.65, 0, 0, 0),
                         },
                     },
                 },
-                'total_in': {
+                "total_in": {
                     None: (0.65, 0, 0, 0),
                 },
             },
-
-            'outlet2': {
-                'origins': {
+            "outlet2": {
+                "origins": {
                     None: {
-                        'cstr2': {
+                        "cstr2": {
                             None: (0.35, 0, 0, 0),
                         },
                     }
                 },
-                'total_in': {
+                "total_in": {
                     None: (0.35, 0, 0, 0),
                 },
-            }
+            },
         }
 
         calc_flow_rate = self.flow_sheet.get_flow_rates()
@@ -1621,9 +1519,9 @@ class TestFlowRateSelfMatrix(unittest.TestCase):
 
         flow_sheet = FlowSheet(self.component_system)
 
-        inlet = Inlet(self.component_system, name='inlet')
-        cstr = Cstr(self.component_system, name='cstr')
-        outlet = Outlet(self.component_system, name='outlet')
+        inlet = Inlet(self.component_system, name="inlet")
+        cstr = Cstr(self.component_system, name="cstr")
+        outlet = Outlet(self.component_system, name="outlet")
 
         flow_sheet.add_unit(inlet)
         flow_sheet.add_unit(cstr)
@@ -1642,53 +1540,53 @@ class TestFlowRateSelfMatrix(unittest.TestCase):
         self.flow_sheet.inlet.flow_rate = [1]
 
         expected_flow_rates = {
-            'inlet': {
-                'total_out': {
+            "inlet": {
+                "total_out": {
                     None: (1, 0, 0, 0),
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr': {
-                'total_in': {
+            "cstr": {
+                "total_in": {
                     None: (2, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (2, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'inlet': {
+                        "inlet": {
                             None: (1, 0, 0, 0),
                         },
-                        'cstr': {
+                        "cstr": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'outlet': {
+                        "outlet": {
                             None: (1, 0, 0, 0),
                         },
-                        'cstr': {
+                        "cstr": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet': {
-                'total_in': {
+            "outlet": {
+                "total_in": {
                     None: (1, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'cstr': {
+                        "cstr": {
                             None: (1, 0, 0, 0),
                         },
                     },
@@ -1710,15 +1608,14 @@ class TestSingularFlowMatrix(unittest.TestCase):
     """
 
     def setUp(self):
-
         self.component_system = ComponentSystem(1)
 
         flow_sheet = FlowSheet(self.component_system)
 
-        inlet = Inlet(self.component_system, name='inlet')
-        cstr1 = Cstr(self.component_system, name='cstr1')
-        cstr2 = Cstr(self.component_system, name='cstr2')
-        outlet = Outlet(self.component_system, name='outlet')
+        inlet = Inlet(self.component_system, name="inlet")
+        cstr1 = Cstr(self.component_system, name="cstr1")
+        cstr2 = Cstr(self.component_system, name="cstr2")
+        outlet = Outlet(self.component_system, name="outlet")
 
         flow_sheet.add_unit(inlet)
         flow_sheet.add_unit(cstr1)
@@ -1747,69 +1644,67 @@ class TestSingularFlowMatrix(unittest.TestCase):
     def test_expelled_circuit_with_flow(self):
         # Solvable because both disconnected circles have their own flow rates
         expected_flow_rates = {
-            'inlet': {
-                'total_out': {
+            "inlet": {
+                "total_out": {
                     None: (1, 0, 0, 0),
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'outlet': {
+                        "outlet": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'cstr1': {
-                'total_in': {
+            "cstr1": {
+                "total_in": {
                     None: (1, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (1, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'cstr2': {
+                        "cstr2": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr2': {
-                            None: (1, 0, 0, 0)
-                        },
+                        "cstr2": {None: (1, 0, 0, 0)},
                     },
                 },
             },
-            'cstr2': {
-                'total_in': {
+            "cstr2": {
+                "total_in": {
                     None: (1, 0, 0, 0),
                 },
-                'total_out': {
+                "total_out": {
                     None: (1, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'cstr1': {
+                        "cstr1": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
-                'destinations': {
+                "destinations": {
                     None: {
-                        'cstr1': {
+                        "cstr1": {
                             None: (1, 0, 0, 0),
                         },
                     },
                 },
             },
-            'outlet': {
-                'total_in': {
+            "outlet": {
+                "total_in": {
                     None: (1, 0, 0, 0),
                 },
-                'origins': {
+                "origins": {
                     None: {
-                        'inlet': {
+                        "inlet": {
                             None: (1, 0, 0, 0),
                         },
                     },
@@ -1824,5 +1719,5 @@ class TestSingularFlowMatrix(unittest.TestCase):
         np.testing.assert_equal(flow_sheet.get_flow_rates(), expected_flow_rates)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_flow_sheet.py
+++ b/tests/test_flow_sheet.py
@@ -1,13 +1,16 @@
 import unittest
 
 import numpy as np
-
 from CADETProcess import CADETProcessError
-from CADETProcess.processModel import ComponentSystem
 from CADETProcess.processModel import (
-    Inlet, Cstr, MCT, LumpedRateModelWithoutPores, Outlet
+    MCT,
+    ComponentSystem,
+    Cstr,
+    FlowSheet,
+    Inlet,
+    LumpedRateModelWithoutPores,
+    Outlet,
 )
-from CADETProcess.processModel import FlowSheet
 
 
 def assert_almost_equal_dict(dict_actual, dict_expected, decimal=7, verbose=True):
@@ -811,7 +814,7 @@ class TestFlowSheet(unittest.TestCase):
         output_state = self.ssr_flow_sheet.output_states[column]
         np.testing.assert_equal(output_state, output_state_expected)
 
-        self.ssr_flow_sheet.set_output_state(column, [0,  1])
+        self.ssr_flow_sheet.set_output_state(column, [0, 1])
         output_state_expected = {None: [0, 1]}
         output_state = self.ssr_flow_sheet._output_states[column]
         np.testing.assert_equal(output_state, output_state_expected)
@@ -1117,11 +1120,11 @@ class TestPorts(unittest.TestCase):
             mct_2c1: {
                 'origins': {
                     'channel_0': {
-                        mct_3c:['channel_0'],
+                        mct_3c: ['channel_0'],
                     },
 
                     'channel_1': {
-                        mct_3c:['channel_0'],
+                        mct_3c: ['channel_0'],
                     },
                 },
                 'destinations': {
@@ -1137,7 +1140,7 @@ class TestPorts(unittest.TestCase):
             mct_2c2: {
                 'origins': {
                     'channel_0': {
-                        mct_3c:['channel_1'],
+                        mct_3c: ['channel_1'],
                     },
                     'channel_1': {
 
@@ -1155,9 +1158,9 @@ class TestPorts(unittest.TestCase):
             },
 
             outlet1: {
-                'origins':{
+                'origins': {
                     None: {
-                        mct_2c1:['channel_0','channel_1'],
+                        mct_2c1: ['channel_0', 'channel_1'],
                     },
                 },
 
@@ -1165,9 +1168,9 @@ class TestPorts(unittest.TestCase):
             },
 
             outlet2: {
-                'origins':{
+                'origins': {
                     None: {
-                        mct_2c2:['channel_0'],
+                        mct_2c2: ['channel_0'],
                     },
                 },
 

--- a/tests/test_fractions.py
+++ b/tests/test_fractions.py
@@ -1,11 +1,10 @@
 import unittest
 
-import numpy as np
 import CADETProcess
+import numpy as np
 
 
 class Test_Fractions(unittest.TestCase):
-
     def create_fractions(self):
         m_0 = np.array([0, 0])
         frac0 = CADETProcess.fractionation.Fraction(m_0, 1)
@@ -48,20 +47,18 @@ class Test_Fractions(unittest.TestCase):
     def test_fraction_concentration(self):
         fractions = self.create_fractions()
 
-        np.testing.assert_equal(fractions[0].concentration, np.array([0., 0.]))
+        np.testing.assert_equal(fractions[0].concentration, np.array([0.0, 0.0]))
         np.testing.assert_equal(fractions[1].concentration, np.array([1.5, 0]))
-        np.testing.assert_equal(
-            fractions[2].concentration, np.array([1/3, 2/3])
-        )
-        np.testing.assert_equal(fractions[3].concentration, np.array([0, 2/3]))
+        np.testing.assert_equal(fractions[2].concentration, np.array([1 / 3, 2 / 3]))
+        np.testing.assert_equal(fractions[3].concentration, np.array([0, 2 / 3]))
         np.testing.assert_equal(fractions[4].concentration, np.array([0, 0]))
 
     def test_fraction_purity(self):
         fractions = self.create_fractions()
 
-        np.testing.assert_equal(fractions[0].purity, np.array([0., 0.]))
+        np.testing.assert_equal(fractions[0].purity, np.array([0.0, 0.0]))
         np.testing.assert_equal(fractions[1].purity, np.array([1, 0]))
-        np.testing.assert_equal(fractions[2].purity, np.array([1/3, 2/3]))
+        np.testing.assert_equal(fractions[2].purity, np.array([1 / 3, 2 / 3]))
         np.testing.assert_equal(fractions[3].purity, np.array([0, 1]))
         np.testing.assert_equal(fractions[4].purity, np.array([0, 0]))
 
@@ -72,8 +69,7 @@ class Test_Fractions(unittest.TestCase):
         self.assertEqual(pools[0].fractions[0].n_comp, 2)
 
         m_wrong_n_comp = np.array([0, 0, 0])
-        frac_wrong_n_comp = \
-            CADETProcess.fractionation.Fraction(m_wrong_n_comp, 1)
+        frac_wrong_n_comp = CADETProcess.fractionation.Fraction(m_wrong_n_comp, 1)
 
         with self.assertRaises(CADETProcess.CADETProcessError):
             pools[0].add_fraction(frac_wrong_n_comp)
@@ -81,7 +77,7 @@ class Test_Fractions(unittest.TestCase):
     def test_pool_mass(self):
         pools = self.create_pools()
 
-        np.testing.assert_equal(pools[0].mass, np.array([4., 2.]))
+        np.testing.assert_equal(pools[0].mass, np.array([4.0, 2.0]))
         np.testing.assert_equal(pools[1].mass, np.array([0, 2]))
         np.testing.assert_equal(pools[2].mass, np.array([0, 0]))
 
@@ -102,17 +98,17 @@ class Test_Fractions(unittest.TestCase):
     def test_pool_concentration(self):
         pools = self.create_pools()
 
-        np.testing.assert_equal(pools[0].concentration, np.array([2/3, 1/3]))
-        np.testing.assert_equal(pools[1].concentration, np.array([0, 2/3]))
+        np.testing.assert_equal(pools[0].concentration, np.array([2 / 3, 1 / 3]))
+        np.testing.assert_equal(pools[1].concentration, np.array([0, 2 / 3]))
         np.testing.assert_equal(pools[2].concentration, np.array([0, 0]))
 
     def test_pool_purity(self):
         pools = self.create_pools()
 
-        np.testing.assert_equal(pools[0].purity, np.array([2/3, 1/3]))
+        np.testing.assert_equal(pools[0].purity, np.array([2 / 3, 1 / 3]))
         np.testing.assert_equal(pools[1].purity, np.array([0, 1]))
         np.testing.assert_equal(pools[2].purity, np.array([0, 0]))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_individual.py
+++ b/tests/test_individual.py
@@ -1,8 +1,7 @@
 import unittest
 
 import numpy as np
-
-from CADETProcess.optimization import hash_array, Individual
+from CADETProcess.optimization import Individual, hash_array
 
 
 def setup_individual(n_vars=2, n_obj=1, n_nonlin=0, n_meta=0, rng=None):
@@ -101,19 +100,11 @@ class TestIndividual(unittest.TestCase):
         self.assertFalse(self.individual_1.dominates(self.individual_2))
         self.assertTrue(self.individual_2.dominates(self.individual_1))
 
-        self.assertFalse(
-            self.individual_multi_1.dominates(self.individual_multi_2)
-        )
-        self.assertTrue(
-            self.individual_multi_2.dominates(self.individual_multi_1)
-        )
-        self.assertFalse(
-            self.individual_multi_3.dominates(self.individual_multi_2)
-        )
+        self.assertFalse(self.individual_multi_1.dominates(self.individual_multi_2))
+        self.assertTrue(self.individual_multi_2.dominates(self.individual_multi_1))
+        self.assertFalse(self.individual_multi_3.dominates(self.individual_multi_2))
 
-        self.assertFalse(
-            self.individual_multi_3.dominates(self.individual_multi_2)
-        )
+        self.assertFalse(self.individual_multi_3.dominates(self.individual_multi_2))
 
     def test_similarity(self):
         self.assertTrue(self.individual_1.is_similar(self.individual_2, 1e-1))
@@ -129,20 +120,21 @@ class TestIndividual(unittest.TestCase):
     def test_to_dict(self):
         data = self.individual_1.to_dict()
 
-        np.testing.assert_equal(data['x'], self.individual_1.x)
-        np.testing.assert_equal(data['f'], self.individual_1.f)
-        np.testing.assert_equal(
-            data['x_transformed'], self.individual_1.x_transformed
-        )
-        self.assertEqual(data['variable_names'], self.individual_1.variable_names)
+        np.testing.assert_equal(data["x"], self.individual_1.x)
+        np.testing.assert_equal(data["f"], self.individual_1.f)
+        np.testing.assert_equal(data["x_transformed"], self.individual_1.x_transformed)
+        self.assertEqual(data["variable_names"], self.individual_1.variable_names)
         self.assertEqual(
-            data['independent_variable_names'],
-            self.individual_1.independent_variable_names
+            data["independent_variable_names"],
+            self.individual_1.independent_variable_names,
         )
 
         # Missing: Test for labels.
         # self.assertEqual(data['objective_labels'], self.individual_1.objective_labels)
-        # self.assertEqual(data['nonlinear_constraint_labels'], self.individual_1.nonlinear_constraint_labels)
+        # self.assertEqual(
+        #     data['nonlinear_constraint_labels'],
+        #     self.individual_1.nonlinear_constraint_labels,
+        # )
         # self.assertEqual(data['meta_score_labels'], elf.individual_1.meta_score_labels)
 
     def test_from_dict(self):
@@ -161,13 +153,14 @@ class TestIndividual(unittest.TestCase):
         )
         self.assertEqual(
             test_individual.independent_variable_names,
-            self.individual_1.independent_variable_names
+            self.individual_1.independent_variable_names,
         )
         self.assertEqual(
             test_individual.objective_labels, self.individual_1.objective_labels
         )
         self.assertEqual(
-            test_individual.nonlinear_constraint_labels, self.individual_1.nonlinear_constraint_labels
+            test_individual.nonlinear_constraint_labels,
+            self.individual_1.nonlinear_constraint_labels,
         )
         self.assertEqual(
             test_individual.meta_score_labels, self.individual_1.meta_score_labels
@@ -175,5 +168,5 @@ class TestIndividual(unittest.TestCase):
         self.assertEqual(test_individual.id, self.individual_1.id)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_numerics.py
+++ b/tests/test_numerics.py
@@ -46,7 +46,9 @@ def test_mixed_values():
 
 
 def test_invalid_digits():
-    with pytest.raises(ValueError, match="Number of significant digits must be greater than 0."):
+    with pytest.raises(
+        ValueError, match="Number of significant digits must be greater than 0."
+    ):
         round_to_significant_digits(np.array([123.456]), 0)
 
 
@@ -72,7 +74,7 @@ def test_none_digits():
 
 
 def test_nan_digits():
-    values = np.array([123.456,  np.nan, 98765])
+    values = np.array([123.456, np.nan, 98765])
     expected = np.array([123.0, np.nan, 98800.0])
     result = round_to_significant_digits(values, 3)
     np.testing.assert_allclose(result, expected, rtol=1e-6)

--- a/tests/test_optimization_integration.py
+++ b/tests/test_optimization_integration.py
@@ -1,12 +1,12 @@
-from pathlib import Path
-import time
 import shutil
 import sys
+import time
 import unittest
+from pathlib import Path
 
 from CADETProcess import settings
 
-sys.path.insert(0, '../')
+sys.path.insert(0, "../")
 
 # Set flags for which test cases to run
 test_batch_elution_single_objective_single_core = True
@@ -20,27 +20,30 @@ class TestBatchElutionOptimizationSingleObjective(unittest.TestCase):
         self.tearDown()
 
         if not (
-                test_batch_elution_single_objective_single_core
-                or
-                test_batch_elution_single_objective_multi_core
+            test_batch_elution_single_objective_single_core
+            or test_batch_elution_single_objective_multi_core
         ):
             return
 
-        settings.working_directory = './test_batch'
-        settings.temp_dir = './test_batch/tmp'
+        settings.working_directory = "./test_batch"
+        settings.temp_dir = "./test_batch/tmp"
 
         from examples.batch_elution.optimization_single import (
-            optimization_problem, optimizer
+            optimization_problem,
+            optimizer,
         )
-        optimization_problem.cache_directory = './test_batch/diskcache_batch_elution_single'
+
+        optimization_problem.cache_directory = (
+            "./test_batch/diskcache_batch_elution_single"
+        )
 
         self.optimization_problem = optimization_problem
         self.optimizer = optimizer
 
     def tearDown(self):
-        shutil.rmtree('./test_batch', ignore_errors=True)
-        shutil.rmtree('./diskcache_batch_elution_single', ignore_errors=True)
-        shutil.rmtree('./tmp', ignore_errors=True)
+        shutil.rmtree("./test_batch", ignore_errors=True)
+        shutil.rmtree("./diskcache_batch_elution_single", ignore_errors=True)
+        shutil.rmtree("./tmp", ignore_errors=True)
 
         settings.working_directory = None
 
@@ -61,7 +64,9 @@ class TestBatchElutionOptimizationSingleObjective(unittest.TestCase):
         )
         end = time.time()
 
-        print(f"Finalized test_batch_elution_single_objective_single_core in {end - start} s")
+        print(
+            f"Finalized test_batch_elution_single_objective_single_core in {end - start} s"
+        )
 
     @unittest.skipIf(__name__ != "__main__", "Only run test if test is run as __main__")
     def test_multi_core(self):
@@ -81,8 +86,10 @@ class TestBatchElutionOptimizationSingleObjective(unittest.TestCase):
         )
         end = time.time()
 
-        print(f"Finalized test_batch_elution_single_objective_multi_core in {end - start} s")
-        print(f"Equivalent CPU time: {(end - start)* self.optimizer.n_cores} s")
+        print(
+            f"Finalized test_batch_elution_single_objective_multi_core in {end - start} s"
+        )
+        print(f"Equivalent CPU time: {(end - start) * self.optimizer.n_cores} s")
 
 
 class TestBatchElutionOptimizationMultiObjective(unittest.TestCase):
@@ -92,21 +99,25 @@ class TestBatchElutionOptimizationMultiObjective(unittest.TestCase):
         if not test_batch_elution_multi_objective:
             return
 
-        settings.working_directory = './test_batch'
-        settings.temp_dir = './test_batch/tmp'
+        settings.working_directory = "./test_batch"
+        settings.temp_dir = "./test_batch/tmp"
 
         from examples.batch_elution.optimization_multi import (
-            optimization_problem, optimizer
+            optimization_problem,
+            optimizer,
         )
-        optimization_problem.cache_directory = './test_batch/diskcache_batch_elution_multi'
+
+        optimization_problem.cache_directory = (
+            "./test_batch/diskcache_batch_elution_multi"
+        )
 
         self.optimization_problem = optimization_problem
         self.optimizer = optimizer
 
     def tearDown(self):
-        shutil.rmtree('./test_batch', ignore_errors=True)
-        shutil.rmtree('./diskcache_batch_elution_multi', ignore_errors=True)
-        shutil.rmtree('./tmp', ignore_errors=True)
+        shutil.rmtree("./test_batch", ignore_errors=True)
+        shutil.rmtree("./diskcache_batch_elution_multi", ignore_errors=True)
+        shutil.rmtree("./tmp", ignore_errors=True)
 
         settings.working_directory = None
 
@@ -129,7 +140,7 @@ class TestBatchElutionOptimizationMultiObjective(unittest.TestCase):
         end = time.time()
 
         print(f"Finalized test_batch_elution_multi_objective in {end - start} s")
-        print(f"Equivalent CPU time: {(end - start)* self.optimizer.n_cores} s")
+        print(f"Equivalent CPU time: {(end - start) * self.optimizer.n_cores} s")
 
         print(results.f)
         print(results.x)
@@ -142,26 +153,33 @@ class TestFitColumnParameters(unittest.TestCase):
         if not test_fit_column_parameters:
             return
 
-        settings.working_directory = './test_fit_column_parameters'
-        settings.temp_dir = './test_fit_column_parameters/tmp'
+        settings.working_directory = "./test_fit_column_parameters"
+        settings.temp_dir = "./test_fit_column_parameters/tmp"
 
-        data_dir = Path(__file__).parent.parent / 'examples/characterize_chromatographic_system/experimental_data'
-        shutil.copytree(data_dir, './experimental_data')
+        data_dir = (
+            Path(__file__).parent.parent
+            / "examples/characterize_chromatographic_system/experimental_data"
+        )
+        shutil.copytree(data_dir, "./experimental_data")
 
         from examples.characterize_chromatographic_system.column_transport_parameters import (
-            optimization_problem, optimizer
+            optimization_problem,
+            optimizer,
         )
-        optimization_problem.cache_directory = './test_fit_column_parameters/diskcache_bed_porosity_axial_dispersion'
+
+        optimization_problem.cache_directory = (
+            "./test_fit_column_parameters/diskcache_bed_porosity_axial_dispersion"
+        )
 
         self.optimization_problem = optimization_problem
         self.optimizer = optimizer
 
     def tearDown(self):
-        shutil.rmtree('./test_fit_column_parameters', ignore_errors=True)
-        shutil.rmtree('./diskcache_bed_porosity_axial_dispersion/', ignore_errors=True)
-        shutil.rmtree('./tmp', ignore_errors=True)
+        shutil.rmtree("./test_fit_column_parameters", ignore_errors=True)
+        shutil.rmtree("./diskcache_bed_porosity_axial_dispersion/", ignore_errors=True)
+        shutil.rmtree("./tmp", ignore_errors=True)
 
-        shutil.rmtree('./experimental_data/', ignore_errors=True)
+        shutil.rmtree("./experimental_data/", ignore_errors=True)
 
         settings.working_directory = None
 
@@ -183,9 +201,9 @@ class TestFitColumnParameters(unittest.TestCase):
         end = time.time()
 
         print(f"Finalized test_fit_column_parameters in {end - start} s")
-        print(f"Equivalent CPU time: {(end - start)* self.optimizer.n_cores} s")
+        print(f"Equivalent CPU time: {(end - start) * self.optimizer.n_cores} s")
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     # Run the tests
     unittest.main()

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -1,19 +1,25 @@
-from abc import ABC, abstractmethod
 import shutil
 import time
 import unittest
+from abc import ABC, abstractmethod
 
-from addict import Dict
 import numpy as np
-
+from addict import Dict
 from CADETProcess import settings
 from CADETProcess.dataStructure import (
-    Structure, Float, List, SizedList, SizedNdArray, Polynomial, NdPolynomial
+    Float,
+    List,
+    NdPolynomial,
+    Polynomial,
+    SizedList,
+    SizedNdArray,
+    Structure,
 )
 from CADETProcess.optimization import OptimizationProblem
+
 from tests.optimization_problem_fixtures import (
     LinearConstraintsSooTestProblem2,
-    LinearEqualityConstraintsSooTestProblem
+    LinearEqualityConstraintsSooTestProblem,
 )
 
 
@@ -31,20 +37,20 @@ class EvaluationObject(Structure):
     nd_polynomial_param = NdPolynomial(size=(2, 4), default=0)
 
     _parameters = [
-        'uninitialized',
-        'scalar_param',
-        'scalar_param_2',
-        'list_param',
-        'sized_list_param',
-        'sized_list_param_single',
-        'sized_list_param_no_default',
-        'nd_array',
-        'polynomial_param',
-        'polynomial_param_no_default',
-        'nd_polynomial_param',
+        "uninitialized",
+        "scalar_param",
+        "scalar_param_2",
+        "list_param",
+        "sized_list_param",
+        "sized_list_param_single",
+        "sized_list_param_no_default",
+        "nd_array",
+        "polynomial_param",
+        "polynomial_param_no_default",
+        "nd_polynomial_param",
     ]
 
-    def __init__(self, name='Dummy'):
+    def __init__(self, name="Dummy"):
         self.name = name
         super().__init__()
 
@@ -68,10 +74,10 @@ class ExpensiveEvaluator(Evaluator):
     """Mockup for an expensive evaluator"""
 
     def evaluate(self, evaluation_object):
-        print('Run expensive evaluator; this takes forever...')
+        print("Run expensive evaluator; this takes forever...")
 
         expensive_results = Dict()
-        expensive_results.result = np.array(2*[evaluation_object.scalar_param])
+        expensive_results.result = np.array(2 * [evaluation_object.scalar_param])
 
         time.sleep(1)
 
@@ -82,7 +88,7 @@ class CheapEvaluator(Evaluator):
     """Mockup for a cheap evaluator"""
 
     def evaluate(self, expensive_results):
-        print('Run cheap evaluator.')
+        print("Run cheap evaluator.")
         cheap_results = Dict()
         cheap_results.result_1 = expensive_results.result * 2
         cheap_results.result_2 = expensive_results.result * 2
@@ -96,19 +102,19 @@ def sum_x(x):
 
 
 def min_results_1(cheap_results):
-    print('run MinResult1')
+    print("run MinResult1")
     score = cheap_results.result_1 * 2
     return score.tolist()
 
 
 def min_results_2(cheap_results):
-    print('run MinResult2')
+    print("run MinResult2")
     score = cheap_results.result_2 * 3
     return score.tolist()
 
 
-from CADETProcess.optimization import OptimizationVariable
 from CADETProcess import CADETProcessError
+from CADETProcess.optimization import OptimizationVariable
 
 
 class Test_OptimizationVariable(unittest.TestCase):
@@ -117,9 +123,9 @@ class Test_OptimizationVariable(unittest.TestCase):
 
     def test_index(self):
         var = OptimizationVariable(
-            'no_index_required',
+            "no_index_required",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='scalar_param',
+            parameter_path="scalar_param",
         )
         var.value = 1
         np.testing.assert_equal(var.value, 1)
@@ -127,17 +133,17 @@ class Test_OptimizationVariable(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'parameter_not_sized',
+                "parameter_not_sized",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='scalar_param',
-                indices=1
+                parameter_path="scalar_param",
+                indices=1,
             )
 
         var = OptimizationVariable(
-            'list_index',
+            "list_index",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='sized_list_param',
-            indices=1
+            parameter_path="sized_list_param",
+            indices=1,
         )
         var.value = 2
         np.testing.assert_equal(var.value, 2)
@@ -147,42 +153,41 @@ class Test_OptimizationVariable(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'index_exceeds_list_size',
+                "index_exceeds_list_size",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='sized_list_param',
-                indices=2
+                parameter_path="sized_list_param",
+                indices=2,
             )
 
         # Test uninitialized value
         with self.assertRaises(CADETProcessError):
             var = OptimizationVariable(
-                'uninitialized_attribute',
+                "uninitialized_attribute",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='uninitialized',
-                indices=2
+                parameter_path="uninitialized",
+                indices=2,
             )
 
     def test_significant_digits(self):
         var_no_precision = OptimizationVariable(
-            'not_rounded_variable',
+            "not_rounded_variable",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='scalar_param',
-            significant_digits=None
+            parameter_path="scalar_param",
+            significant_digits=None,
         )
         var_no_precision.value = 1.1234
         np.testing.assert_equal(var_no_precision.value, 1.1234)
         np.testing.assert_equal(self.evaluation_object.scalar_param, 1.1234)
 
         var_with_precision = OptimizationVariable(
-            'rounded_variable',
+            "rounded_variable",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='scalar_param',
-            significant_digits=2
+            parameter_path="scalar_param",
+            significant_digits=2,
         )
         var_with_precision.value = 1.1234
         np.testing.assert_equal(var_with_precision.value, 1.1)
         np.testing.assert_equal(self.evaluation_object.scalar_param, 1.1)
-
 
     def test_sized_list_single(self):
         """
@@ -192,9 +197,9 @@ class Test_OptimizationVariable(unittest.TestCase):
         """
         # No indices
         var = OptimizationVariable(
-            'sized_list_param_single',
+            "sized_list_param_single",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='sized_list_param_single',
+            parameter_path="sized_list_param_single",
         )
         np.testing.assert_equal(var.indices, [[(slice(None, None, None),)]])
         var.value = 1
@@ -203,12 +208,12 @@ class Test_OptimizationVariable(unittest.TestCase):
 
         # Explicit index
         var = OptimizationVariable(
-            'sized_list_param_single',
+            "sized_list_param_single",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='sized_list_param_single',
+            parameter_path="sized_list_param_single",
             indices=0,
         )
-        np.testing.assert_equal(var.indices, [[(0, )]])
+        np.testing.assert_equal(var.indices, [[(0,)]])
         var.value = 2
         np.testing.assert_equal(var.value, 2)
         np.testing.assert_equal(self.evaluation_object.sized_list_param_single, [2])
@@ -216,18 +221,18 @@ class Test_OptimizationVariable(unittest.TestCase):
         # Raise Exception for exceeding index
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'sized_list_param_single',
+                "sized_list_param_single",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='sized_list_param_single',
+                parameter_path="sized_list_param_single",
                 indices=1,
             )
 
     def test_nd_array(self):
         var = OptimizationVariable(
-            'nd_array_index',
+            "nd_array_index",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='nd_array',
-            indices=(0, 0)
+            parameter_path="nd_array",
+            indices=(0, 0),
         )
         var.value = 1
         np.testing.assert_equal(var.value, 1)
@@ -238,10 +243,10 @@ class Test_OptimizationVariable(unittest.TestCase):
         )
 
         var = OptimizationVariable(
-            'nd_array_slice',
+            "nd_array_slice",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='nd_array',
-            indices=np.s_[:, 0]
+            parameter_path="nd_array",
+            indices=np.s_[:, 0],
         )
         var.value = 2
         np.testing.assert_equal(var.value, 2)
@@ -252,9 +257,9 @@ class Test_OptimizationVariable(unittest.TestCase):
         )
 
         var = OptimizationVariable(
-            'nd_array_all',
+            "nd_array_all",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='nd_array',
+            parameter_path="nd_array",
         )
         var.value = 3
         np.testing.assert_equal(var.value, 3)
@@ -264,10 +269,10 @@ class Test_OptimizationVariable(unittest.TestCase):
 
     def test_polynomial(self):
         var = OptimizationVariable(
-            'polynomial',
+            "polynomial",
             evaluation_objects=self.evaluation_object,
-            parameter_path='polynomial_param',
-            indices=0
+            parameter_path="polynomial_param",
+            indices=0,
         )
 
         var.value = 1
@@ -279,35 +284,35 @@ class Test_OptimizationVariable(unittest.TestCase):
         # Check convenience function; No index should modify constant coefficient and
         # and set rest to 0
         var = OptimizationVariable(
-            'polynomial_convenience_1D',
+            "polynomial_convenience_1D",
             evaluation_objects=self.evaluation_object,
-            parameter_path='polynomial_param',
+            parameter_path="polynomial_param",
         )
         var.value = 1
         np.testing.assert_equal(var.value, 1)
         np.testing.assert_equal(self.evaluation_object.polynomial_param, [1, 0])
 
         var = OptimizationVariable(
-            'polynomial_convenience_ND_all',
+            "polynomial_convenience_ND_all",
             evaluation_objects=self.evaluation_object,
-            parameter_path='nd_polynomial_param',
+            parameter_path="nd_polynomial_param",
         )
         var.value = 1
         np.testing.assert_equal(var.value, 1)
         np.testing.assert_equal(var.indices, [[(slice(None, None, None),)]])
         np.testing.assert_equal(
             var.full_indices,
-            [[(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]]
+            [[(0, 0), (0, 1), (0, 2), (0, 3), (1, 0), (1, 1), (1, 2), (1, 3)]],
         )
         np.testing.assert_equal(
             self.evaluation_object.nd_polynomial_param, [[1, 0, 0, 0], [1, 0, 0, 0]]
         )
 
         var = OptimizationVariable(
-            'polynomial_convenience_ND_single',
+            "polynomial_convenience_ND_single",
             evaluation_objects=self.evaluation_object,
-            parameter_path='nd_polynomial_param',
-            indices=0
+            parameter_path="nd_polynomial_param",
+            indices=0,
         )
         var.value = 2
         np.testing.assert_equal(var.value, 2)
@@ -318,10 +323,10 @@ class Test_OptimizationVariable(unittest.TestCase):
         )
 
         var = OptimizationVariable(
-            'polynomial_convenience_ND_single',
+            "polynomial_convenience_ND_single",
             evaluation_objects=self.evaluation_object,
-            parameter_path='nd_polynomial_param',
-            indices=np.s_[0, :]
+            parameter_path="nd_polynomial_param",
+            indices=np.s_[0, :],
         )
         var.value = 3
         np.testing.assert_equal(var.value, 3)
@@ -333,59 +338,70 @@ class Test_OptimizationVariable(unittest.TestCase):
 
     def test_transform(self):
         var = OptimizationVariable(
-            'scalar_param',
+            "scalar_param",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='scalar_param',
+            parameter_path="scalar_param",
         )
 
         # Missing bounds
         with self.assertRaises(CADETProcessError):
             var = OptimizationVariable(
-                'scalar_param',
+                "scalar_param",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='scalar_param',
-                transform='auto'
+                parameter_path="scalar_param",
+                transform="auto",
             )
 
 
 from tests.test_events import HandlerFixture
+
+
 class Test_OptimizationVariableEvents(unittest.TestCase):
     def setUp(self):
         evaluation_object = HandlerFixture()
 
         evt = evaluation_object.add_event(
-            'single_index_1D', 'performer.array_1d', 1, indices=0, time=1
+            "single_index_1D", "performer.array_1d", 1, indices=0, time=1
         )
         evt = evaluation_object.add_event(
-            'single_index_ND', 'performer.ndarray', 1, indices=(0, 0), time=2
-        )
-
-        evt = evaluation_object.add_event(
-            'multi_index_1D', 'performer.array_1d', [0, 1], indices=[0, 1], time=3
-        )
-        evt = evaluation_object.add_event(
-            'multi_index_ND', 'performer.ndarray',
-            [0, 1], indices=[(0, 0), (0, 1)], time=4
+            "single_index_ND", "performer.ndarray", 1, indices=(0, 0), time=2
         )
 
         evt = evaluation_object.add_event(
-            'nd_evt_state', 'performer.ndarray', [[8, 7, 6, 5], [4, 3, 2, 1]], time=5
+            "multi_index_1D", "performer.array_1d", [0, 1], indices=[0, 1], time=3
+        )
+        evt = evaluation_object.add_event(
+            "multi_index_ND",
+            "performer.ndarray",
+            [0, 1],
+            indices=[(0, 0), (0, 1)],
+            time=4,
         )
 
         evt = evaluation_object.add_event(
-            'array_1d_poly_full', 'performer.array_1d_poly', 1, time=6
-        )
-        evt = evaluation_object.add_event(
-            'array_1d_poly_indices', 'performer.array_1d_poly',
-            [1, 1], indices=[1, 2], time=7
+            "nd_evt_state", "performer.ndarray", [[8, 7, 6, 5], [4, 3, 2, 1]], time=5
         )
 
         evt = evaluation_object.add_event(
-            'ndarray_poly_full', 'performer.ndarray_poly', 1, time=8
+            "array_1d_poly_full", "performer.array_1d_poly", 1, time=6
         )
         evt = evaluation_object.add_event(
-            'ndarray_poly_indices', 'performer.ndarray_poly',
-            [1, 1], indices=[(0, 1), (1, -1)], time=9
+            "array_1d_poly_indices",
+            "performer.array_1d_poly",
+            [1, 1],
+            indices=[1, 2],
+            time=7,
+        )
+
+        evt = evaluation_object.add_event(
+            "ndarray_poly_full", "performer.ndarray_poly", 1, time=8
+        )
+        evt = evaluation_object.add_event(
+            "ndarray_poly_indices",
+            "performer.ndarray_poly",
+            [1, 1],
+            indices=[(0, 1), (1, -1)],
+            time=9,
         )
 
         self.evaluation_object = evaluation_object
@@ -393,9 +409,9 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
     def test_index(self):
         # Single Event.state entry
         var = OptimizationVariable(
-            'single_index_1D',
+            "single_index_1D",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='single_index_1D.state',
+            parameter_path="single_index_1D.state",
         )
         var.value = 2
         np.testing.assert_equal(var.value, 2)
@@ -404,37 +420,38 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'event_state_not_sized',
+                "event_state_not_sized",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='single_index_1D.state',
-                indices=1
+                parameter_path="single_index_1D.state",
+                indices=1,
             )
 
         var = OptimizationVariable(
-            'single_index_ND',
+            "single_index_ND",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='single_index_ND.state',
+            parameter_path="single_index_ND.state",
         )
         var.value = 2
         np.testing.assert_equal(var.value, 2)
         np.testing.assert_equal(self.evaluation_object.single_index_ND.state, 2)
         np.testing.assert_equal(
-            self.evaluation_object.performer.ndarray, [[2, 7, 6, 5], [4, 3, 2, 1]])
+            self.evaluation_object.performer.ndarray, [[2, 7, 6, 5], [4, 3, 2, 1]]
+        )
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'event_state_not_sized',
+                "event_state_not_sized",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='single_index_ND.state',
-                indices=1
+                parameter_path="single_index_ND.state",
+                indices=1,
             )
 
         # 1D Event.state with multiple entries
         var = OptimizationVariable(
-            'multi_index_1D',
+            "multi_index_1D",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='multi_index_1D.state',
-            indices=0
+            parameter_path="multi_index_1D.state",
+            indices=0,
         )
         var.value = 3
         np.testing.assert_equal(var.value, 3)
@@ -443,17 +460,17 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'index_exceeds_parameter',
+                "index_exceeds_parameter",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='multi_index_1D.state',
-                indices=2
+                parameter_path="multi_index_1D.state",
+                indices=2,
             )
         # ND Event.state with multiple entries (in 1D)
         var = OptimizationVariable(
-            'multi_index_ND',
+            "multi_index_ND",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='multi_index_ND.state',
-            indices=0
+            parameter_path="multi_index_ND.state",
+            indices=0,
         )
         var.value = 4
         np.testing.assert_equal(var.value, 4)
@@ -464,26 +481,26 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'index_exceeds_parameter',
+                "index_exceeds_parameter",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='multi_index_ND.state',
-                indices=2
+                parameter_path="multi_index_ND.state",
+                indices=2,
             )
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'index_exceeds_parameter_dimension',
+                "index_exceeds_parameter_dimension",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='multi_index_ND.state',
-                indices=(1, 1)
+                parameter_path="multi_index_ND.state",
+                indices=(1, 1),
             )
 
         # ND Event.state with multiple entries in ND
         var = OptimizationVariable(
-            'nd_evt_state',
+            "nd_evt_state",
             evaluation_objects=[self.evaluation_object],
-            parameter_path='nd_evt_state.state',
-            indices=(0, 0)
+            parameter_path="nd_evt_state.state",
+            indices=(0, 0),
         )
         var.value = 5
         np.testing.assert_equal(var.value, 5)
@@ -496,35 +513,33 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'index_exceeds_parameter',
+                "index_exceeds_parameter",
                 evaluation_objects=[self.evaluation_object],
-                parameter_path='nd_evt_state.state',
-                indices=(2, 2)
+                parameter_path="nd_evt_state.state",
+                indices=(2, 2),
             )
 
     def test_polynomial(self):
         # Event state modifies entire 1D polyomial coefficients using `fill_values`
         var = OptimizationVariable(
-            'array_1d_poly_full',
+            "array_1d_poly_full",
             evaluation_objects=self.evaluation_object,
-            parameter_path='array_1d_poly_full.state',
+            parameter_path="array_1d_poly_full.state",
         )
 
         var.value = 2
         np.testing.assert_equal(var.value, 2)
-        np.testing.assert_equal(
-            self.evaluation_object.array_1d_poly_full.state, 2
-        )
+        np.testing.assert_equal(self.evaluation_object.array_1d_poly_full.state, 2)
         np.testing.assert_equal(
             self.evaluation_object.performer.array_1d_poly, [2, 0, 0, 0]
         )
 
         # Event state modifies individual 1D polyomial coefficients
         var = OptimizationVariable(
-            'array_1d_poly_indices',
+            "array_1d_poly_indices",
             evaluation_objects=self.evaluation_object,
-            parameter_path='array_1d_poly_indices.state',
-            indices=0
+            parameter_path="array_1d_poly_indices.state",
+            indices=0,
         )
 
         var.value = 2
@@ -545,26 +560,24 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
 
         # Event state modifies entire ND polyomial coefficients using `fill_values`
         var = OptimizationVariable(
-            'ndarray_poly_full',
+            "ndarray_poly_full",
             evaluation_objects=self.evaluation_object,
-            parameter_path='ndarray_poly_full.state',
+            parameter_path="ndarray_poly_full.state",
         )
 
         var.value = 2
         np.testing.assert_equal(var.value, 2)
-        np.testing.assert_equal(
-            self.evaluation_object.ndarray_poly_full.state, 2
-        )
+        np.testing.assert_equal(self.evaluation_object.ndarray_poly_full.state, 2)
         np.testing.assert_equal(
             self.evaluation_object.performer.ndarray_poly, [[2, 0, 0, 0], [2, 0, 0, 0]]
         )
 
         # Event state modifies individual 1D polyomial coefficients
         var = OptimizationVariable(
-            'ndarray_poly_indices',
+            "ndarray_poly_indices",
             evaluation_objects=self.evaluation_object,
-            parameter_path='ndarray_poly_indices.state',
-            indices=0
+            parameter_path="ndarray_poly_indices.state",
+            indices=0,
         )
 
         var.value = 2
@@ -588,24 +601,28 @@ class Test_OptimizationVariableEvents(unittest.TestCase):
         evaluation_object_2 = HandlerFixture()
 
         evt = evaluation_object_2.add_event(
-            'multi_index_ND', 'performer.ndarray',
-            [0, 1, 2], indices=[(0, 0), (0, 1), (1, 1)], time=0
+            "multi_index_ND",
+            "performer.ndarray",
+            [0, 1, 2],
+            indices=[(0, 0), (0, 1), (1, 1)],
+            time=0,
         )
 
         var = OptimizationVariable(
-            'multi_index_ND',
+            "multi_index_ND",
             evaluation_objects=[self.evaluation_object, evaluation_object_2],
-            parameter_path='multi_index_ND.state',
-            indices=0
+            parameter_path="multi_index_ND.state",
+            indices=0,
         )
 
         with self.assertRaises(IndexError):
             var = OptimizationVariable(
-                'index_exceeds_one_eval_obj_state',
+                "index_exceeds_one_eval_obj_state",
                 evaluation_objects=[self.evaluation_object, evaluation_object_2],
-                parameter_path='multi_index_ND.state',
-                indices=2
+                parameter_path="multi_index_ND.state",
+                indices=2,
             )
+
 
 def setup_dummy_eval_fun(n_metrics, rng=None):
     if rng is None:
@@ -622,11 +639,20 @@ def dummy_meta_score(f):
 
 
 def setup_optimization_problem(
-        n_vars=2, n_obj=1, n_lincon=0, n_lineqcon=0, n_nonlincon=0, n_meta=0,
-        bounds=None, obj_fun=None, nonlincon_fun=None, lincons=None, lineqcons=None,
-        use_diskcache=False,
-        ):
-    optimization_problem = OptimizationProblem('simple', use_diskcache=use_diskcache)
+    n_vars=2,
+    n_obj=1,
+    n_lincon=0,
+    n_lineqcon=0,
+    n_nonlincon=0,
+    n_meta=0,
+    bounds=None,
+    obj_fun=None,
+    nonlincon_fun=None,
+    lincons=None,
+    lineqcons=None,
+    use_diskcache=False,
+):
+    optimization_problem = OptimizationProblem("simple", use_diskcache=use_diskcache)
 
     for i_var in range(n_vars):
         if bounds is None:
@@ -634,15 +660,12 @@ def setup_optimization_problem(
         else:
             lb, ub = bounds[i_var]
 
-        optimization_problem.add_variable(
-            f'var_{i_var}',
-            lb=lb, ub=ub
-        )
+        optimization_problem.add_variable(f"var_{i_var}", lb=lb, ub=ub)
 
     if n_lincon > 0:
         if lincons is None:
             lincons = [
-                ([f'var_{i_var}', f'var_{i_var+1}'], [1, -1], 0)
+                ([f"var_{i_var}", f"var_{i_var + 1}"], [1, -1], 0)
                 for i_var in range(n_lincon)
             ]
         for opt_vars, lhs, b in lincons:
@@ -651,7 +674,7 @@ def setup_optimization_problem(
     if n_lineqcon > 0:
         if lineqcons is None:
             lineqcons = [
-                ([f'var_{i_var}', f'var_{i_var+1}'], [1, -1], 0)
+                ([f"var_{i_var}", f"var_{i_var + 1}"], [1, -1], 0)
                 for i_var in range(n_lineqcon)
             ]
         for opt_vars, lhs, beq in lineqcons:
@@ -661,20 +684,18 @@ def setup_optimization_problem(
         obj_fun = setup_dummy_eval_fun(n_obj)
 
     optimization_problem.add_objective(
-        obj_fun,
-        n_objectives=n_obj,
-        labels=[f'f_{i}' for i in range(n_obj)]
+        obj_fun, n_objectives=n_obj, labels=[f"f_{i}" for i in range(n_obj)]
     )
 
     if n_nonlincon > 0:
         if nonlincon_fun is None:
             nonlincon_fun = setup_dummy_eval_fun(n_nonlincon)
         optimization_problem.add_nonlinear_constraint(
-            nonlincon_fun, n_nonlinear_constraints=n_nonlincon,
-            labels=[f'g_{i}' for i in range(n_nonlincon)],
-            bounds=0.5
+            nonlincon_fun,
+            n_nonlinear_constraints=n_nonlincon,
+            labels=[f"g_{i}" for i in range(n_nonlincon)],
+            bounds=0.5,
         )
-
 
     if n_meta > 0:
         optimization_problem.add_meta_score(dummy_meta_score)
@@ -684,25 +705,25 @@ def setup_optimization_problem(
 
 class Test_OptimizationProblemSimple(unittest.TestCase):
     def setUp(self):
-        optimization_problem = OptimizationProblem('simple', use_diskcache=False)
+        optimization_problem = OptimizationProblem("simple", use_diskcache=False)
 
-        optimization_problem.add_variable('var_0', lb=0, ub=1)
-        optimization_problem.add_variable('var_1', lb=0, ub=10)
+        optimization_problem.add_variable("var_0", lb=0, ub=1)
+        optimization_problem.add_variable("var_1", lb=0, ub=10)
 
         self.optimization_problem = optimization_problem
 
     def tearDown(self):
-        shutil.rmtree('./results_simple', ignore_errors=True)
+        shutil.rmtree("./results_simple", ignore_errors=True)
         settings.working_directory = None
 
     def test_variable_names(self):
-        names_expected = ['var_0', 'var_1']
+        names_expected = ["var_0", "var_1"]
         names = self.optimization_problem.variable_names
         self.assertEqual(names_expected, names)
 
         # Variable already exists
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_variable('var_0')
+            self.optimization_problem.add_variable("var_0")
 
     def test_bounds(self):
         lb_expected = [0, 0]
@@ -715,7 +736,7 @@ class Test_OptimizationProblemSimple(unittest.TestCase):
 
         # lb >= ub
         with self.assertRaises(ValueError):
-            self.optimization_problem.add_variable('spam', lb=0, ub=0)
+            self.optimization_problem.add_variable("spam", lb=0, ub=0)
 
 
 class Test_OptimizationProblemLinCon(unittest.TestCase):
@@ -727,23 +748,23 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         self.optimization_problem = optimization_problem
 
     def test_add_linear_constraints(self):
-        self.optimization_problem.add_linear_constraint('var_0')
-        self.optimization_problem.add_linear_constraint(['var_0', 'var_1'])
+        self.optimization_problem.add_linear_constraint("var_0")
+        self.optimization_problem.add_linear_constraint(["var_0", "var_1"])
 
-        self.optimization_problem.add_linear_constraint(['var_0', 'var_1'], [2, 2])
-        self.optimization_problem.add_linear_constraint(
-            ['var_0', 'var_1'], [3, 3], 1
+        self.optimization_problem.add_linear_constraint(["var_0", "var_1"], [2, 2])
+        self.optimization_problem.add_linear_constraint(["var_0", "var_1"], [3, 3], 1)
+        self.optimization_problem.add_linear_constraint(["var_0", "var_1"], 4)
+
+        A_expected = np.array(
+            [
+                [1.0, -1.0],
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+                [3.0, 3.0],
+                [4.0, 4.0],
+            ]
         )
-        self.optimization_problem.add_linear_constraint(['var_0', 'var_1'], 4)
-
-        A_expected = np.array([
-            [1., -1.],
-            [1., 0.],
-            [1., 1.],
-            [2., 2.],
-            [3., 3.],
-            [4., 4.],
-        ])
 
         A = self.optimization_problem.A
         np.testing.assert_almost_equal(A, A_expected)
@@ -754,31 +775,33 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
 
         # Variable does not exist
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_linear_constraint('inexistent')
+            self.optimization_problem.add_linear_constraint("inexistent")
 
         # Incorrect shape
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_linear_constraint('var_0', [])
+            self.optimization_problem.add_linear_constraint("var_0", [])
 
     def test_add_linear_equality_constraints(self):
-        self.optimization_problem.add_linear_equality_constraint('var_0')
-        self.optimization_problem.add_linear_equality_constraint(['var_0', 'var_1'])
+        self.optimization_problem.add_linear_equality_constraint("var_0")
+        self.optimization_problem.add_linear_equality_constraint(["var_0", "var_1"])
 
         self.optimization_problem.add_linear_equality_constraint(
-            ['var_0', 'var_1'], [2, 2]
+            ["var_0", "var_1"], [2, 2]
         )
         self.optimization_problem.add_linear_equality_constraint(
-            ['var_0', 'var_1'], [3, 3], 1
+            ["var_0", "var_1"], [3, 3], 1
         )
-        self.optimization_problem.add_linear_equality_constraint(['var_0', 'var_1'], 4)
+        self.optimization_problem.add_linear_equality_constraint(["var_0", "var_1"], 4)
 
-        Aeq_expected = np.array([
-            [1., 0.],
-            [1., 1.],
-            [2., 2.],
-            [3., 3.],
-            [4., 4.],
-        ])
+        Aeq_expected = np.array(
+            [
+                [1.0, 0.0],
+                [1.0, 1.0],
+                [2.0, 2.0],
+                [3.0, 3.0],
+                [4.0, 4.0],
+            ]
+        )
 
         Aeq = self.optimization_problem.Aeq
         np.testing.assert_almost_equal(Aeq, Aeq_expected)
@@ -789,11 +812,11 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
 
         # Variable does not exist
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_linear_equality_constraint('inexistent')
+            self.optimization_problem.add_linear_equality_constraint("inexistent")
 
         # Incorrect shape
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_linear_equality_constraint('var_0', [])
+            self.optimization_problem.add_linear_equality_constraint("var_0", [])
 
     def test_initial_values(self):
         x0_chebyshev_expected = [0.29289322, 0.70710678]
@@ -803,9 +826,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
 
         x0_seed_1_expected = [[0.3448127, 0.9138096]]
-        x0_seed_1 = self.optimization_problem.create_initial_values(
-            1, seed=1
-        )
+        x0_seed_1 = self.optimization_problem.create_initial_values(1, seed=1)
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(1)
@@ -818,19 +839,17 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
 
         x0_seed_10_expected = [
             [0.34481272, 0.91380963],
-            [0.13935918, 0.7377129 ],
-            [0.5219434 , 0.63404393],
-            [0.23933603, 0.8127269 ],
-            [0.30483107, 0.980534  ],
+            [0.13935918, 0.7377129],
+            [0.5219434, 0.63404393],
+            [0.23933603, 0.8127269],
+            [0.30483107, 0.980534],
             [0.11605111, 0.86206301],
-            [0.1869498 , 0.99896377],
+            [0.1869498, 0.99896377],
             [0.55986142, 0.65237364],
             [0.49963092, 0.98791549],
-            [0.6839696 , 0.92668444]
+            [0.6839696, 0.92668444],
         ]
-        x0_seed_10 = self.optimization_problem.create_initial_values(
-            10, seed=1
-        )
+        x0_seed_10 = self.optimization_problem.create_initial_values(10, seed=1)
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(10)
@@ -841,26 +860,26 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
 
 class Test_OptimizationProblemDepVar(unittest.TestCase):
     def setUp(self):
-        optimization_problem = OptimizationProblem('simple', use_diskcache=False)
+        optimization_problem = OptimizationProblem("simple", use_diskcache=False)
 
-        optimization_problem.add_variable('foo', lb=0, ub=1)
-        optimization_problem.add_variable('bar', lb=0, ub=1)
-        optimization_problem.add_variable('spam', lb=0, ub=1)
-        optimization_problem.add_variable('eggs', lb=0, ub=1)
+        optimization_problem.add_variable("foo", lb=0, ub=1)
+        optimization_problem.add_variable("bar", lb=0, ub=1)
+        optimization_problem.add_variable("spam", lb=0, ub=1)
+        optimization_problem.add_variable("eggs", lb=0, ub=1)
 
-        optimization_problem.add_linear_constraint(['foo', 'spam'], [-1, 1])
-        optimization_problem.add_linear_constraint(['foo', 'eggs'], [-1, 1])
-        optimization_problem.add_linear_constraint(['eggs', 'spam'], [-1, 1])
+        optimization_problem.add_linear_constraint(["foo", "spam"], [-1, 1])
+        optimization_problem.add_linear_constraint(["foo", "eggs"], [-1, 1])
+        optimization_problem.add_linear_constraint(["eggs", "spam"], [-1, 1])
 
         def copy_var(var):
             return var
 
-        optimization_problem.add_variable_dependency('spam', 'bar', copy_var)
+        optimization_problem.add_variable_dependency("spam", "bar", copy_var)
 
         self.optimization_problem = optimization_problem
 
     def test_dependencies(self):
-        independent_variables_expected = ['foo', 'bar', 'eggs']
+        independent_variables_expected = ["foo", "bar", "eggs"]
         independent_variables = self.optimization_problem.independent_variable_names
         self.assertEqual(independent_variables_expected, independent_variables)
 
@@ -870,35 +889,35 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         # Variable does not exist
         with self.assertRaises(CADETProcessError):
             self.optimization_problem.add_variable_dependency(
-                'inexistent', ['bar', 'spam'], transform
+                "inexistent", ["bar", "spam"], transform
             )
 
         # Dependent Variable does not exist
         with self.assertRaises(CADETProcessError):
             self.optimization_problem.add_variable_dependency(
-                'foo', ['inexistent', 'spam'], transform
+                "foo", ["inexistent", "spam"], transform
             )
 
         # Variable is already dependent
         with self.assertRaises(CADETProcessError):
             self.optimization_problem.add_variable_dependency(
-                'spam', ['bar', 'spam'], transform
+                "spam", ["bar", "spam"], transform
             )
 
         # Transform is not callable
         with self.assertRaises(CADETProcessError):
             self.optimization_problem.add_variable_dependency(
-                'spam', ['bar', 'spam'], transform=None
+                "spam", ["bar", "spam"], transform=None
             )
 
         independent_variables = self.optimization_problem.independent_variable_names
         self.assertEqual(independent_variables_expected, independent_variables)
 
-        dependent_variables_expected = ['spam']
+        dependent_variables_expected = ["spam"]
         dependent_variables = self.optimization_problem.dependent_variable_names
         self.assertEqual(dependent_variables_expected, dependent_variables)
 
-        variables_expected = ['foo', 'bar', 'spam', 'eggs']
+        variables_expected = ["foo", "bar", "spam", "eggs"]
         variables = self.optimization_problem.variable_names
         self.assertEqual(variables_expected, variables)
 
@@ -913,7 +932,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         variables = self.optimization_problem.get_dependent_values(x0_chebyshev)
         np.testing.assert_almost_equal(variables, variables_expected)
 
-        x0_seed_1_expected = [[0.8324936, 0.279713 , 0.6649623]]
+        x0_seed_1_expected = [[0.8324936, 0.279713, 0.6649623]]
         x0_seed_1 = self.optimization_problem.create_initial_values(
             1, seed=1, include_dependent_variables=False
         )
@@ -935,16 +954,16 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
             np.testing.assert_almost_equal(x0_seed_1_random, x0_chebyshev_expected)
 
         x0_seed_10_expected = [
-            [0.8324936 , 0.27971297, 0.66496231],
-            [0.73128644, 0.17275154, 0.5115499 ],
+            [0.8324936, 0.27971297, 0.66496231],
+            [0.73128644, 0.17275154, 0.5115499],
             [0.95771264, 0.19106333, 0.79216119],
-            [0.81089326, 0.29062957, 0.6673637 ],
+            [0.81089326, 0.29062957, 0.6673637],
             [0.76359474, 0.20575487, 0.59221373],
-            [0.9596961 , 0.6718687 , 0.90182574],
+            [0.9596961, 0.6718687, 0.90182574],
             [0.89945427, 0.01653708, 0.49987409],
-            [0.92682306, 0.07106034, 0.8258856 ],
-            [0.77868893, 0.4824452 , 0.77038195],
-            [0.59375802, 0.03129941, 0.22275326]
+            [0.92682306, 0.07106034, 0.8258856],
+            [0.77868893, 0.4824452, 0.77038195],
+            [0.59375802, 0.03129941, 0.22275326],
         ]
         x0_seed_10 = self.optimization_problem.create_initial_values(
             10, seed=1, include_dependent_variables=False
@@ -966,15 +985,21 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         np.testing.assert_almost_equal(x0_chebyshev, x0_chebyshev_expected)
 
         independent_variables_expected = [0.70710678, 0.29289322, 0.29289322]
-        independent_variables = self.optimization_problem.get_independent_values(x0_chebyshev)
-        np.testing.assert_almost_equal(independent_variables, independent_variables_expected)
+        independent_variables = self.optimization_problem.get_independent_values(
+            x0_chebyshev
+        )
+        np.testing.assert_almost_equal(
+            independent_variables, independent_variables_expected
+        )
 
-        x0_seed_1_expected = [[0.8324936, 0.279713 , 0.279713 , 0.6649623]]
+        x0_seed_1_expected = [[0.8324936, 0.279713, 0.279713, 0.6649623]]
         x0_seed_1 = self.optimization_problem.create_initial_values(
             1, seed=1, include_dependent_variables=True
         )
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
-        self.assertTrue(self.optimization_problem.check_linear_constraints(x0_seed_1[0]))
+        self.assertTrue(
+            self.optimization_problem.check_linear_constraints(x0_seed_1[0])
+        )
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(
             1, include_dependent_variables=True
@@ -987,16 +1012,16 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
             np.testing.assert_almost_equal(x0_seed_1_random, x0_chebyshev_expected)
 
         x0_seed_10_expected = [
-            [0.8324936 , 0.27971297, 0.27971297, 0.66496231],
-            [0.73128644, 0.17275154, 0.17275154, 0.5115499 ],
+            [0.8324936, 0.27971297, 0.27971297, 0.66496231],
+            [0.73128644, 0.17275154, 0.17275154, 0.5115499],
             [0.95771264, 0.19106333, 0.19106333, 0.79216119],
-            [0.81089326, 0.29062957, 0.29062957, 0.6673637 ],
+            [0.81089326, 0.29062957, 0.29062957, 0.6673637],
             [0.76359474, 0.20575487, 0.20575487, 0.59221373],
-            [0.9596961 , 0.6718687 , 0.6718687 , 0.90182574],
+            [0.9596961, 0.6718687, 0.6718687, 0.90182574],
             [0.89945427, 0.01653708, 0.01653708, 0.49987409],
-            [0.92682306, 0.07106034, 0.07106034, 0.8258856 ],
-            [0.77868893, 0.4824452 , 0.4824452 , 0.77038195],
-            [0.59375802, 0.03129941, 0.03129941, 0.22275326]
+            [0.92682306, 0.07106034, 0.07106034, 0.8258856],
+            [0.77868893, 0.4824452, 0.4824452, 0.77038195],
+            [0.59375802, 0.03129941, 0.03129941, 0.22275326],
         ]
         x0_seed_10 = self.optimization_problem.create_initial_values(
             10, seed=1, include_dependent_variables=True
@@ -1014,40 +1039,40 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
 class Test_OptimizationProblemJacobian(unittest.TestCase):
     def setUp(self):
         def single_obj_single_var(x):
-            return x[0]**2
+            return x[0] ** 2
 
-        name = 'single_obj_single_var'
+        name = "single_obj_single_var"
         optimization_problem = OptimizationProblem(name, use_diskcache=False)
-        optimization_problem.add_variable('x')
+        optimization_problem.add_variable("x")
         optimization_problem.add_objective(single_obj_single_var)
         self.single_obj_single_var = optimization_problem
 
         def single_obj_two_vars(x):
-            return x[1]**2 - x[0]**2
+            return x[1] ** 2 - x[0] ** 2
 
-        name = 'single_obj_two_vars'
+        name = "single_obj_two_vars"
         optimization_problem = OptimizationProblem(name, use_diskcache=False)
-        optimization_problem.add_variable('x_1')
-        optimization_problem.add_variable('x_2')
+        optimization_problem.add_variable("x_1")
+        optimization_problem.add_variable("x_2")
         optimization_problem.add_objective(single_obj_two_vars)
         self.single_obj_two_vars = optimization_problem
 
         def two_obj_single_var(x):
-            return [x[0]**2, x[0]**2]
+            return [x[0] ** 2, x[0] ** 2]
 
-        name = 'two_obj_single_var'
+        name = "two_obj_single_var"
         optimization_problem = OptimizationProblem(name, use_diskcache=False)
-        optimization_problem.add_variable('x')
+        optimization_problem.add_variable("x")
         optimization_problem.add_objective(two_obj_single_var, n_objectives=2)
         self.two_obj_single_var = optimization_problem
 
         def two_obj_two_var(x):
-            return [x[0]**2, x[1]**2]
+            return [x[0] ** 2, x[1] ** 2]
 
-        name = 'two_obj_two_var'
+        name = "two_obj_two_var"
         optimization_problem = OptimizationProblem(name, use_diskcache=False)
-        optimization_problem.add_variable('x_1')
-        optimization_problem.add_variable('x_2')
+        optimization_problem.add_variable("x_1")
+        optimization_problem.add_variable("x_2")
         optimization_problem.add_objective(two_obj_two_var, n_objectives=2)
         self.two_obj_two_var = optimization_problem
 
@@ -1076,17 +1101,11 @@ class Test_OptimizationProblemJacobian(unittest.TestCase):
         jac = self.two_obj_single_var.objective_jacobian([0])
         np.testing.assert_almost_equal(jac, jac_expected)
 
-        jac_expected = [
-            [4.001, 0],
-            [0, 4.001]
-        ]
+        jac_expected = [[4.001, 0], [0, 4.001]]
         jac = self.two_obj_two_var.objective_jacobian([2, 2])
         np.testing.assert_almost_equal(jac, jac_expected)
 
-        jac_expected = [
-            [0.001, 0],
-            [0, 0.001]
-        ]
+        jac_expected = [[0.001, 0], [0, 0.001]]
         jac = self.two_obj_two_var.objective_jacobian([0, 0])
         np.testing.assert_almost_equal(jac, jac_expected)
 
@@ -1097,11 +1116,12 @@ class Test_OptimizationProblemConstraintTransforms(unittest.TestCase):
     tests if `A_transformed` and `b_transformed` properties are correctly
     computed.
     """
+
     def setup(self):
-        settings.working_directory = './test_problem'
+        settings.working_directory = "./test_problem"
 
     def tearDown(self):
-        shutil.rmtree('./test_problem', ignore_errors=True)
+        shutil.rmtree("./test_problem", ignore_errors=True)
         settings.working_directory = None
 
     @staticmethod
@@ -1157,11 +1177,7 @@ class Test_OptimizationProblemConstraintTransforms(unittest.TestCase):
         rng = np.random.default_rng(seed=72729)
         X = rng.uniform(0, 1, size=(100000, nvars))
 
-        CV = check_constraint_func(
-            X=X,
-            problem=problem,
-            transformed_space=True
-        )
+        CV = check_constraint_func(X=X, problem=problem, transformed_space=True)
 
         # extract valid X and untransform then check constraints in
         # untransformed space
@@ -1169,9 +1185,7 @@ class Test_OptimizationProblemConstraintTransforms(unittest.TestCase):
         X_valid = problem.untransform(X_valid)
 
         CV_test_valid = check_constraint_func(
-            X=X_valid,
-            problem=problem,
-            transformed_space=False
+            X=X_valid, problem=problem, transformed_space=False
         )
 
         # extract invalid X and untransform, then check constraints in
@@ -1180,9 +1194,7 @@ class Test_OptimizationProblemConstraintTransforms(unittest.TestCase):
         X_invalid = problem.untransform(X_invalid)
 
         CV_test_invalid = check_constraint_func(
-            X=X_invalid,
-            problem=problem,
-            transformed_space=False
+            X=X_invalid, problem=problem, transformed_space=False
         )
 
         # tests if all valid X remain valid in untransformed space
@@ -1197,9 +1209,7 @@ class Test_OptimizationProblemConstraintTransforms(unittest.TestCase):
             use_diskcache=False,
         )
 
-        self.check_constraint_transform(
-            problem, self.check_inequality_constraints
-        )
+        self.check_constraint_transform(problem, self.check_inequality_constraints)
 
     def test_linear_equality_constrained_transform(self):
         problem = LinearEqualityConstraintsSooTestProblem(
@@ -1207,9 +1217,7 @@ class Test_OptimizationProblemConstraintTransforms(unittest.TestCase):
             use_diskcache=False,
         )
 
-        self.check_constraint_transform(
-            problem, self.check_equality_constraints
-        )
+        self.check_constraint_transform(problem, self.check_equality_constraints)
 
 
 class Test_OptimizationProblemEvaluator(unittest.TestCase):
@@ -1233,13 +1241,13 @@ class Test_OptimizationProblemEvaluator(unittest.TestCase):
 
         # Simple case
         optimization_problem = OptimizationProblem(
-            'with_evaluator', use_diskcache=False
+            "with_evaluator", use_diskcache=False
         )
 
         optimization_problem.add_evaluation_object(eval_obj)
 
-        optimization_problem.add_variable('scalar_param')
-        optimization_problem.add_variable('sized_list_param', lb=0, ub=10, indices=0)
+        optimization_problem.add_variable("scalar_param")
+        optimization_problem.add_variable("sized_list_param", lb=0, ub=10, indices=0)
 
         self.optimization_problem = optimization_problem
 
@@ -1247,23 +1255,23 @@ class Test_OptimizationProblemEvaluator(unittest.TestCase):
             return var
 
         optimization_problem.add_variable_dependency(
-            'sized_list_param', 'scalar_param', copy_var
+            "sized_list_param", "scalar_param", copy_var
         )
 
     def test_variable_names(self):
-        names_expected = ['scalar_param', 'sized_list_param']
+        names_expected = ["scalar_param", "sized_list_param"]
         names = self.optimization_problem.variable_names
         self.assertEqual(names_expected, names)
 
         # Variable does not exist in Evaluator
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_variable('bar', lb=0, ub=1)
+            self.optimization_problem.add_variable("bar", lb=0, ub=1)
 
         # Check that adding dummy variables still works
         self.optimization_problem.add_variable(
-            'bar', evaluation_objects=None, lb=0, ub=1
+            "bar", evaluation_objects=None, lb=0, ub=1
         )
-        names_expected = ['scalar_param', 'sized_list_param', 'bar']
+        names_expected = ["scalar_param", "sized_list_param", "bar"]
         names = self.optimization_problem.variable_names
         self.assertEqual(names_expected, names)
 
@@ -1277,27 +1285,34 @@ class Test_OptimizationProblemEvaluator(unittest.TestCase):
         self.optimization_problem.check_duplicate_variables()
 
         # Duplicate name
-        self.optimization_problem.add_variable('foo', evaluation_objects=None)
+        self.optimization_problem.add_variable("foo", evaluation_objects=None)
 
         with self.assertRaises(CADETProcessError):
-            self.optimization_problem.add_variable('foo', evaluation_objects=None)
+            self.optimization_problem.add_variable("foo", evaluation_objects=None)
 
         # Duplicate scalar parameter variable
         with self.assertRaises(CADETProcessError):
             self.optimization_problem.add_variable(
-                name='another_scalar_parameter', parameter_path='scalar_param',
+                name="another_scalar_parameter",
+                parameter_path="scalar_param",
             )
 
         # Duplicate index parameter variable
         self.optimization_problem.add_variable(
-            name='another_sized_list_param_var', parameter_path='sized_list_param',
-            lb=0, ub=10, indices=1
+            name="another_sized_list_param_var",
+            parameter_path="sized_list_param",
+            lb=0,
+            ub=10,
+            indices=1,
         )
 
         with self.assertRaises(CADETProcessError):
             self.optimization_problem.add_variable(
-                name='yet_another_sized_list_param_var', parameter_path='sized_list_param',
-                lb=0, ub=10, indices=1
+                name="yet_another_sized_list_param_var",
+                parameter_path="sized_list_param",
+                lb=0,
+                ub=10,
+                indices=1,
             )
 
     def test_cache(self):
@@ -1306,48 +1321,53 @@ class Test_OptimizationProblemEvaluator(unittest.TestCase):
 
 class Test_MultiEvaluationObjects(unittest.TestCase):
     def setUp(self):
-        eval_obj_1 = EvaluationObject(name='foo')
-        eval_obj_2 = EvaluationObject(name='bar')
+        eval_obj_1 = EvaluationObject(name="foo")
+        eval_obj_2 = EvaluationObject(name="bar")
 
         # Simple case
         optimization_problem = OptimizationProblem(
-            'with_evaluator', use_diskcache=False
+            "with_evaluator", use_diskcache=False
         )
 
         optimization_problem.add_evaluation_object(eval_obj_1)
         optimization_problem.add_evaluation_object(eval_obj_2)
 
         optimization_problem.add_variable(
-            name='scalar_eval_obj_1', parameter_path='scalar_param', lb=0, ub=1,
-            evaluation_objects=[eval_obj_1]
+            name="scalar_eval_obj_1",
+            parameter_path="scalar_param",
+            lb=0,
+            ub=1,
+            evaluation_objects=[eval_obj_1],
         )
         optimization_problem.add_variable(
-            name='scalar_eval_obj_2', parameter_path='scalar_param', lb=0, ub=1,
-            evaluation_objects=[eval_obj_2]
+            name="scalar_eval_obj_2",
+            parameter_path="scalar_param",
+            lb=0,
+            ub=1,
+            evaluation_objects=[eval_obj_2],
         )
 
         optimization_problem.add_variable(
-            name='scalar_both_eval_obj', parameter_path='scalar_param_2', lb=0, ub=1,
+            name="scalar_both_eval_obj",
+            parameter_path="scalar_param_2",
+            lb=0,
+            ub=1,
         )
-
 
         def single_obj_1(eval_obj):
             return 0
 
         optimization_problem.add_objective(single_obj_1)
 
-
         def single_obj_2(eval_obj):
             return 1
 
         optimization_problem.add_objective(single_obj_2, evaluation_objects=eval_obj_1)
 
-
         def multi_obj(eval_obj):
             return [2, 3]
 
         optimization_problem.add_objective(multi_obj, n_objectives=2)
-
 
         self.optimization_problem = optimization_problem
 
@@ -1362,23 +1382,23 @@ class Test_MultiEvaluationObjects(unittest.TestCase):
         np.testing.assert_allclose(f, f_expected)
 
     def test_names(self):
-        names_expected = ['single_obj_1', 'single_obj_2', 'multi_obj']
+        names_expected = ["single_obj_1", "single_obj_2", "multi_obj"]
         names = self.optimization_problem.objective_names
         self.assertEqual(names, names_expected)
 
     def test_labels(self):
         labels_expected = [
-            'foo_single_obj_1',
-            'bar_single_obj_1',
-            'single_obj_2',
-            'foo_multi_obj_0',
-            'bar_multi_obj_0',
-            'foo_multi_obj_1',
-            'bar_multi_obj_1'
+            "foo_single_obj_1",
+            "bar_single_obj_1",
+            "single_obj_2",
+            "foo_multi_obj_0",
+            "bar_multi_obj_0",
+            "foo_multi_obj_1",
+            "bar_multi_obj_1",
         ]
         labels = self.optimization_problem.objective_labels
         self.assertEqual(labels, labels_expected)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimization_results.py
+++ b/tests/test_optimization_results.py
@@ -2,22 +2,22 @@ import shutil
 import unittest
 from pathlib import Path
 
-from addict import Dict
 import numpy as np
+from addict import Dict
+from CADETProcess.optimization import U_NSGA3, OptimizationResults
 
-from CADETProcess.optimization import OptimizationResults
-from CADETProcess.optimization import U_NSGA3
-
-from tests.test_population import setup_population
 from tests.test_optimization_problem import setup_optimization_problem
+from tests.test_population import setup_population
 
 
 class OptimizationResultsWithoutNans(OptimizationResults):
     """
-    Patch class that removes None values in the OptimizationResults during .to_dict() call. This allows
-    serialization with any version of CADET-Python pending the merge of https://github.com/cadet/CADET-Python/pull/48
+    Patch class that removes None values in the OptimizationResults during .to_dict() call.
+    This allows serialization with any version of CADET-Python pending the merge of
+    https://github.com/cadet/CADET-Python/pull/48
 
     """
+
     def to_dict(self) -> dict:
         """Convert Results to a dictionary.
 
@@ -73,14 +73,22 @@ class OptimizationResultsWithoutNans(OptimizationResults):
         return dictionary
 
 
-
 def setup_optimization_problem_and_results(
-        n_gen=3, n_ind=3, n_vars=2, n_obj=1, n_nonlin=0, n_meta=0, rng=None,
-        initialize_data=True):
+    n_gen=3,
+    n_ind=3,
+    n_vars=2,
+    n_obj=1,
+    n_nonlin=0,
+    n_meta=0,
+    rng=None,
+    initialize_data=True,
+):
     optimization_problem = setup_optimization_problem(n_vars, n_obj, n_nonlin, n_meta)
     optimizer = U_NSGA3()
 
-    optimization_results = OptimizationResultsWithoutNans(optimization_problem, optimizer)
+    optimization_results = OptimizationResultsWithoutNans(
+        optimization_problem, optimizer
+    )
     results_dir = Path("tmp") / "optimization_results"
 
     shutil.rmtree(results_dir, ignore_errors=True)
@@ -115,11 +123,13 @@ class TestOptimizationResults(unittest.TestCase):
         n_evals = self.optimization_results.n_evals
         self.assertEqual(n_evals, n_evals_expected)
 
-        f_min_history_expected = np.array([
-            [-0.79736546],
-            [-0.94888115],
-            [-0.94888115],
-        ])
+        f_min_history_expected = np.array(
+            [
+                [-0.79736546],
+                [-0.94888115],
+                [-0.94888115],
+            ]
+        )
         f_min_history = self.optimization_results.f_min_history
         np.testing.assert_almost_equal(f_min_history, f_min_history_expected)
 
@@ -143,19 +153,23 @@ class TestOptimizationResults(unittest.TestCase):
         optimization_problem, _ = setup_optimization_problem_and_results()
 
         # save_results() needs to happen after creation of optimization_problem,
-        #  because during optimization_problem creation the results folder gets cleared and that would delete the save
+        # because during optimization_problem creation the results folder gets cleared
+        # and that would delete the save
         self.optimization_results.save_results("checkpoint")
 
         optimizer = U_NSGA3()
         optimization_results_new = optimizer.load_results(
-            checkpoint_path=self.optimization_results.results_directory / "checkpoint.h5",
-            optimization_problem=optimization_problem
+            checkpoint_path=self.optimization_results.results_directory
+            / "checkpoint.h5",
+            optimization_problem=optimization_problem,
         )
         np.testing.assert_equal(
             desired=self.optimization_results.to_dict(),
-            actual=OptimizationResultsWithoutNans._remove_none_values(optimization_results_new.to_dict())
+            actual=OptimizationResultsWithoutNans._remove_none_values(
+                optimization_results_new.to_dict()
+            ),
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -1,15 +1,14 @@
 from functools import partial
+
 import numpy as np
 import pytest
-
-
 from CADETProcess.optimization import (
-    OptimizerBase,
-    TrustConstr,
     COBYLA,
-    NelderMead,
     SLSQP,
     U_NSGA3,
+    NelderMead,
+    OptimizerBase,
+    TrustConstr,
 )
 
 skip_ax = False
@@ -23,17 +22,17 @@ except ImportError:
     skip_ax = True
 
 from tests.optimization_problem_fixtures import (
-    TestProblem,
-    Rosenbrock,
+    LinearConstraintsMooTestProblem,
     LinearConstraintsSooTestProblem,
     LinearConstraintsSooTestProblem2,
     LinearEqualityConstraintsSooTestProblem,
-    NonlinearConstraintsSooTestProblem,
-    NonlinearLinearConstraintsSooTestProblem,
-    LinearConstraintsMooTestProblem,
     LinearNonlinearConstraintsMooTestProblem,
     NonlinearConstraintsMooTestProblem,
-) # noqa: E402
+    NonlinearConstraintsSooTestProblem,
+    NonlinearLinearConstraintsSooTestProblem,
+    Rosenbrock,
+    TestProblem,
+)  # noqa: E402
 
 # %% Optimizer Setup
 
@@ -112,7 +111,9 @@ class U_NSGA3(U_NSGA3):
     pop_size = 100
     n_max_gen = 20  # before used 100 generations --> this did not improve the fit
 
+
 if not skip_ax:
+
     class GPEI(GPEI):
         cv_lincon_tol = CV_LINCON_TOL
         n_init_evals = 40
@@ -120,14 +121,12 @@ if not skip_ax:
         early_stopping_improvement_window = 10
         n_max_evals = 50
 
-
     class NEHVI(NEHVI):
         cv_lincon_tol = CV_LINCON_TOL
         n_init_evals = 50
         early_stopping_improvement_bar = 1e-4
         early_stopping_improvement_window = 10
         n_max_evals = 60
-
 
     class qNParEGO(qNParEGO):
         cv_lincon_tol = CV_LINCON_TOL
@@ -139,6 +138,7 @@ if not skip_ax:
 
 # %% Test problem factory
 
+
 @pytest.fixture(
     params=[
         # single objective problems
@@ -148,12 +148,10 @@ if not skip_ax:
         NonlinearConstraintsSooTestProblem,
         LinearEqualityConstraintsSooTestProblem,
         NonlinearLinearConstraintsSooTestProblem,
-
         # multi objective problems
         LinearConstraintsMooTestProblem,
         NonlinearConstraintsMooTestProblem,
         LinearNonlinearConstraintsMooTestProblem,
-
         # transformed problems
         partial(LinearConstraintsSooTestProblem, transform="linear"),
         partial(LinearEqualityConstraintsSooTestProblem, transform="linear"),
@@ -163,7 +161,8 @@ if not skip_ax:
 def optimization_problem(request):
     return request.param(use_diskcache=False)
 
-params=[
+
+params = [
     TrustConstr,
     COBYLA,
     SLSQP,
@@ -176,7 +175,7 @@ if not skip_ax:
         [
             GPEI,
             NEHVI,
-            qNParEGO
+            qNParEGO,
         ]
     )
     EXCLUDE_COMBINATIONS.append(
@@ -189,9 +188,7 @@ if not skip_ax:
     )
 
 
-@pytest.fixture(
-    params=params
-)
+@pytest.fixture(params=params)
 def optimizer(request):
     optimizer = request.param()
     optimizer.progress_freqency = None
@@ -215,11 +212,11 @@ def test_convergence(optimization_problem: TestProblem, optimizer: OptimizerBase
         else:
             optimization_problem.test_if_solved(results, MOO_TEST_KWARGS)
 
+
 @pytest.mark.slow
 def test_from_initial_values(
     optimization_problem: TestProblem, optimizer: OptimizerBase
 ):
-
     if optimizer.check_optimization_problem(optimization_problem):
         skip_if_combination_excluded(optimizer, optimization_problem)
         set_non_default_parameters(optimizer, optimization_problem)
@@ -254,6 +251,7 @@ class AbortingCallback:
             raise RuntimeError("Max number of evaluations reached. Aborting!")
         self.n_calls += 1
 
+
 @pytest.mark.slow
 def test_resume_from_checkpoint(
     optimization_problem: TestProblem, optimizer: OptimizerBase
@@ -262,7 +260,6 @@ def test_resume_from_checkpoint(
 
     # TODO: Do we need to run this for all problems?
     if optimizer.check_optimization_problem(optimization_problem):
-
         callback = AbortingCallback(n_max_evals=2, abort=True)
         optimization_problem.add_callback(callback)
 

--- a/tests/test_parallelization_adapter.py
+++ b/tests/test_parallelization_adapter.py
@@ -6,17 +6,13 @@ import time
 import unittest
 
 from CADETProcess import settings
-from CADETProcess.optimization import U_NSGA3
+from CADETProcess.optimization import U_NSGA3, SequentialBackend
 from CADETProcess.simulator import Cadet
-from CADETProcess.optimization import SequentialBackend
 
 from tests.test_cadet_adapter import detect_cadet
 from tests.test_optimization_problem import setup_optimization_problem
 
-
-parallel_backends_module = importlib.import_module(
-    'CADETProcess.optimization'
-)
+parallel_backends_module = importlib.import_module("CADETProcess.optimization")
 
 _parallel_backends = [
     "Joblib",
@@ -57,7 +53,7 @@ class TestParallelizationBackend(unittest.TestCase):
     def test_max_cores(self):
         for Backend in parallel_backends:
             with self.assertRaises(ValueError):
-                backend = Backend(n_cores=cpu_count+1)
+                backend = Backend(n_cores=cpu_count + 1)
 
     def test_negative_n_cores(self):
         for Backend in parallel_backends:
@@ -69,12 +65,12 @@ class TestParallelizationBackend(unittest.TestCase):
 
             backend.n_cores = -2
             if cpu_count > 1:
-                self.assertEqual(backend._n_cores, cpu_count-1)
+                self.assertEqual(backend._n_cores, cpu_count - 1)
             else:
                 self.assertEqual(backend._n_cores, 1)
 
             with self.assertRaises(ValueError):
-                backend.n_cores = - cpu_count - 1
+                backend.n_cores = -cpu_count - 1
 
 
 class TestParallelEvaluation(unittest.TestCase):
@@ -87,8 +83,8 @@ class TestParallelEvaluation(unittest.TestCase):
     """
 
     def tearDown(self):
-        shutil.rmtree('./tmp', ignore_errors=True)
-        shutil.rmtree('./test_parallelization', ignore_errors=True)
+        shutil.rmtree("./tmp", ignore_errors=True)
+        shutil.rmtree("./test_parallelization", ignore_errors=True)
 
     def test_parallelization_backend(self):
         def evaluation_function(sleep_time=0.0):
@@ -140,8 +136,8 @@ class TestOptimizerParallelizationBackend(unittest.TestCase):
     def tearDown(self):
         settings.working_directory = None
 
-        shutil.rmtree('./test_parallelization', ignore_errors=True)
-        shutil.rmtree('./diskcache_simple', ignore_errors=True)
+        shutil.rmtree("./test_parallelization", ignore_errors=True)
+        shutil.rmtree("./diskcache_simple", ignore_errors=True)
 
     def test_parallel_optimization(self):
         def run_optimization(backend=None):
@@ -150,7 +146,7 @@ class TestOptimizerParallelizationBackend(unittest.TestCase):
                 time.sleep(0.05)
                 return y
 
-            settings.working_directory = './test_parallelization'
+            settings.working_directory = "./test_parallelization"
 
             optimization_problem = setup_optimization_problem(
                 use_diskcache=True, obj_fun=dummy_objective_function
@@ -189,5 +185,5 @@ class TestOptimizerParallelizationBackend(unittest.TestCase):
             run_optimization(backend=backend)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_parameters.py
+++ b/tests/test_parameters.py
@@ -1,93 +1,101 @@
 import unittest
 
 import numpy as np
-
 from CADETProcess.dataStructure import (
-    Structure,
-    Constant, Switch,
-    Typed, Integer, Float, String, List,
-    IntegerList, FloatList,
+    Aggregator,
     Callable,
-    RangedFloat, UnsignedInteger,
-    SizedList, SizedNdArray,
-    SizedUnsignedList, SizedUnsignedNdArray,
-    Polynomial, NdPolynomial,
-    Vector, Matrix,
+    Constant,
     DependentlyModulatedUnsignedList,
-    Aggregator, SizedAggregator,
+    Float,
+    FloatList,
+    Integer,
+    IntegerList,
+    List,
+    Matrix,
+    NdPolynomial,
+    Polynomial,
+    RangedFloat,
+    SizedAggregator,
+    SizedList,
+    SizedNdArray,
+    SizedUnsignedList,
+    SizedUnsignedNdArray,
+    String,
+    Structure,
+    Switch,
+    Typed,
+    UnsignedInteger,
+    Vector,
 )
 
 
 class TestDescription(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
-            param_with_description = Integer(description='foo')
+            param_with_description = Integer(description="foo")
 
         self.model = Model()
 
     def test_description(self):
-        self.assertEqual(type(self.model).param_with_description.description, 'foo')
+        self.assertEqual(type(self.model).param_with_description.description, "foo")
 
     def test_modified_descriptor(self):
-        type(self.model).param_with_description.description = 'bar'
-        self.assertEqual(type(self.model).param_with_description.description, 'bar')
+        type(self.model).param_with_description.description = "bar"
+        self.assertEqual(type(self.model).param_with_description.description, "bar")
 
 
 class TestParameterDictionaries(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
             param = Integer()
             param_default = Integer(default=1)
             no_param = None
 
-            _parameters = ['param', 'param_default']
+            _parameters = ["param", "param_default"]
 
         self.model = Model()
 
     def test_parameters_dict_getter(self):
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': None, 'param_default': 1}
+            self.model._parameters_dict, {"param": None, "param_default": 1}
         )
 
         self.model.param = 1
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': 1, 'param_default': 1}
+            self.model._parameters_dict, {"param": 1, "param_default": 1}
         )
 
         self.model.param = None
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': None, 'param_default': 1}
+            self.model._parameters_dict, {"param": None, "param_default": 1}
         )
 
         self.model.param_default = 2
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': None, 'param_default': 2}
+            self.model._parameters_dict, {"param": None, "param_default": 2}
         )
 
         self.model.param_default = None
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': None, 'param_default': 1}
+            self.model._parameters_dict, {"param": None, "param_default": 1}
         )
 
     def test_parameters_dict_setter(self):
-        self.model.parameters = {'param': 1, 'param_default': 2}
+        self.model.parameters = {"param": 1, "param_default": 2}
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': 1, 'param_default': 2}
+            self.model._parameters_dict, {"param": 1, "param_default": 2}
         )
 
-        self.model.parameters = {'param': 2}
+        self.model.parameters = {"param": 2}
         np.testing.assert_equal(
-            self.model._parameters_dict, {'param': 2, 'param_default': 2}
+            self.model._parameters_dict, {"param": 2, "param_default": 2}
         )
 
         with self.assertRaises(ValueError):
-            self.model.parameters = {'not_a_valid_param': 1}
+            self.model.parameters = {"not_a_valid_param": 1}
 
 
 class TestConstant(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
             const_int = Constant(value=0)
@@ -108,38 +116,38 @@ class TestConstant(unittest.TestCase):
 
     def test_error_when_no_value(self):
         with self.assertRaises(TypeError):
+
             class NoValue(Structure):
                 const = Constant()
 
 
 class TestSwitch(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
-            switch = Switch(valid=['foo', 'bar'], default='foo')
+            switch = Switch(valid=["foo", "bar"], default="foo")
 
         self.model = Model()
 
     def test_value(self):
-        self.model.switch = 'bar'
-        self.assertEqual(self.model.switch, 'bar')
+        self.model.switch = "bar"
+        self.assertEqual(self.model.switch, "bar")
 
         with self.assertRaises(ValueError):
-            self.model.switch = 'spam'
+            self.model.switch = "spam"
 
     def test_default(self):
-        self.assertEqual(self.model.switch, 'foo')
+        self.assertEqual(self.model.switch, "foo")
 
         with self.assertRaises(ValueError):
+
             class InvalidDefault(Structure):
-                switch = Switch(valid=['foo', 'bar'], default='spam')
+                switch = Switch(valid=["foo", "bar"], default="spam")
 
 
 class TestTyped(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
-            string_param = String(default='foo')
+            string_param = String(default="foo")
             list_param = List(default=[1, 2])
             dynamic_type_param = Typed(ty=list, default=[0, 1])
 
@@ -147,14 +155,21 @@ class TestTyped(unittest.TestCase):
         self.model_other = Model()
 
     def test_values(self):
-        self.model.string_param = 'string_param'
-        self.assertEqual(self.model.string_param, 'string_param')
+        self.model.string_param = "string_param"
+        self.assertEqual(self.model.string_param, "string_param")
 
         with self.assertRaises(TypeError):
             self.model.string_param = 0
 
-        self.model.list_param = [0,]
-        self.assertEqual(self.model.list_param, [0,])
+        self.model.list_param = [
+            0,
+        ]
+        self.assertEqual(
+            self.model.list_param,
+            [
+                0,
+            ],
+        )
 
         with self.assertRaises(TypeError):
             self.model.list_param = 0
@@ -164,7 +179,7 @@ class TestTyped(unittest.TestCase):
             self.model.dynamic_type_param = 0
 
     def test_default(self):
-        self.assertEqual(self.model.string_param, 'foo')
+        self.assertEqual(self.model.string_param, "foo")
         self.assertEqual(self.model.list_param, [1, 2])
         self.assertEqual(self.model.dynamic_type_param, [0, 1])
 
@@ -172,10 +187,12 @@ class TestTyped(unittest.TestCase):
         self.assertFalse(self.model.dynamic_type_param is self.model_other.list_param)
 
         with self.assertRaises(TypeError):
+
             class WrongDefaultType(Structure):
-                param_1 = List(default='string')
+                param_1 = List(default="string")
 
         with self.assertRaises(TypeError):
+
             class WrongDefaultType(Structure):
                 param_1 = List(default=1)
 
@@ -184,7 +201,6 @@ class TestTyped(unittest.TestCase):
 
 
 class TestCallable(unittest.TestCase):
-
     def setUp(self):
         def default_method(x):
             return x
@@ -197,10 +213,10 @@ class TestCallable(unittest.TestCase):
 
     def test_values(self):
         def method(x):
-            return 2*x
+            return 2 * x
 
         self.model.method = method
-        assert (callable(self.model.method))
+        assert callable(self.model.method)
 
         self.assertEqual(self.model.method(2), 4)
 
@@ -208,7 +224,7 @@ class TestCallable(unittest.TestCase):
             self.model.method = 2
 
     def test_default(self):
-        assert (callable(self.model.method_default))
+        assert callable(self.model.method_default)
         self.assertEqual(self.model.method_default(2), 2)
 
 
@@ -226,14 +242,13 @@ class TestDtype(unittest.TestCase):
         self.assertEqual(self.model.integer_list_param, [1, 2])
 
         with self.assertRaises(ValueError):
-            self.model.integer_list_param = [1, 'foo']
+            self.model.integer_list_param = [1, "foo"]
 
-        self.model.float_list_param = [1., 2]
-        self.assertEqual(self.model.float_list_param, [1., 2.])
+        self.model.float_list_param = [1.0, 2]
+        self.assertEqual(self.model.float_list_param, [1.0, 2.0])
 
 
 class TestRanged(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
             bound_float_param = RangedFloat(lb=-1, ub=1, default=0)
@@ -260,12 +275,12 @@ class TestRanged(unittest.TestCase):
         self.assertEqual(self.model.unsigned_integer_param, 1)
 
         with self.assertRaises(ValueError):
+
             class InvalidDefault(Structure):
                 param_1 = UnsignedInteger(default=-1)
 
 
 class TestSizedUnified(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
             sized_list = SizedList(size=4, default=0)
@@ -315,20 +330,20 @@ class TestSizedUnified(unittest.TestCase):
         )
 
         # Full default
-        ## List
-        np.testing.assert_equal(
-            self.model.sized_list_full_default, [1, 2, 3, 4]
-        )
+        # List
+        np.testing.assert_equal(self.model.sized_list_full_default, [1, 2, 3, 4])
 
         with self.assertRaises(ValueError):
+
             class InvalidDefaultSize(Structure):
                 param_1 = SizedList(size=4, default=[1, 2, 3])
 
-        ## Array
+        # Array
         np.testing.assert_equal(
             self.model.sized_array_full_default, [[1, 2, 3, 4], [5, 6, 7, 8]]
         )
         with self.assertRaises(ValueError):
+
             class InvalidDefaultSize(Structure):
                 param_1 = SizedNdArray(
                     size=(4, 2), default=[[1, 2, 3, 4], [5, 6, 7, 8], [10, 11, 12, 13]]
@@ -336,6 +351,7 @@ class TestSizedUnified(unittest.TestCase):
 
         # Invalid range
         with self.assertRaises(ValueError):
+
             class InvalidDefaultRange(Structure):
                 param_1 = SizedUnsignedList(size=4, default=-1)
 
@@ -348,25 +364,19 @@ class TestSizedDependent(unittest.TestCase):
             dep_1 = UnsignedInteger()
             dep_2 = UnsignedInteger(default=3)
 
-            list_single_dep_param = SizedUnsignedList(
-                size='dep_1', default=1
-            )
-            array_single_dep_param = SizedUnsignedNdArray(
-                size='dep_1', default=1
-            )
+            list_single_dep_param = SizedUnsignedList(size="dep_1", default=1)
+            array_single_dep_param = SizedUnsignedNdArray(size="dep_1", default=1)
 
             list_double_dep_param = SizedUnsignedList(
-                size=('dep_1', 'dep_2'), default=1
+                size=("dep_1", "dep_2"), default=1
             )
             array_double_dep_param = SizedUnsignedNdArray(
-                size=('dep_1', 'dep_2'), default=1
+                size=("dep_1", "dep_2"), default=1
             )
 
-            list_double_dep_with_int = SizedUnsignedList(
-                size=('dep_1', 2), default=2
-            )
+            list_double_dep_with_int = SizedUnsignedList(size=("dep_1", 2), default=2)
             array_double_dep_with_int = SizedUnsignedNdArray(
-                size=('dep_1', 2), default=2
+                size=("dep_1", 2), default=2
             )
 
         self.model = Model()
@@ -393,9 +403,7 @@ class TestSizedDependent(unittest.TestCase):
             self.model.list_single_dep_param = [2, 2, 2]
 
         # Multiple dependencies
-        np.testing.assert_array_equal(
-            self.model.list_double_dep_param, np.ones((6,))
-        )
+        np.testing.assert_array_equal(self.model.list_double_dep_param, np.ones((6,)))
         np.testing.assert_array_equal(
             self.model.array_double_dep_param, np.ones((2, 3))
         )
@@ -424,57 +432,61 @@ class TestSizedDependent(unittest.TestCase):
 
         # Full default
         with self.assertRaises(ValueError):
+
             class InvalidDefaultSizeList(Structure):
                 dep_1 = UnsignedInteger()
-                param_1 = SizedUnsignedList(size='dep_1', default=[1, 2, 3])
+                param_1 = SizedUnsignedList(size="dep_1", default=[1, 2, 3])
 
         with self.assertRaises(ValueError):
+
             class InvalidDefaultSizeArray(Structure):
                 param_1 = SizedUnsignedNdArray(
-                    size=(4, 'dep_1'), default=[[1, 2, 3, 4], [5, 6, 7, 8]]
+                    size=(4, "dep_1"), default=[[1, 2, 3, 4], [5, 6, 7, 8]]
                 )
 
         # Range error
         with self.assertRaises(ValueError):
+
             class InvalidDefault(Structure):
-                list_single_dep_param = SizedUnsignedList(
-                    size='dep_1', default=-1
-                )
+                list_single_dep_param = SizedUnsignedList(size="dep_1", default=-1)
 
 
 class TestPolynomial(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
             poly_param = Polynomial(n_coeff=2, default=0)
             ndpoly_param = NdPolynomial(n_entries=2, n_coeff=4)
 
             n_coeff = 4
-            poly_param_dep = Polynomial(size=('n_coeff'))
+            poly_param_dep = Polynomial(size=("n_coeff"))
 
             n_entries = 3
-            ndpoly_param_dep = NdPolynomial(size=('n_entries', 'n_coeff'))
+            ndpoly_param_dep = NdPolynomial(size=("n_entries", "n_coeff"))
 
         self.model = Model()
 
     def test_parameter(self):
         with self.assertRaises(ValueError):
+
             class TestDuplicateCoeffs(Structure):
                 n_coeff = 2
-                faulty = Polynomial(n_coeff=2, size=('n_coeff'))
+                faulty = Polynomial(n_coeff=2, size=("n_coeff"))
 
         with self.assertRaises(ValueError):
+
             class TestMissingEntries(Structure):
                 n_coeff = 2
-                faulty = NdPolynomial(size=('n_coeff'))
+                faulty = NdPolynomial(size=("n_coeff"))
 
         with self.assertRaises(ValueError):
+
             class TestDuplicateCoeff(Structure):
                 n_coeff = 2
                 entries = 2
-                faulty = NdPolynomial(n_entries=2, n_coeff=2, size=('n_coeff'))
+                faulty = NdPolynomial(n_entries=2, n_coeff=2, size=("n_coeff"))
 
         with self.assertRaises(ValueError):
+
             class TestInvalidDefault(Structure):
                 faulty = NdPolynomial(n_entries=2, n_coeff=2, default=1)
 
@@ -504,18 +516,14 @@ class TestPolynomial(unittest.TestCase):
 
         # Multiple entries
         self.model.ndpoly_param = 2
-        np.testing.assert_equal(
-            self.model.ndpoly_param, [[2, 0, 0, 0], [2, 0, 0, 0]]
-        )
+        np.testing.assert_equal(self.model.ndpoly_param, [[2, 0, 0, 0], [2, 0, 0, 0]])
 
         self.model.ndpoly_param = [3, 2]
-        np.testing.assert_equal(
-            self.model.ndpoly_param, [[3, 0, 0, 0], [2, 0, 0, 0]]
-        )
+        np.testing.assert_equal(self.model.ndpoly_param, [[3, 0, 0, 0], [2, 0, 0, 0]])
 
         self.model.ndpoly_param = [[1, 2], [0, 1, 2]]
         np.testing.assert_equal(
-            self.model.ndpoly_param, [[1, 2, 0., 0.], [0, 1, 2, 0]]
+            self.model.ndpoly_param, [[1, 2, 0.0, 0.0], [0, 1, 2, 0]]
         )
 
         with self.assertRaises(ValueError):
@@ -572,12 +580,11 @@ class TestPolynomial(unittest.TestCase):
 
 
 class TestModulated(unittest.TestCase):
-
     def setUp(self):
         class Model(Structure):
             n_mod = 4
 
-            modulated_list = DependentlyModulatedUnsignedList(size='n_mod')
+            modulated_list = DependentlyModulatedUnsignedList(size="n_mod")
 
         self.model = Model()
 
@@ -622,18 +629,18 @@ class TestAggregator(unittest.TestCase):
             sized_param_transposed = SizedNdArray(size=2)
 
         class Model(Structure):
-            aggregator = Aggregator('float_param', 'container')
-            sized_aggregator = SizedAggregator('sized_param', 'container')
+            aggregator = Aggregator("float_param", "container")
+            sized_aggregator = SizedAggregator("sized_param", "container")
             transposed_sized_aggregator = SizedAggregator(
-                'sized_param_transposed', 'container', transpose=True
+                "sized_param_transposed", "container", transpose=True
             )
 
             def __init__(self):
                 self.container = [
                     DummyInstance(
                         float_param=i,
-                        sized_param=[float(i*j) for j in range(4)],
-                        sized_param_transposed=[float(i*j) for j in range(2)]
+                        sized_param=[float(i * j) for j in range(4)],
+                        sized_param_transposed=[float(i * j) for j in range(2)],
                     )
                     for i in range(3)
                 ]
@@ -666,13 +673,13 @@ class TestAggregator(unittest.TestCase):
                 [0, 0, 0, 0],
                 [0, 1, 2, 3],
                 [0, 2, 4, 6],
-            ]
+            ],
         )
 
         new_value = [
-                [1., 2., 3., 4.],
-                [2., 3., 4., 5.],
-                [3., 4., 5., 6.],
+            [1.0, 2.0, 3.0, 4.0],
+            [2.0, 3.0, 4.0, 5.0],
+            [3.0, 4.0, 5.0, 6.0],
         ]
         self.model.sized_aggregator = new_value
 
@@ -685,16 +692,16 @@ class TestAggregator(unittest.TestCase):
             self.model.sized_aggregator = 3
 
         with self.assertRaises((ValueError, TypeError)):
-            self.model.sized_aggregator = [1., 2., 3., 4.]
+            self.model.sized_aggregator = [1.0, 2.0, 3.0, 4.0]
 
         with self.assertRaises(IndexError):
             self.model.sized_aggregator[3] = 3.0
 
         # Test setting slices and indexes
         new_value = [
-                [1.5, 2.5, 3.5, 4.5],
-                [2.5, 3.5, 4.5, 5.5],
-                [3.5, 4.5, 5.5, 6.5],
+            [1.5, 2.5, 3.5, 4.5],
+            [2.5, 3.5, 4.5, 5.5],
+            [3.5, 4.5, 5.5, 6.5],
         ]
 
         self.model.sized_aggregator[0] = new_value[0]
@@ -707,13 +714,13 @@ class TestAggregator(unittest.TestCase):
         np.testing.assert_almost_equal(
             self.model.transposed_sized_aggregator,
             [
-               [0, 0, 0],
-               [0, 1, 2]
-            ]
+                [0, 0, 0],
+                [0, 1, 2],
+            ],
         )
         new_value = [
-               [1, 2, 3],
-               [2, 3, 4]
+            [1, 2, 3],
+            [2, 3, 4],
         ]
         self.model.transposed_sized_aggregator = new_value
 
@@ -724,5 +731,5 @@ class TestAggregator(unittest.TestCase):
             np.testing.assert_almost_equal(con.sized_param_transposed, val)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -1,5 +1,6 @@
-import numpy as np
 import unittest
+
+import numpy as np
 from CADETProcess.performance import Performance, RankedPerformance
 
 
@@ -15,8 +16,13 @@ class PerformanceTestCase(unittest.TestCase):
         mass_balance_difference = np.array([0.2, 0.1, -0.1])
 
         self.performance = Performance(
-            mass, concentration, purity, recovery,
-            productivity, eluent_consumption, mass_balance_difference
+            mass,
+            concentration,
+            purity,
+            recovery,
+            productivity,
+            eluent_consumption,
+            mass_balance_difference,
         )
 
     def test_attributes(self):
@@ -46,13 +52,13 @@ class PerformanceTestCase(unittest.TestCase):
 
     def test_to_dict(self):
         expected_dict = {
-            'mass': [10.0, 20.0, 30.0],
-            'concentration': [0.5, 0.4, 0.3],
-            'purity': [0.9, 0.85, 0.95],
-            'recovery': [0.8, 0.75, 0.9],
-            'productivity': [0.7, 0.6, 0.65],
-            'eluent_consumption': [1.5, 2.0, 1.2],
-            'mass_balance_difference': [0.2, 0.1, -0.1]
+            "mass": [10.0, 20.0, 30.0],
+            "concentration": [0.5, 0.4, 0.3],
+            "purity": [0.9, 0.85, 0.95],
+            "recovery": [0.8, 0.75, 0.9],
+            "productivity": [0.7, 0.6, 0.65],
+            "eluent_consumption": [1.5, 2.0, 1.2],
+            "mass_balance_difference": [0.2, 0.1, -0.1],
         }
         self.assertDictEqual(self.performance.to_dict(), expected_dict)
 
@@ -69,8 +75,13 @@ class RankedPerformanceTestCase(unittest.TestCase):
         mass_balance_difference = np.array([0.2, 0.1, -0.1])
 
         performance = Performance(
-            mass, concentration, purity, recovery,
-            productivity, eluent_consumption, mass_balance_difference
+            mass,
+            concentration,
+            purity,
+            recovery,
+            productivity,
+            eluent_consumption,
+            mass_balance_difference,
         )
 
         self.ranked_performance_equal = RankedPerformance(performance, ranking=1)
@@ -114,5 +125,6 @@ class RankedPerformanceTestCase(unittest.TestCase):
             self.ranked_performance_diff.mass_balance_difference, -0.03333333333333333
         )
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_population.py
+++ b/tests/test_population.py
@@ -1,10 +1,11 @@
 import unittest
 
 import numpy as np
-
 from CADETProcess import CADETProcessError
-from CADETProcess.optimization import Individual, Population, ParetoFront
+from CADETProcess.optimization import Individual, ParetoFront, Population
+
 from tests.test_individual import setup_individual
+
 enable_plot = False
 
 
@@ -22,7 +23,6 @@ def setup_population(n_ind, n_vars, n_obj, n_nonlin=0, n_meta=0, rng=None):
 
 
 class TestPopulation(unittest.TestCase):
-
     def setUp(self):
         x = [1, 2]
         f = [-1]
@@ -100,41 +100,43 @@ class TestPopulation(unittest.TestCase):
         self.assertEqual(1, self.population_meta.n_m)
 
     def test_values(self):
-        x_expected = np.array([
-            [1, 2],
-            [2, 3],
-            [1.001, 2]
-        ])
+        x_expected = np.array(
+            [
+                [1, 2],
+                [2, 3],
+                [1.001, 2],
+            ]
+        )
         x = self.population.x
         np.testing.assert_almost_equal(x, x_expected)
 
-        f_expected = np.array([
-            [-1],
-            [-2],
-            [-1.001]
-        ])
+        f_expected = np.array(
+            [
+                [-1],
+                [-2],
+                [-1.001],
+            ]
+        )
         f = self.population.f
         np.testing.assert_almost_equal(f, f_expected)
 
-        g_expected = np.array([
-            [3],
-            [0]
-        ])
+        g_expected = np.array(
+            [
+                [3],
+                [0],
+            ]
+        )
         g = self.population_constr.g
         np.testing.assert_almost_equal(g, g_expected)
 
     def test_add_remove(self):
         with self.assertRaises(TypeError):
-            self.population.add_individual('foo')
+            self.population.add_individual("foo")
 
-        self.population.add_individual(
-            self.individual_1, ignore_duplicate=True
-        )
+        self.population.add_individual(self.individual_1, ignore_duplicate=True)
 
         with self.assertRaises(CADETProcessError):
-            self.population.add_individual(
-                self.individual_1, ignore_duplicate=False
-            )
+            self.population.add_individual(self.individual_1, ignore_duplicate=False)
 
         new_individual = Individual([9, 10], f=[3], g=[-1])
         with self.assertRaises(CADETProcessError):
@@ -145,55 +147,67 @@ class TestPopulation(unittest.TestCase):
         self.assertFalse(new_individual in self.population)
         self.assertTrue(self.individual_1 in self.population_constr)
 
-        x_expected = np.array([
-            [1, 2],
-            [2, 3],
-            [9, 10],
-        ])
+        x_expected = np.array(
+            [
+                [1, 2],
+                [2, 3],
+                [9, 10],
+            ]
+        )
         x = self.population_constr.x
         np.testing.assert_almost_equal(x, x_expected)
 
-        f_expected = np.array([
-            [-1],
-            [-2],
-            [3]
-        ])
+        f_expected = np.array(
+            [
+                [-1],
+                [-2],
+                [3],
+            ]
+        )
         f = self.population_constr.f
         np.testing.assert_almost_equal(f, f_expected)
 
-        g_expected = np.array([
-            [3],
-            [0],
-            [-1]
-        ])
+        g_expected = np.array(
+            [
+                [3],
+                [0],
+                [-1],
+            ]
+        )
         g = self.population_constr.g
         np.testing.assert_almost_equal(g, g_expected)
 
         with self.assertRaises(TypeError):
-            self.population.remove_individual('foo')
+            self.population.remove_individual("foo")
 
         with self.assertRaises(CADETProcessError):
             self.population.remove_individual(new_individual)
 
         self.population_constr.remove_individual(new_individual)
-        x_expected = np.array([
-            [1, 2],
-            [2, 3],
-        ])
+        x_expected = np.array(
+            [
+                [1, 2],
+                [2, 3],
+            ]
+        )
         x = self.population_constr.x
         np.testing.assert_almost_equal(x, x_expected)
 
-        f_expected = np.array([
-            [-1],
-            [-2],
-        ])
+        f_expected = np.array(
+            [
+                [-1],
+                [-2],
+            ]
+        )
         f = self.population_constr.f
         np.testing.assert_almost_equal(f, f_expected)
 
-        g_expected = np.array([
-            [3],
-            [0],
-        ])
+        g_expected = np.array(
+            [
+                [3],
+                [0],
+            ]
+        )
         g = self.population_constr.g
         np.testing.assert_almost_equal(g, g_expected)
 
@@ -221,9 +235,9 @@ class TestPopulation(unittest.TestCase):
     def test_to_dict(self):
         # Test that Population can be converted to a dictionary
         population_dict = self.population.to_dict()
-        individuals_list = population_dict['individuals']
+        individuals_list = population_dict["individuals"]
         self.assertEqual(len(individuals_list), 3)
-        self.assertEqual(population_dict['id'], str(self.population.id))
+        self.assertEqual(population_dict["id"], str(self.population.id))
 
     def test_from_dict(self):
         # Test that a Population can be created from a dictionary
@@ -236,7 +250,6 @@ class TestPopulation(unittest.TestCase):
 
 
 class TestPareto(unittest.TestCase):
-
     def setUp(self):
         front = ParetoFront(3)
 
@@ -254,7 +267,7 @@ class TestPareto(unittest.TestCase):
         front.update(population)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     enable_plot = True
 
     unittest.main()

--- a/tests/test_pymoo.py
+++ b/tests/test_pymoo.py
@@ -1,5 +1,5 @@
-import unittest
 import shutil
+import unittest
 
 from CADETProcess import settings
 from CADETProcess.optimization import U_NSGA3
@@ -8,13 +8,12 @@ from tests.test_optimization_problem import setup_optimization_problem
 
 
 class Test_OptimizationProblemSimple(unittest.TestCase):
-
     def tearDown(self):
-        shutil.rmtree('./results_simple', ignore_errors=True)
+        shutil.rmtree("./results_simple", ignore_errors=True)
         settings.working_directory = None
 
     def test_restart_from_checkpoint(self):
-        class Callback():
+        class Callback:
             def __init__(self, n_calls=0, kill=True):
                 self.n_calls = n_calls
                 self.kill = kill
@@ -52,5 +51,5 @@ class Test_OptimizationProblemSimple(unittest.TestCase):
         )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_reaction.py
+++ b/tests/test_reaction.py
@@ -6,24 +6,28 @@
 import unittest
 
 import numpy as np
-
-from CADETProcess.processModel import ComponentSystem
-from CADETProcess.processModel import MassActionLaw, MassActionLawParticle
+from CADETProcess.processModel import (
+    ComponentSystem,
+    MassActionLaw,
+    MassActionLawParticle,
+)
 
 
 class Test_Reaction(unittest.TestCase):
-
     def create_simple_bulk_reaction(self, is_kinetic=True, k_fwd_min=100):
         # 0: NH4+(aq) <=> NH3(aq) + H+(aq)
         component_system = ComponentSystem()
-        component_system.add_component('H+', charge=1)
+        component_system.add_component("H+", charge=1)
         component_system.add_component(
-            'Ammonia', species=['NH4+', 'NH3'], charge=[1, 0]
+            "Ammonia", species=["NH4+", "NH3"], charge=[1, 0]
         )
-        reaction_model = MassActionLaw(component_system, 'simple')
+        reaction_model = MassActionLaw(component_system, "simple")
         reaction_model.add_reaction(
-            ['NH4+', 'NH3', 'H+'], [-1, 1, 1], 10**(-9.2)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["NH4+", "NH3", "H+"],
+            [-1, 1, 1],
+            10 ** (-9.2) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         return reaction_model
 
@@ -37,83 +41,98 @@ class Test_Reaction(unittest.TestCase):
         # 5: Arg+ <=> Arg + H+
         # 6: Arg <=> Arg- + H+
         component_system = ComponentSystem()
-        component_system.add_component('H+', charge=1)
+        component_system.add_component("H+", charge=1)
         component_system.add_component(
-            'Ammonia', species=['NH4+', 'NH3'], charge=[1, 0]
+            "Ammonia", species=["NH4+", "NH3"], charge=[1, 0]
         )
         component_system.add_component(
-            'Lysine',
-            species=['Lys2+', 'Lys+', 'Lys', 'Lys-'],
-            charge=[2, 1, 0, -1]
+            "Lysine", species=["Lys2+", "Lys+", "Lys", "Lys-"], charge=[2, 1, 0, -1]
         )
         component_system.add_component(
-            'Arginine',
-            species=['Arg2+', 'Arg+', 'Arg', 'Arg-'],
-            charge=[2, 1, 0, -1]
+            "Arginine", species=["Arg2+", "Arg+", "Arg", "Arg-"], charge=[2, 1, 0, -1]
         )
-        reaction_model = MassActionLaw(component_system, 'complex')
+        reaction_model = MassActionLaw(component_system, "complex")
         # 0: NH4+(aq) <=> NH3(aq) + H+(aq)
         reaction_model.add_reaction(
-            ['NH4+','NH3', 'H+'], [-1, 1, 1], 10**(-9.2)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["NH4+", "NH3", "H+"],
+            [-1, 1, 1],
+            10 ** (-9.2) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         # 1: Lys2+(aq) <=> Lys+(aq) + H+(aq)
         reaction_model.add_reaction(
-            ['Lys2+', 'Lys+', 'H+'], [-1, 1, 1], 10**(-2.20)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["Lys2+", "Lys+", "H+"],
+            [-1, 1, 1],
+            10 ** (-2.20) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         # 2: Lys+(aq) <=> Lys(aq) + H+(aq)
         reaction_model.add_reaction(
-            ['Lys+', 'Lys', 'H+'], [-1, 1, 1], 10**(-8.90)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["Lys+", "Lys", "H+"],
+            [-1, 1, 1],
+            10 ** (-8.90) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         # 3: Lys(aq) <=> Lys-(aq) + H+(aq)
         reaction_model.add_reaction(
-            ['Lys', 'Lys-', 'H+'], [-1, 1, 1], 10**(-10.28)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["Lys", "Lys-", "H+"],
+            [-1, 1, 1],
+            10 ** (-10.28) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         # 4: Arg2+ <=> Arg+ + H+
         reaction_model.add_reaction(
-            ['Arg2+', 'Arg+', 'H+'], [-1, 1, 1], 10**(-2.18)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["Arg2+", "Arg+", "H+"],
+            [-1, 1, 1],
+            10 ** (-2.18) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         # 5: Arg+ <=> Arg + H+
         reaction_model.add_reaction(
-            ['Arg+', 'Arg', 'H+'], [-1, 1, 1], 10**(-9.09)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["Arg+", "Arg", "H+"],
+            [-1, 1, 1],
+            10 ** (-9.09) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
         # 6: Arg <=> Arg- + H+
         reaction_model.add_reaction(
-            ['Arg', 'Arg-', 'H+'], [-1, 1, 1], 10**(-13.2)*1e3,
-            is_kinetic=is_kinetic, k_fwd_min=k_fwd_min
+            ["Arg", "Arg-", "H+"],
+            [-1, 1, 1],
+            10 ** (-13.2) * 1e3,
+            is_kinetic=is_kinetic,
+            k_fwd_min=k_fwd_min,
         )
 
         return reaction_model
 
     def test_stoich_bulk(self):
         simple_model = self.create_simple_bulk_reaction()
-        stoich_expected = np.array([
-            [1.0],
-            [-1.0],
-            [1.0]
-        ])
+        stoich_expected = np.array([[1.0], [-1.0], [1.0]])
         stoich_expected = np.array([1, -1, 1], ndmin=2).T
         np.testing.assert_array_equal(stoich_expected, simple_model.stoich)
 
         complex_model = self.create_complex_bulk_reaction()
-        stoich_expected = np.array([
-            [ 1.,  1.,  1.,  1.,  1.,  1.,  1.],
-            [-1.,  0.,  0.,  0.,  0.,  0.,  0.],
-            [ 1.,  0.,  0.,  0.,  0.,  0.,  0.],
-            [ 0., -1.,  0.,  0.,  0.,  0.,  0.],
-            [ 0.,  1., -1.,  0.,  0.,  0.,  0.],
-            [ 0.,  0.,  1., -1.,  0.,  0.,  0.],
-            [ 0.,  0.,  0.,  1.,  0.,  0.,  0.],
-            [ 0.,  0.,  0.,  0., -1.,  0.,  0.],
-            [ 0.,  0.,  0.,  0.,  1., -1.,  0.],
-            [ 0.,  0.,  0.,  0.,  0.,  1., -1.],
-            [ 0.,  0.,  0.,  0.,  0.,  0.,  1.]
-        ])
+        stoich_expected = np.array(
+            [
+                [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0],
+                [-1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+            ]
+        )
 
         np.testing.assert_array_equal(stoich_expected, complex_model.stoich)
 
@@ -149,65 +168,70 @@ class Test_Reaction(unittest.TestCase):
     def create_cross_phase_reaction(self):
         component_system = ComponentSystem()
         component_system.add_component(
-            'Ammonia', species=['NH4+', 'NH3'], charge=[1, 0]
+            "Ammonia", species=["NH4+", "NH3"], charge=[1, 0]
         )
         component_system.add_component(
-            'Lysine',
-            species=['Lys2+', 'Lys+', 'Lys', 'Lys-'],
-            charge=[2, 1, 0, -1]
+            "Lysine", species=["Lys2+", "Lys+", "Lys", "Lys-"], charge=[2, 1, 0, -1]
         )
-        component_system.add_component('H+', charge=1)
+        component_system.add_component("H+", charge=1)
 
-        reaction_model = MassActionLawParticle(component_system, 'complex')
+        reaction_model = MassActionLawParticle(component_system, "complex")
 
         # Pore Liquid
         # 0: NH4+(aq) <=> NH3(aq) + H+(aq)
         reaction_model.add_liquid_reaction(
-            ['NH4+', 'NH3', 'H+'], [-1, 1, 1], 10**(-9.2)*1e3, is_kinetic=False
+            ["NH4+", "NH3", "H+"], [-1, 1, 1], 10 ** (-9.2) * 1e3, is_kinetic=False
         )
         # 1: Lys2+(aq) <=> Lys+(aq) + H+(aq)
         reaction_model.add_liquid_reaction(
-            ['Lys2+', 'Lys+', 'H+'], [-1, 1, 1], 10**(-2.20)*1e3, is_kinetic=False
+            ["Lys2+", "Lys+", "H+"], [-1, 1, 1], 10 ** (-2.20) * 1e3, is_kinetic=False
         )
         # 2: Lys+(aq) <=> Lys(aq) + H+(aq)
         reaction_model.add_liquid_reaction(
-            ['Lys+', 'Lys', 'H+'], [-1, 1, 1], 10**(-8.90)*1e3, is_kinetic=False
+            ["Lys+", "Lys", "H+"], [-1, 1, 1], 10 ** (-8.90) * 1e3, is_kinetic=False
         )
         # 3: Lys(aq) <=> Lys-(aq) + H+(aq)
         reaction_model.add_liquid_reaction(
-            ['Lys', 'Lys-', 'H+'], [-1, 1, 1], 10**(-10.28)*1e3, is_kinetic=False
+            ["Lys", "Lys-", "H+"], [-1, 1, 1], 10 ** (-10.28) * 1e3, is_kinetic=False
         )
 
         # Adsorption
         k_fwd_min_ads = 100
         # 0: NH4+(aq) + H+(s) <=> NH4+(s) + H+(aq)
         reaction_model.add_cross_phase_reaction(
-            ['NH4+', 'H+', 'NH4+', 'H+'], [-1, -1, 1, 1], [0, 1, 1, 0], 1/1.5,
-            k_fwd_min=k_fwd_min_ads
+            ["NH4+", "H+", "NH4+", "H+"],
+            [-1, -1, 1, 1],
+            [0, 1, 1, 0],
+            1 / 1.5,
+            k_fwd_min=k_fwd_min_ads,
         )
         # 1: NH4+(s) <=> NH3(aq) + H+(s)
         reaction_model.add_cross_phase_reaction(
-            ['NH4+', 'NH3', 'H+'], [-1, 1, 1], [1, 0, 1], 1.5, k_fwd_min=k_fwd_min_ads
+            ["NH4+", "NH3", "H+"], [-1, 1, 1], [1, 0, 1], 1.5, k_fwd_min=k_fwd_min_ads
         )
         # 2: Lys2+(aq) + 2H+(s) <=> Lys2+(s) + 2H+(aq)
         reaction_model.add_cross_phase_reaction(
-            ['Lys2+', 'H+', 'Lys2+', 'H+'], [-1, -2, 1, 2], [0, 1, 1, 0], 1/5,
-            k_fwd_min=k_fwd_min_ads
+            ["Lys2+", "H+", "Lys2+", "H+"],
+            [-1, -2, 1, 2],
+            [0, 1, 1, 0],
+            1 / 5,
+            k_fwd_min=k_fwd_min_ads,
         )
         # 3: Lys2+(s) <=> Lys+(aq) + H+(s)
         reaction_model.add_cross_phase_reaction(
-            ['Lys2+', 'Lys+', 'H+'], [-1, 1, 1], [1, 0, 1], 5,
-            k_fwd_min=k_fwd_min_ads
+            ["Lys2+", "Lys+", "H+"], [-1, 1, 1], [1, 0, 1], 5, k_fwd_min=k_fwd_min_ads
         )
         # 4: Lys+(aq) + H+(s) <=> Lys+(s) + H+(aq)
         reaction_model.add_cross_phase_reaction(
-            ['Lys+', 'H+', 'Lys+', 'H+'], [-1, -1, 1, 1], [0, 1, 1, 0], 1/0.75,
-            k_fwd_min=k_fwd_min_ads
+            ["Lys+", "H+", "Lys+", "H+"],
+            [-1, -1, 1, 1],
+            [0, 1, 1, 0],
+            1 / 0.75,
+            k_fwd_min=k_fwd_min_ads,
         )
         # 5: Lys+(s) <=> Lys(aq) + H+(s)
         reaction_model.add_cross_phase_reaction(
-            ['Lys+', 'Lys', 'H+'], [-1, 1, 1], [1, 0, 1], 0.75,
-            k_fwd_min=k_fwd_min_ads
+            ["Lys+", "Lys", "H+"], [-1, 1, 1], [1, 0, 1], 0.75, k_fwd_min=k_fwd_min_ads
         )
 
         return reaction_model
@@ -215,48 +239,52 @@ class Test_Reaction(unittest.TestCase):
     def test_stoich_cross_phase(self):
         cross_phase_model = self.create_cross_phase_reaction()
 
-        stoich_liquid_expected = np.array([
-            [-1.,  0.,  0.,  0., -1.,  0.,  0.,  0.,  0.,  0.],
-            [ 1.,  0.,  0.,  0.,  0.,  1.,  0.,  0.,  0.,  0.],
-            [ 0., -1.,  0.,  0.,  0.,  0., -1.,  0.,  0.,  0.],
-            [ 0.,  1., -1.,  0.,  0.,  0.,  0.,  1., -1.,  0.],
-            [ 0.,  0.,  1., -1.,  0.,  0.,  0.,  0.,  0.,  1.],
-            [ 0.,  0.,  0.,  1.,  0.,  0.,  0.,  0.,  0.,  0.],
-            [ 1.,  1.,  1.,  1.,  1.,  0.,  2.,  0.,  1.,  0.],
-        ])
+        stoich_liquid_expected = np.array(
+            [
+                [-1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, -1.0, 0.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0],
+                [0.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 1.0, -1.0, 0.0],
+                [0.0, 0.0, 1.0, -1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 1.0],
+                [0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [1.0, 1.0, 1.0, 1.0, 1.0, 0.0, 2.0, 0.0, 1.0, 0.0],
+            ]
+        )
         np.testing.assert_array_equal(
             stoich_liquid_expected, cross_phase_model.stoich_liquid
         )
 
-        stoich_solid_expected = np.array([
-            [ 1., -1.,  0.,  0.,  0.,  0.],
-            [ 0.,  0.,  0.,  0.,  0.,  0.],
-            [ 0.,  0.,  1., -1.,  0.,  0.],
-            [ 0.,  0.,  0.,  0.,  1., -1.],
-            [ 0.,  0.,  0.,  0.,  0.,  0.],
-            [ 0.,  0.,  0.,  0.,  0.,  0.],
-            [-1.,  1., -2.,  1., -1.,  1.]
-        ])
+        stoich_solid_expected = np.array(
+            [
+                [1.0, -1.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 1.0, -1.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 1.0, -1.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+                [-1.0, 1.0, -2.0, 1.0, -1.0, 1.0],
+            ]
+        )
         np.testing.assert_array_equal(
             stoich_solid_expected, cross_phase_model.stoich_solid
         )
 
     def test_str(self):
         reaction_system = self.create_complex_bulk_reaction()
-        str_expected = 'NH4+ <=>[6.31E-07][1.00E+00] H+ + NH3'
+        str_expected = "NH4+ <=>[6.31E-07][1.00E+00] H+ + NH3"
         str_ = str(reaction_system.reactions[0])
         self.assertEqual(str_expected, str_)
 
         reaction_system = self.create_complex_bulk_reaction(is_kinetic=False)
-        str_expected = 'NH4+ <=>[6.31E-07] H+ + NH3'
+        str_expected = "NH4+ <=>[6.31E-07] H+ + NH3"
         str_ = str(reaction_system.reactions[0])
         self.assertEqual(str_expected, str_)
 
         reaction_system = self.create_cross_phase_reaction()
-        str_expected = 'NH4+(l) + H+(s) <=>[6.67E-01][1.00E+00] H+(l) + NH4+(s)'
+        str_expected = "NH4+(l) + H+(s) <=>[6.67E-01][1.00E+00] H+(l) + NH4+(s)"
         str_ = str(reaction_system.cross_phase_reactions[0])
         self.assertEqual(str_expected, str_)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_sections.py
+++ b/tests/test_sections.py
@@ -1,13 +1,11 @@
 import unittest
 
 import numpy as np
-
+from CADETProcess.dynamicEvents import MultiTimeLine, Section, TimeLine
 from CADETProcess.dynamicEvents.section import generate_indices
-from CADETProcess.dynamicEvents import Section, TimeLine, MultiTimeLine
 
 
 class TestGenerateIndices(unittest.TestCase):
-
     def test_generate_indices(self):
         shape = (3, 3)
 
@@ -39,7 +37,6 @@ class TestGenerateIndices(unittest.TestCase):
 
 
 class TestSection(unittest.TestCase):
-
     def setUp(self):
         self.constant_section_single = Section(0, 1, 1)
         self.constant_section_multi = Section(1, 2, [1, 2])
@@ -50,7 +47,7 @@ class TestSection(unittest.TestCase):
         np.testing.assert_equal(self.constant_section_single.coeffs, [[1]])
         np.testing.assert_equal(self.constant_section_multi.coeffs, [[1], [2]])
         np.testing.assert_equal(self.poly_section_single.coeffs, [[0, 1, 0, 0]])
-        np.testing.assert_equal(self.poly_section_multi.coeffs, [[0,  1], [1, -1]])
+        np.testing.assert_equal(self.poly_section_multi.coeffs, [[0, 1], [1, -1]])
 
     def test_section_value(self):
         const_single = self.constant_section_single
@@ -104,7 +101,6 @@ class TestSection(unittest.TestCase):
 
 
 class TestTimeLine(unittest.TestCase):
-
     def create_timeline_constant_single(self):
         """Piecewise constant sections with single entry."""
         section_0 = Section(0, 1, 1.5)
@@ -225,19 +221,19 @@ class TestTimeLine(unittest.TestCase):
         tl = self.create_timeline_poly_single()
 
         np.testing.assert_equal(tl.integral(0, 0), 0.0)
-        np.testing.assert_equal(tl.integral(0, 0.5), 1.5/2)
+        np.testing.assert_equal(tl.integral(0, 0.5), 1.5 / 2)
         np.testing.assert_equal(tl.integral(0, 1), 1.5)
         np.testing.assert_equal(tl.integral(0, 2), 1.5)
-        np.testing.assert_equal(tl.integral(2, 2.5), 0.5/2/2)
+        np.testing.assert_equal(tl.integral(2, 2.5), 0.5 / 2 / 2)
         np.testing.assert_equal(tl.integral(2, 3), 0.5)
 
         tl = self.create_timeline_poly_multi()
 
         np.testing.assert_equal(tl.integral(0, 0), [0.0, 0.0])
-        np.testing.assert_equal(tl.integral(0, 0.5), [1.5/2, 0.125])
+        np.testing.assert_equal(tl.integral(0, 0.5), [1.5 / 2, 0.125])
         np.testing.assert_equal(tl.integral(0, 1), [1.5, 0.5])
         np.testing.assert_equal(tl.integral(0, 2), [1.5, 2.0])
-        np.testing.assert_equal(tl.integral(5, 6), [1, 1/3])
+        np.testing.assert_equal(tl.integral(5, 6), [1, 1 / 3])
 
     def test_timeline_coeff(self):
         """Test coefficient values at given times."""
@@ -247,13 +243,9 @@ class TestTimeLine(unittest.TestCase):
 
         tl = self.create_timeline_poly_multi()
 
-        np.testing.assert_equal(
-            tl.coefficients(0.0), [[1.5, 0, 0], [0, 1, 0]]
-        )
+        np.testing.assert_equal(tl.coefficients(0.0), [[1.5, 0, 0], [0, 1, 0]])
 
-        np.testing.assert_equal(
-            tl.coefficients(5.5), [[1, -2, 0], [0.25, 1, 1]]
-        )
+        np.testing.assert_equal(tl.coefficients(5.5), [[1, -2, 0], [0.25, 1, 1]])
 
     def test_section_times(self):
         """Test section times."""
@@ -264,14 +256,13 @@ class TestTimeLine(unittest.TestCase):
     def test_tl_from_profile(self):
         """Test creation of time line from time series profile."""
         time = np.linspace(0, 100, 1001)
-        y = np.sin(time/10)
+        y = np.sin(time / 10)
 
         tl = TimeLine.from_profile(time, y)
         np.testing.assert_almost_equal(tl.value(time)[:, 0], y, decimal=3)
 
 
 class TestMultiTimeLine(unittest.TestCase):
-
     def create_timeline_constant_multi(self):
         """Piecewise constant sections with multiple entries managed by MultiTimeline."""
         section_0_0 = Section(0, 1, 1.5)
@@ -300,29 +291,29 @@ class TestMultiTimeLine(unittest.TestCase):
     def create_timeline_poly_multi(self):
         """Polynomial sections with multiple entries managed by MultiTimeline."""
         # Entry 0
-        ## Const. Coeff.
+        # Const. Coeff.
         section_0_0_0 = Section(0, 1, 1.5)
         section_0_0_1 = Section(1, 3, 0)
         section_0_0_2 = Section(3, 4, 1)
         section_0_0_3 = Section(4, 6, 2)
 
-        ## Lin. Coeff.
+        # Lin. Coeff.
         section_0_1_0 = Section(0, 2, 0)
         section_0_1_1 = Section(2, 3, 1)
         section_0_1_2 = Section(3, 5, 0)
         section_0_1_3 = Section(5, 6, -2)
 
         # Entry 1
-        ## Const. Coeff.
+        # Const. Coeff.
         section_1_0_0 = Section(0, 1, 0)
         section_1_0_1 = Section(1, 3, 1)
         section_1_0_2 = Section(3, 6, 0)
 
-        ## Lin. Coeff.
+        # Lin. Coeff.
         section_1_1_0 = Section(0, 3, 1)
         section_1_1_1 = Section(3, 6, 0)
 
-        ## Cubic Coeff
+        # Cubic Coeff
         section_1_2_0 = Section(0, 5, 0)
         section_1_2_1 = Section(5, 6, 1)
 
@@ -381,22 +372,18 @@ class TestMultiTimeLine(unittest.TestCase):
         tl = multi_tl.combined_time_line
 
         np.testing.assert_equal(tl.integral(0, 0), [0.0, 0.0])
-        np.testing.assert_equal(tl.integral(0, 0.5), [1.5/2, 0.125])
+        np.testing.assert_equal(tl.integral(0, 0.5), [1.5 / 2, 0.125])
         np.testing.assert_equal(tl.integral(0, 1), [1.5, 0.5])
         np.testing.assert_equal(tl.integral(0, 2), [1.5, 2.0])
-        np.testing.assert_equal(tl.integral(5, 6), [1, 1/3])
+        np.testing.assert_equal(tl.integral(5, 6), [1, 1 / 3])
 
     def test_timeline_coeff(self):
         """Test coefficient values at given times."""
         multi_tl = self.create_timeline_poly_multi()
         tl = multi_tl.combined_time_line
 
-        np.testing.assert_equal(
-            tl.coefficients(0.0), [[1.5, 0, 0, 0], [0, 1, 0, 0]]
-        )
-        np.testing.assert_equal(
-            tl.coefficients(5.5), [[1, -2, 0, 0], [0.25, 1, 1, 0]]
-        )
+        np.testing.assert_equal(tl.coefficients(0.0), [[1.5, 0, 0, 0], [0, 1, 0, 0]])
+        np.testing.assert_equal(tl.coefficients(5.5), [[1, -2, 0, 0], [0.25, 1, 1, 0]])
 
     def test_section_times(self):
         """Test section times."""
@@ -424,5 +411,6 @@ class TestMultiTimeLine(unittest.TestCase):
     def test_combined_timeline(self):
         pass
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_solution.py
+++ b/tests/test_solution.py
@@ -34,19 +34,18 @@ They are available for the Solution, as well as the TimeLine objects.
 import unittest
 
 import numpy as np
-from scipy import stats
-
-from CADETProcess.solution import SolutionIO, slice_solution
+from CADETProcess.dynamicEvents import Section, TimeLine
 from CADETProcess.processModel import ComponentSystem
-from CADETProcess.dynamicEvents import TimeLine, Section
+from CADETProcess.solution import SolutionIO, slice_solution
+from scipy import stats
 
 show_plots = False
 
 comp_2 = ComponentSystem(2)
 
 comp_2_3_species = ComponentSystem()
-comp_2_3_species.add_component('A')
-comp_2_3_species.add_component('B', species=['B+', 'B-'])
+comp_2_3_species.add_component("A")
+comp_2_3_species.add_component("B", species=["B+", "B-"])
 
 # Note that signal is recorded at 10 Hz.
 time = np.linspace(0, 100, 1001)
@@ -86,71 +85,60 @@ q_interrupted.add_section(Section(40, 100, [1, 0, 0, 0], is_polynomial=True))
 
 q_linear = TimeLine()
 q_linear.add_section(Section(0, 35, [0, 0, 0, 0], is_polynomial=True))
-q_linear.add_section(Section(35, 45, [0, 1/10, 0, 0], is_polynomial=True))
+q_linear.add_section(Section(35, 45, [0, 1 / 10, 0, 0], is_polynomial=True))
 q_linear.add_section(Section(45, 100, [0, 0, 0, 0], is_polynomial=True))
 
 
 class TestSolution(unittest.TestCase):
-
     def setUp(self):
         # 2 Components, constant concentration, constant flow
         self.solution_constant = SolutionIO(
-            'simple', comp_2, time, solution_2_constant,
-            q_const
+            "simple", comp_2, time, solution_2_constant, q_const
         )
 
         # 2 Components, square peaks, constant flow
         self.solution_square = SolutionIO(
-            'simple', comp_2, time, solution_2_square,
-            q_const
+            "simple", comp_2, time, solution_2_square, q_const
         )
 
         # 3 Components (species), linear peaks, constant flow
         self.solution_species = SolutionIO(
-            'simple', comp_2_3_species, time, solution_3_linear,
-            q_const
+            "simple", comp_2_3_species, time, solution_3_linear, q_const
         )
 
         # 2 Components, constant concentration, interrupted flow
         self.solution_constant_interrupted = SolutionIO(
-            'simple', comp_2, time, solution_2_constant,
-            q_interrupted
+            "simple", comp_2, time, solution_2_constant, q_interrupted
         )
 
         # 2 Components, constant concentration, linear flow
         self.solution_constant_linear = SolutionIO(
-            'simple', comp_2, time, solution_2_constant,
-            q_linear
+            "simple", comp_2, time, solution_2_constant, q_linear
         )
 
         # 2 Components, square peaks, interrupted flow
         self.solution_square_interrupted = SolutionIO(
-            'simple', comp_2, time, solution_2_square,
-            q_interrupted
+            "simple", comp_2, time, solution_2_square, q_interrupted
         )
 
         # 2 Components, square peaks, linear flow
         self.solution_square_linear = SolutionIO(
-            'simple', comp_2, time, solution_2_square,
-            q_linear
+            "simple", comp_2, time, solution_2_square, q_linear
         )
 
         # 2 Components, gaussian peaks, constant flow
         self.solution_gaussian = SolutionIO(
-            'simple', comp_2, time, solution_2_gaussian,
-            q_const
+            "simple", comp_2, time, solution_2_gaussian, q_const
         )
 
         # 2 Components, gaussian peaks, interrupted flow
         self.solution_gaussian_interrupted = SolutionIO(
-            'simple', comp_2, time, solution_2_gaussian,
-            q_interrupted
+            "simple", comp_2, time, solution_2_gaussian, q_interrupted
         )
 
         # 2 Components, gaussian peaks, linear flow
         self.solution_gaussian_linear = SolutionIO(
-            'simple', comp_2, time, solution_2_gaussian,
-            q_linear
+            "simple", comp_2, time, solution_2_gaussian, q_linear
         )
 
     def test_total_concentration(self):
@@ -228,38 +216,28 @@ class TestSolution(unittest.TestCase):
         t = 150
         c_total_comp_expected = [1, 0]
         c_total_comp_actual = c_total_comp[t]
-        np.testing.assert_almost_equal(
-            c_total_comp_actual, c_total_comp_expected
-        )
+        np.testing.assert_almost_equal(c_total_comp_actual, c_total_comp_expected)
 
         t = 300
         c_total_comp_expected = [0.5, 0.5]
         c_total_comp_actual = c_total_comp[t]
-        np.testing.assert_almost_equal(
-            c_total_comp_actual, c_total_comp_expected
-        )
+        np.testing.assert_almost_equal(c_total_comp_actual, c_total_comp_expected)
 
         t = 350
         c_total_comp_expected = [0.25, 1]
         c_total_comp_actual = c_total_comp[t]
-        np.testing.assert_almost_equal(
-            c_total_comp_actual, c_total_comp_expected
-        )
+        np.testing.assert_almost_equal(c_total_comp_actual, c_total_comp_expected)
 
         t = 450
         c_total_comp_expected = [0, 1.5]
         c_total_comp_actual = c_total_comp[t]
-        np.testing.assert_almost_equal(
-            c_total_comp_actual, c_total_comp_expected
-        )
+        np.testing.assert_almost_equal(c_total_comp_actual, c_total_comp_expected)
 
     def test_local_purity_components(self):
         # Simple case
-        local_purity_expected = [1/3, 2/3]
+        local_purity_expected = [1 / 3, 2 / 3]
         local_purity_actual = self.solution_constant.local_purity_components[0]
-        np.testing.assert_almost_equal(
-            local_purity_actual, local_purity_expected
-        )
+        np.testing.assert_almost_equal(local_purity_actual, local_purity_expected)
 
         # 2 Components, square peaks
         local_purity = self.solution_square.local_purity_components
@@ -267,37 +245,27 @@ class TestSolution(unittest.TestCase):
         t = 0
         local_purity_expected = [0, 0]
         local_purity_actual = local_purity[t]
-        np.testing.assert_almost_equal(
-            local_purity_actual, local_purity_expected
-        )
+        np.testing.assert_almost_equal(local_purity_actual, local_purity_expected)
 
         t = 250
         local_purity_expected = [1, 0]
         local_purity_actual = local_purity[t]
-        np.testing.assert_almost_equal(
-            local_purity_actual, local_purity_expected
-        )
+        np.testing.assert_almost_equal(local_purity_actual, local_purity_expected)
 
         t = 350
-        local_purity_expected = [2/3, 1/3]
+        local_purity_expected = [2 / 3, 1 / 3]
         local_purity_actual = local_purity[t]
-        np.testing.assert_almost_equal(
-            local_purity_actual, local_purity_expected
-        )
+        np.testing.assert_almost_equal(local_purity_actual, local_purity_expected)
 
         t = 450
         local_purity_expected = [0, 1]
         local_purity_actual = local_purity[t]
-        np.testing.assert_almost_equal(
-            local_purity_actual, local_purity_expected
-        )
+        np.testing.assert_almost_equal(local_purity_actual, local_purity_expected)
 
         t = 550
         local_purity_expected = [0, 0]
         local_purity_actual = local_purity[t]
-        np.testing.assert_almost_equal(
-            local_purity_actual, local_purity_expected
-        )
+        np.testing.assert_almost_equal(local_purity_actual, local_purity_expected)
 
         # 2 Components, 3 species (summed up)
         local_purity_components = self.solution_species.local_purity_components
@@ -409,38 +377,33 @@ class TestSolution(unittest.TestCase):
         mass_actual = self.solution_constant.fraction_mass(0, 10)
         np.testing.assert_almost_equal(mass_actual, mass_expected)
 
-        mass_expected = np.array([
-            np.diff(stats.norm.cdf([-2, 2]))[0],
-            np.diff(stats.norm.cdf([-4, 0]))[0]
-        ])
+        mass_expected = np.array(
+            [np.diff(stats.norm.cdf([-2, 2]))[0], np.diff(stats.norm.cdf([-4, 0]))[0]]
+        )
         mass_actual = self.solution_gaussian.fraction_mass(20, 40)
         np.testing.assert_almost_equal(mass_actual, mass_expected)
 
-        mass_expected = np.array([
-            np.diff(stats.norm.cdf([-2, 0]))[0],
-            np.diff(stats.norm.cdf([-4, -2]))[0]
-        ])
+        mass_expected = np.array(
+            [np.diff(stats.norm.cdf([-2, 0]))[0], np.diff(stats.norm.cdf([-4, -2]))[0]]
+        )
         mass_actual = self.solution_gaussian_interrupted.fraction_mass(20, 40)
         np.testing.assert_almost_equal(mass_actual, mass_expected)
 
 
 class TestSliceSolution(unittest.TestCase):
-
     def setUp(self):
         # 2 Components, gaussian peaks, constant flow
         self.solution_gaussian = SolutionIO(
-            'simple', comp_2, time, solution_2_gaussian,
-            q_const
+            "simple", comp_2, time, solution_2_gaussian, q_const
         )
 
         self.solution_species = SolutionIO(
-            'simple', comp_2_3_species, time, solution_3_linear,
-            q_const
+            "simple", comp_2_3_species, time, solution_3_linear, q_const
         )
 
     def test_coordinates(self):
         solution = slice_solution(
-            self.solution_gaussian, coordinates={'time': [30, 40]}
+            self.solution_gaussian, coordinates={"time": [30, 40]}
         )
 
         np.testing.assert_almost_equal(solution.time, np.linspace(30, 40, 101))
@@ -450,8 +413,8 @@ class TestSliceSolution(unittest.TestCase):
 
     def test_components(self):
         # Test single component
-        solution = slice_solution(self.solution_gaussian, components='0')
-        self.assertEqual(solution.component_system.names, ['0'])
+        solution = slice_solution(self.solution_gaussian, components="0")
+        self.assertEqual(solution.component_system.names, ["0"])
 
         np.testing.assert_equal(
             self.solution_gaussian.solution[..., [0]], solution.solution
@@ -460,9 +423,9 @@ class TestSliceSolution(unittest.TestCase):
         # Test with multiple components
 
         # Test with component that has > 1 species
-        solution = slice_solution(self.solution_species, components='B')
-        self.assertEqual(solution.component_system.names, ['B'])
-        self.assertEqual(solution.component_system.species, ['B+', 'B-'])
+        solution = slice_solution(self.solution_species, components="B")
+        self.assertEqual(solution.component_system.names, ["B"])
+        self.assertEqual(solution.component_system.species, ["B+", "B-"])
 
         np.testing.assert_equal(
             self.solution_species.solution[..., 1:], solution.solution
@@ -472,8 +435,8 @@ class TestSliceSolution(unittest.TestCase):
         solution = slice_solution(
             self.solution_species, use_total_concentration_components=True
         )
-        self.assertEqual(solution.component_system.names, ['A', 'B'])
-        self.assertEqual(solution.component_system.species, ['A', 'B'])
+        self.assertEqual(solution.component_system.names, ["A", "B"])
+        self.assertEqual(solution.component_system.species, ["A", "B"])
 
         np.testing.assert_equal(
             self.solution_species.solution[..., 0], solution.solution[:, 0]
@@ -481,58 +444,53 @@ class TestSliceSolution(unittest.TestCase):
 
         np.testing.assert_equal(
             np.sum(self.solution_species.solution[..., 1:]),
-            np.sum(solution.solution[:, 1])
+            np.sum(solution.solution[:, 1]),
         )
         np.testing.assert_equal(
             self.solution_species.total_concentration_components,
-            solution.total_concentration_components
+            solution.total_concentration_components,
         )
 
     def test_total_concentration(self):
-        solution = slice_solution(
-            self.solution_species, use_total_concentration=True
-        )
-        self.assertEqual(solution.component_system.names, ['total_concentration'])
+        solution = slice_solution(self.solution_species, use_total_concentration=True)
+        self.assertEqual(solution.component_system.names, ["total_concentration"])
 
         np.testing.assert_equal(
             np.sum(self.solution_species.solution[..., :]),
-            np.sum(solution.solution, axis=0)
+            np.sum(solution.solution, axis=0),
         )
         np.testing.assert_equal(
-            self.solution_species.total_concentration,
-            solution.total_concentration
+            self.solution_species.total_concentration, solution.total_concentration
         )
 
         # One component
         solution = slice_solution(
-            self.solution_species, components=['A'], use_total_concentration=True
+            self.solution_species, components=["A"], use_total_concentration=True
         )
-        self.assertEqual(solution.component_system.names, ['total_concentration'])
+        self.assertEqual(solution.component_system.names, ["total_concentration"])
 
         np.testing.assert_equal(
-            self.solution_species.solution[..., [0]],
-            solution.solution
+            self.solution_species.solution[..., [0]], solution.solution
         )
 
         np.testing.assert_equal(
-            self.solution_species.solution[..., [0]],
-            solution.total_concentration
+            self.solution_species.solution[..., [0]], solution.total_concentration
         )
 
         # One component with two species
         solution = slice_solution(
-            self.solution_species, components=['B'], use_total_concentration=True
+            self.solution_species, components=["B"], use_total_concentration=True
         )
-        self.assertEqual(solution.component_system.names, ['total_concentration'])
+        self.assertEqual(solution.component_system.names, ["total_concentration"])
 
         np.testing.assert_equal(
             np.sum(self.solution_species.solution[..., 1:], keepdims=True, axis=1),
-            solution.solution
+            solution.solution,
         )
 
         np.testing.assert_equal(
             np.sum(self.solution_species.solution[..., 1:], keepdims=True, axis=1),
-            solution.total_concentration
+            solution.total_concentration,
         )
 
 
@@ -540,8 +498,7 @@ class TestPlot(unittest.TestCase):
     def setUp(self):
         # 2 Components, gaussian peaks, constant flow
         self.solution_species = SolutionIO(
-            'simple', comp_2_3_species, time, solution_3_linear,
-            q_const
+            "simple", comp_2_3_species, time, solution_3_linear, q_const
         )
 
     def test_plot(self):
@@ -577,21 +534,21 @@ class TestPlot(unittest.TestCase):
             )
 
             self.solution_species.plot(
-                components=['A'],
+                components=["A"],
                 plot_components=True,
                 plot_species=True,
                 plot_total_concentration=True,
             )
 
             self.solution_species.plot(
-                components=['B'],
+                components=["B"],
                 plot_components=True,
                 plot_species=True,
                 plot_total_concentration=True,
             )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     show_plots = True
 
     unittest.main()

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -1,12 +1,14 @@
 import unittest
 
 from CADETProcess.transform import (
-    NullTransformer, NormLinearTransformer, NormLogTransformer, AutoTransformer
+    AutoTransformer,
+    NormLinearTransformer,
+    NormLogTransformer,
+    NullTransformer,
 )
 
 
 class Test_Transformer(unittest.TestCase):
-
     def test_input_range(self):
         transform = NormLinearTransformer(0, 100)
 
@@ -96,21 +98,21 @@ class Test_Transformer(unittest.TestCase):
         self.assertAlmostEqual(out_expected, out)
 
         in_ = 10
-        out_expected = 1/3
+        out_expected = 1 / 3
         out = transform.transform(in_)
         self.assertAlmostEqual(out_expected, out)
 
-        in_ = 1/3
+        in_ = 1 / 3
         out_expected = 10
         out = transform.untransform(in_)
         self.assertAlmostEqual(out_expected, out)
 
         in_ = 100
-        out_expected = 2/3
+        out_expected = 2 / 3
         out = transform.transform(in_)
         self.assertAlmostEqual(out_expected, out)
 
-        in_ = 2/3
+        in_ = 2 / 3
         out_expected = 100
         out = transform.untransform(in_)
         self.assertAlmostEqual(out_expected, out)
@@ -138,5 +140,5 @@ class Test_Transformer(unittest.TestCase):
         self.assertTrue(transform.use_log)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/test_unit_operation.py
+++ b/tests/test_unit_operation.py
@@ -1,22 +1,20 @@
-import pytest
 import numpy as np
-
-from CADETProcess.processModel import ComponentSystem
+import pytest
 from CADETProcess.processModel import (
-    Inlet,
-    Cstr,
-    TubularReactor,
-    LumpedRateModelWithPores,
-    LumpedRateModelWithoutPores,
-    GeneralRateModel,
     MCT,
+    ComponentSystem,
+    Cstr,
+    GeneralRateModel,
+    Inlet,
+    LumpedRateModelWithoutPores,
+    LumpedRateModelWithPores,
+    TubularReactor,
 )
-
 
 length = 0.6
 diameter = 0.024
 
-cross_section_area = np.pi/4 * diameter**2
+cross_section_area = np.pi / 4 * diameter**2
 volume_liquid = cross_section_area * length
 volume = cross_section_area * length
 
@@ -118,31 +116,46 @@ def mct(components=1):
     return mct
 
 
-@pytest.mark.parametrize("unit_operation, expected_geometry", [
-    ("cstr", {
-        "volume_liquid": total_porosity * volume,
-        "volume_solid": (1 - total_porosity) * volume,
-    }),
-    ("lrm", {
-        "cross_section_area": cross_section_area,
-        "total_porosity": total_porosity,
-        "volume": volume,
-        "volume_interstitial": total_porosity * volume,
-        "volume_liquid": total_porosity * volume,
-        "volume_solid": (1 - total_porosity) * volume,
-    }),
-    ("lrmp", {
-        "cross_section_area": cross_section_area,
-        "total_porosity": total_porosity,
-        "volume": volume,
-        "volume_interstitial": bed_porosity * volume,
-        "volume_liquid": total_porosity * volume,
-        "volume_solid": (1 - total_porosity) * volume,
-    }),
-    ("mct", {
-        "volume": length * sum(channel_cross_section_areas),
-    }),
-])
+@pytest.mark.parametrize(
+    "unit_operation, expected_geometry",
+    [
+        (
+            "cstr",
+            {
+                "volume_liquid": total_porosity * volume,
+                "volume_solid": (1 - total_porosity) * volume,
+            },
+        ),
+        (
+            "lrm",
+            {
+                "cross_section_area": cross_section_area,
+                "total_porosity": total_porosity,
+                "volume": volume,
+                "volume_interstitial": total_porosity * volume,
+                "volume_liquid": total_porosity * volume,
+                "volume_solid": (1 - total_porosity) * volume,
+            },
+        ),
+        (
+            "lrmp",
+            {
+                "cross_section_area": cross_section_area,
+                "total_porosity": total_porosity,
+                "volume": volume,
+                "volume_interstitial": bed_porosity * volume,
+                "volume_liquid": total_porosity * volume,
+                "volume_solid": (1 - total_porosity) * volume,
+            },
+        ),
+        (
+            "mct",
+            {
+                "volume": length * sum(channel_cross_section_areas),
+            },
+        ),
+    ],
+)
 def test_geometry(unit_operation, expected_geometry, request):
     unit = request.getfixturevalue(unit_operation)
 
@@ -170,212 +183,219 @@ def test_geometry(unit_operation, expected_geometry, request):
         assert np.isclose(unit.diameter, diameter / (2**0.5))
 
 
-@pytest.mark.parametrize("input_c, expected_c", [
-    (1, np.array([[1, 0, 0, 0], [1, 0, 0, 0]])),
-    ([1, 1], np.array([[1, 0, 0, 0], [1, 0, 0, 0]])),
-    ([1, 2], np.array([[1, 0, 0, 0], [2, 0, 0, 0]])),
-    ([[1, 0], [2, 0]], np.array([[1, 0, 0, 0], [2, 0, 0, 0]])),
-    ([[1, 2], [3, 4]], np.array([[1, 2, 0, 0], [3, 4, 0, 0]])),
-])
+@pytest.mark.parametrize(
+    "input_c, expected_c",
+    [
+        (1, np.array([[1, 0, 0, 0], [1, 0, 0, 0]])),
+        ([1, 1], np.array([[1, 0, 0, 0], [1, 0, 0, 0]])),
+        ([1, 2], np.array([[1, 0, 0, 0], [2, 0, 0, 0]])),
+        ([[1, 0], [2, 0]], np.array([[1, 0, 0, 0], [2, 0, 0, 0]])),
+        ([[1, 2], [3, 4]], np.array([[1, 2, 0, 0], [3, 4, 0, 0]])),
+    ],
+)
 def test_polynomial_inlet_concentration(inlet, input_c, expected_c):
     inlet.c = input_c
     np.testing.assert_equal(inlet.c, expected_c)
 
 
-@pytest.mark.parametrize("unit_operation, input_flow_rate, expected_flow_rate", [
-    ("inlet", 1, np.array([1, 0, 0, 0])),
-    ("inlet", [1, 0], np.array([1, 0, 0, 0])),
-    ("inlet", [1, 1], np.array([1, 1, 0, 0])),
-    ("cstr", 1, np.array([1, 0, 0, 0])),
-    ("cstr", [1, 0], np.array([1, 0, 0, 0])),
-    ("cstr", [1, 1], np.array([1, 1, 0, 0])),
-])
+@pytest.mark.parametrize(
+    "unit_operation, input_flow_rate, expected_flow_rate",
+    [
+        ("inlet", 1, np.array([1, 0, 0, 0])),
+        ("inlet", [1, 0], np.array([1, 0, 0, 0])),
+        ("inlet", [1, 1], np.array([1, 1, 0, 0])),
+        ("cstr", 1, np.array([1, 0, 0, 0])),
+        ("cstr", [1, 0], np.array([1, 0, 0, 0])),
+        ("cstr", [1, 1], np.array([1, 1, 0, 0])),
+    ],
+)
 def test_polynomial_flow_rate(
-        unit_operation,
-        input_flow_rate,
-        expected_flow_rate,
-        request
-        ):
+    unit_operation, input_flow_rate, expected_flow_rate, request
+):
     unit = request.getfixturevalue(unit_operation)
     unit.flow_rate = input_flow_rate
     np.testing.assert_equal(unit.flow_rate, expected_flow_rate)
 
 
-@pytest.mark.parametrize("unit_operation, expected_parameters", [
-    ("cstr", {
-        "flow_rate": np.array([1, 0, 0, 0]),
-        "init_liquid_volume": init_liquid_volume,
-        "flow_rate_filter": 0,
-        "c": [0, 0],
-        "q": None,
-        "const_solid_volume": const_solid_volume,
-    }),
-    ("tubular_reactor", {
-        "length": length,
-        "diameter": diameter,
-        "axial_dispersion": [axial_dispersion, axial_dispersion],
-        "flow_direction": flow_direction,
-        "c": [0, 0],
-        "discretization": {
-            "ncol": 100,
-            "use_analytic_jacobian": True,
-            "reconstruction": "WENO",
-            "weno": {
-                "boundary_model": 0,
-                "weno_eps": 1e-10,
-                "weno_order": 3
+@pytest.mark.parametrize(
+    "unit_operation, expected_parameters",
+    [
+        (
+            "cstr",
+            {
+                "flow_rate": np.array([1, 0, 0, 0]),
+                "init_liquid_volume": init_liquid_volume,
+                "flow_rate_filter": 0,
+                "c": [0, 0],
+                "q": None,
+                "const_solid_volume": const_solid_volume,
             },
-            "consistency_solver": {
-                "solver_name": "LEVMAR",
-                "init_damping": 0.01,
-                "min_damping": 0.0001,
-                "max_iterations": 50,
-                "subsolvers": "LEVMAR"
-            }
-        }
-    }),
-    ("lrm", {
-        "length": length,
-        "diameter": diameter,
-        "total_porosity": total_porosity,
-        "axial_dispersion": [axial_dispersion, axial_dispersion],
-        "flow_direction": flow_direction,
-        "c": [0, 0],
-        "q": None,
-        "discretization": {
-            "ncol": 100,
-            "use_analytic_jacobian": True,
-            "reconstruction": "WENO",
-            "weno": {
-                "boundary_model": 0,
-                "weno_eps": 1e-10,
-                "weno_order": 3
+        ),
+        (
+            "tubular_reactor",
+            {
+                "length": length,
+                "diameter": diameter,
+                "axial_dispersion": [axial_dispersion, axial_dispersion],
+                "flow_direction": flow_direction,
+                "c": [0, 0],
+                "discretization": {
+                    "ncol": 100,
+                    "use_analytic_jacobian": True,
+                    "reconstruction": "WENO",
+                    "weno": {"boundary_model": 0, "weno_eps": 1e-10, "weno_order": 3},
+                    "consistency_solver": {
+                        "solver_name": "LEVMAR",
+                        "init_damping": 0.01,
+                        "min_damping": 0.0001,
+                        "max_iterations": 50,
+                        "subsolvers": "LEVMAR",
+                    },
+                },
             },
-            "consistency_solver": {
-                "solver_name": "LEVMAR",
-                "init_damping": 0.01,
-                "min_damping": 0.0001,
-                "max_iterations": 50,
-                "subsolvers": "LEVMAR"
-            }
-        }
-    }),
-    ("lrmp", {
-        "length": length,
-        "diameter": diameter,
-        "bed_porosity": bed_porosity,
-        "axial_dispersion": [axial_dispersion, axial_dispersion],
-        "pore_accessibility": [1, 1],
-        "film_diffusion": [film_diffusion_0, film_diffusion_1],
-        "particle_radius": particle_radius,
-        "particle_porosity": particle_porosity,
-        "flow_direction": flow_direction,
-        "c": [0, 0],
-        "cp": [0, 0],
-        "q": None,
-        "discretization": {
-            "ncol": 100,
-            "par_geom": "SPHERE",
-            "use_analytic_jacobian": True,
-            "gs_type": True,
-            "max_krylov": 0,
-            "max_restarts": 10,
-            "schur_safety": 1e-08,
-            "reconstruction": "WENO",
-            "weno": {
-                "boundary_model": 0,
-                "weno_eps": 1e-10,
-                "weno_order": 3
+        ),
+        (
+            "lrm",
+            {
+                "length": length,
+                "diameter": diameter,
+                "total_porosity": total_porosity,
+                "axial_dispersion": [axial_dispersion, axial_dispersion],
+                "flow_direction": flow_direction,
+                "c": [0, 0],
+                "q": None,
+                "discretization": {
+                    "ncol": 100,
+                    "use_analytic_jacobian": True,
+                    "reconstruction": "WENO",
+                    "weno": {"boundary_model": 0, "weno_eps": 1e-10, "weno_order": 3},
+                    "consistency_solver": {
+                        "solver_name": "LEVMAR",
+                        "init_damping": 0.01,
+                        "min_damping": 0.0001,
+                        "max_iterations": 50,
+                        "subsolvers": "LEVMAR",
+                    },
+                },
             },
-            "consistency_solver": {
-                "solver_name": "LEVMAR",
-                "init_damping": 0.01,
-                "min_damping": 0.0001,
-                "max_iterations": 50,
-                "subsolvers": "LEVMAR"
-            }
-        }
-    }),
-    ("grm", {
-        "length": length,
-        "diameter": diameter,
-        "bed_porosity": bed_porosity,
-        "axial_dispersion": [axial_dispersion, axial_dispersion],
-        "pore_accessibility": [1, 1],
-        "film_diffusion": [film_diffusion_0, film_diffusion_1],
-        "particle_radius": particle_radius,
-        "particle_porosity": particle_porosity,
-        "pore_diffusion": [pore_diffusion_0, pore_diffusion_1],
-        "surface_diffusion": None,
-        "flow_direction": flow_direction,
-        "c": [0, 0],
-        "cp": [0, 0],
-        "q": None,
-        "discretization": {
-            "ncol": 100,
-            "par_geom": "SPHERE",
-            "npar": 5,
-            "par_disc_type": "EQUIDISTANT_PAR",
-            "par_boundary_order": 2,
-            "fix_zero_surface_diffusion": False,
-            "use_analytic_jacobian": True,
-            "gs_type": True,
-            "max_krylov": 0,
-            "max_restarts": 10,
-            "schur_safety": 1e-08,
-            "reconstruction": "WENO",
-            "weno": {
-                "boundary_model": 0,
-                "weno_eps": 1e-10,
-                "weno_order": 3
+        ),
+        (
+            "lrmp",
+            {
+                "length": length,
+                "diameter": diameter,
+                "bed_porosity": bed_porosity,
+                "axial_dispersion": [axial_dispersion, axial_dispersion],
+                "pore_accessibility": [1, 1],
+                "film_diffusion": [film_diffusion_0, film_diffusion_1],
+                "particle_radius": particle_radius,
+                "particle_porosity": particle_porosity,
+                "flow_direction": flow_direction,
+                "c": [0, 0],
+                "cp": [0, 0],
+                "q": None,
+                "discretization": {
+                    "ncol": 100,
+                    "par_geom": "SPHERE",
+                    "use_analytic_jacobian": True,
+                    "gs_type": True,
+                    "max_krylov": 0,
+                    "max_restarts": 10,
+                    "schur_safety": 1e-08,
+                    "reconstruction": "WENO",
+                    "weno": {"boundary_model": 0, "weno_eps": 1e-10, "weno_order": 3},
+                    "consistency_solver": {
+                        "solver_name": "LEVMAR",
+                        "init_damping": 0.01,
+                        "min_damping": 0.0001,
+                        "max_iterations": 50,
+                        "subsolvers": "LEVMAR",
+                    },
+                },
             },
-            "consistency_solver": {
-                "solver_name": "LEVMAR",
-                "init_damping": 0.01,
-                "min_damping": 0.0001,
-                "max_iterations": 50,
-                "subsolvers": "LEVMAR"
-            }
-        }
-    }),
-    ("mct", {
-        "nchannel": nchannel,
-        "length": length,
-        "channel_cross_section_areas": channel_cross_section_areas,
-        "axial_dispersion": nchannel * [axial_dispersion],
-        "exchange_matrix": exchange_matrix,
-        "flow_direction": 1,
-        "c": [[0, 0, 0]],
-        "discretization": {
-            "ncol": 100,
-            "use_analytic_jacobian": True,
-            "reconstruction": "WENO",
-            "weno": {
-                "boundary_model": 0,
-                "weno_eps": 1e-10,
-                "weno_order": 3
+        ),
+        (
+            "grm",
+            {
+                "length": length,
+                "diameter": diameter,
+                "bed_porosity": bed_porosity,
+                "axial_dispersion": [axial_dispersion, axial_dispersion],
+                "pore_accessibility": [1, 1],
+                "film_diffusion": [film_diffusion_0, film_diffusion_1],
+                "particle_radius": particle_radius,
+                "particle_porosity": particle_porosity,
+                "pore_diffusion": [pore_diffusion_0, pore_diffusion_1],
+                "surface_diffusion": None,
+                "flow_direction": flow_direction,
+                "c": [0, 0],
+                "cp": [0, 0],
+                "q": None,
+                "discretization": {
+                    "ncol": 100,
+                    "par_geom": "SPHERE",
+                    "npar": 5,
+                    "par_disc_type": "EQUIDISTANT_PAR",
+                    "par_boundary_order": 2,
+                    "fix_zero_surface_diffusion": False,
+                    "use_analytic_jacobian": True,
+                    "gs_type": True,
+                    "max_krylov": 0,
+                    "max_restarts": 10,
+                    "schur_safety": 1e-08,
+                    "reconstruction": "WENO",
+                    "weno": {"boundary_model": 0, "weno_eps": 1e-10, "weno_order": 3},
+                    "consistency_solver": {
+                        "solver_name": "LEVMAR",
+                        "init_damping": 0.01,
+                        "min_damping": 0.0001,
+                        "max_iterations": 50,
+                        "subsolvers": "LEVMAR",
+                    },
+                },
             },
-            "consistency_solver": {
-                "solver_name": "LEVMAR",
-                "init_damping": 0.01,
-                "min_damping": 0.0001,
-                "max_iterations": 50,
-                "subsolvers": "LEVMAR"
-            }
-        }
-    }),
-])
+        ),
+        (
+            "mct",
+            {
+                "nchannel": nchannel,
+                "length": length,
+                "channel_cross_section_areas": channel_cross_section_areas,
+                "axial_dispersion": nchannel * [axial_dispersion],
+                "exchange_matrix": exchange_matrix,
+                "flow_direction": 1,
+                "c": [[0, 0, 0]],
+                "discretization": {
+                    "ncol": 100,
+                    "use_analytic_jacobian": True,
+                    "reconstruction": "WENO",
+                    "weno": {"boundary_model": 0, "weno_eps": 1e-10, "weno_order": 3},
+                    "consistency_solver": {
+                        "solver_name": "LEVMAR",
+                        "init_damping": 0.01,
+                        "min_damping": 0.0001,
+                        "max_iterations": 50,
+                        "subsolvers": "LEVMAR",
+                    },
+                },
+            },
+        ),
+    ],
+)
 def test_parameters(unit_operation, expected_parameters, request):
     unit = request.getfixturevalue(unit_operation)
     np.testing.assert_equal(expected_parameters, unit.parameters)
 
 
-@pytest.mark.parametrize("unit_operation, flow_rate, expected_velocity", [
-    ("tubular_reactor", 2, 2),
-    ("lrmp", 2, 4),
-    ("tubular_reactor", 0, ZeroDivisionError),
-    ("lrmp", 0, ZeroDivisionError),
-])
+@pytest.mark.parametrize(
+    "unit_operation, flow_rate, expected_velocity",
+    [
+        ("tubular_reactor", 2, 2),
+        ("lrmp", 2, 4),
+        ("tubular_reactor", 0, ZeroDivisionError),
+        ("lrmp", 0, ZeroDivisionError),
+    ],
+)
 def test_interstitial_velocity(unit_operation, flow_rate, expected_velocity, request):
     unit = request.getfixturevalue(unit_operation)
     unit.length = 1
@@ -385,7 +405,7 @@ def test_interstitial_velocity(unit_operation, flow_rate, expected_velocity, req
     if unit_operation == "lrmp":
         unit.bed_porosity = 0.5
 
-    if expected_velocity == ZeroDivisionError:
+    if expected_velocity is ZeroDivisionError:
         with pytest.raises(ZeroDivisionError):
             unit.calculate_interstitial_velocity(flow_rate)
     else:
@@ -394,12 +414,15 @@ def test_interstitial_velocity(unit_operation, flow_rate, expected_velocity, req
         )
 
 
-@pytest.mark.parametrize("unit_operation, flow_rate, expected_velocity", [
-    ("tubular_reactor", 2, 2),
-    ("lrmp", 2, 2),
-    ("tubular_reactor", 0, ZeroDivisionError),
-    ("lrmp", 0, ZeroDivisionError),
-])
+@pytest.mark.parametrize(
+    "unit_operation, flow_rate, expected_velocity",
+    [
+        ("tubular_reactor", 2, 2),
+        ("lrmp", 2, 2),
+        ("tubular_reactor", 0, ZeroDivisionError),
+        ("lrmp", 0, ZeroDivisionError),
+    ],
+)
 def test_superficial_velocity(unit_operation, flow_rate, expected_velocity, request):
     unit = request.getfixturevalue(unit_operation)
     unit.length = 1
@@ -408,7 +431,7 @@ def test_superficial_velocity(unit_operation, flow_rate, expected_velocity, requ
     if unit_operation == "lrmp":
         unit.bed_porosity = 0.5
 
-    if expected_velocity == ZeroDivisionError:
+    if expected_velocity is ZeroDivisionError:
         with pytest.raises(ZeroDivisionError):
             unit.calculate_superficial_velocity(flow_rate)
     else:
@@ -417,17 +440,20 @@ def test_superficial_velocity(unit_operation, flow_rate, expected_velocity, requ
         )
 
 
-@pytest.mark.parametrize("unit_operation, flow_rate, expected_ntp", [
-    ("tubular_reactor", 2, [1/3, 1/3]),
-    ("tubular_reactor", 0, ZeroDivisionError),
-])
+@pytest.mark.parametrize(
+    "unit_operation, flow_rate, expected_ntp",
+    [
+        ("tubular_reactor", 2, [1 / 3, 1 / 3]),
+        ("tubular_reactor", 0, ZeroDivisionError),
+    ],
+)
 def test_ntp(unit_operation, flow_rate, expected_ntp, request):
     unit = request.getfixturevalue(unit_operation)
     unit.length = 1
     unit.cross_section_area = 1
     unit.axial_dispersion = 3
 
-    if expected_ntp == ZeroDivisionError:
+    if expected_ntp is ZeroDivisionError:
         with pytest.raises(ZeroDivisionError):
             unit.NTP(flow_rate)
     else:
@@ -435,19 +461,16 @@ def test_ntp(unit_operation, flow_rate, expected_ntp, request):
 
 
 @pytest.mark.parametrize(
-    "unit_operation, flow_rate, axial_dispersion, expected_bodenstein", [
-        ("tubular_reactor", 2, 3, [2/3, 2/3]),
-        ("lrmp", 2, [3, 2], [4/3, 2]),
+    "unit_operation, flow_rate, axial_dispersion, expected_bodenstein",
+    [
+        ("tubular_reactor", 2, 3, [2 / 3, 2 / 3]),
+        ("lrmp", 2, [3, 2], [4 / 3, 2]),
         ("lrmp", 2, [1, 2], [4, 2]),
-    ]
+    ],
 )
 def test_bodenstein_number(
-        unit_operation,
-        flow_rate,
-        axial_dispersion,
-        expected_bodenstein,
-        request
-        ):
+    unit_operation, flow_rate, axial_dispersion, expected_bodenstein, request
+):
     unit = request.getfixturevalue(unit_operation)
     unit.length = 1
     unit.cross_section_area = 1


### PR DESCRIPTION
Currently CADET-Process doesn't enforce unified coding style rules within the entire code. This is a first attempt  to define some coding style rules that we want to check with ruff.linter and maybe later even use ruff.format to automaticly enforce these rules.
First off some tasks have to be done:

- [x]  agree on linter rules
- [x]  only src of "CADET-Process" or also use the "tests"
- [x]  ruff/linter pipeline

## Rules / Settings

### General Linting Rules

- **E and W**: These are typical Pycodestyle rules, addressing issues like the use of tabs mixed with spaces, and ensuring proper whitespace between operators, among others.
- **F**: These are Pyflakes rules, which check for issues related to imports, f-strings, unused imports, and more.
- **D**: This set of rules pertains to docstrings. Docstrings are enforced for all public classes, functions, methods, and packages, with the exception of modules. Rules `D100`, `D212`, and `D203` are excluded. We enforce a descriptive imperative sentence at the start of every docstring. Module docstrings are excluded due to compatibility issues with Sphinx docstrings that do not conform to standard rules. To exclude a docstring from Ruff checking, use `# noqa`.
- **ANN**: This rule enforces type checking for nearly all public and private functions and methods. Rule `ANN401` is excluded because there are many cases where using `Type[Any]` is more convenient. We may include this rule at a later time.
- **I**: This rule ensure that imports are correctly sorted and grouped according to the specified categories: standard library, third-party, and first-party imports."
- For all test files, docstring and annotation rules are disabled, as well as `E731` and `E402` (module import not at the top and some lambda assignments).

### Line Length

- `line-length = 88` within `tool.ruff`
- `max-line-length = 100` within `tool.ruff.lint.pydocstyle`
- `max-doc-length = 94` within `tool.ruff.lint.pydocstyle`

Note that `max-line-length = 100` is the maximum line length that the Ruff linter accepts, while `max-doc-length` is the maximum line length for docstrings. The `line-length = 88` option is intended for a formatter. In theory, if we add the Ruff formatter, it will attempt to break lines to stay within this boundary. In the future, `line-length` will serve as the default value, and `max-line-length` will act as a buffer if the formatter is unable to break lines accordingly.