### PR TITLE
Use XDG Base Directory Specification for tmp and cache directories

### DIFF
--- a/CADETProcess/hashing.py
+++ b/CADETProcess/hashing.py
@@ -1,0 +1,27 @@
+import hashlib
+from typing import Any
+
+
+def digest_string(obj: Any, length: int = 8) -> str:
+    """
+    Compute a short digest of a string.
+
+    Parameters
+    ----------
+    obj : Any
+        Input to digest. Will be converted to string.
+    length : int, optional
+        Length of the returned digest (default is 8).
+
+    Returns
+    -------
+    digest : str
+        Hexadecimal string digest of the input.
+
+    Examples
+    --------
+    >>> digest_string("hello world")
+    'b94d27b9'
+    """
+    s = str(obj)
+    return hashlib.sha256(s.encode()).hexdigest()[:length]

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -1,7 +1,9 @@
 import copy
 from functools import wraps
+import hashlib
 import inspect
 import math
+import os
 from pathlib import Path
 import random
 import shutil
@@ -15,6 +17,7 @@ import numpy as np
 import numpy.typing as npt
 
 from CADETProcess import CADETProcessError
+from CADETProcess.hashing import digest_string
 from CADETProcess import log
 from CADETProcess import settings
 
@@ -2759,7 +2762,13 @@ class OptimizationProblem(Structure):
     def cache_directory(self):
         """pathlib.Path: Path for results cache database."""
         if self._cache_directory is None:
-            _cache_directory = settings.working_directory / f'diskcache_{self.name}'
+            if 'XDG_CACHE_HOME' in os.environ:
+                _cache_directory = (
+                    Path(os.environ['XDG_CACHE_HOME']) / 'CADET-Process' /
+                    digest_string(settings.working_directory) / f'diskcache_{self.name}'
+                )
+            else:
+                _cache_directory = settings.working_directory / f'diskcache_{self.name}'
         else:
             _cache_directory = Path(self._cache_directory).absolute()
 

--- a/CADETProcess/settings.py
+++ b/CADETProcess/settings.py
@@ -13,7 +13,7 @@ This module provides functionality for general settings.
     Settings
 
 """
-
+import os
 from pathlib import Path
 import shutil
 import tempfile
@@ -120,7 +120,10 @@ class Settings(Structure):
     def temp_dir(self):
         """pathlib.Path: Directory for temporary files."""
         if self._temp_dir is None:
-            _temp_dir = self.working_directory / 'tmp'
+            if 'XDG_RUNTIME_DIR' in os.environ:
+                _temp_dir = Path(os.environ['XDG_RUNTIME_DIR']) / 'CADET-Process'
+            else:
+                _temp_dir = self.working_directory / 'tmp'
         else:
             _temp_dir = Path(self._temp_dir).absolute()
 


### PR DESCRIPTION
Setting the location for the `optimizationProblem.cache_directory` and `settings.temp_dir` can be unwieldy, e.g. when running optimizations on alternating systems (such as the IBT servers or a personal device) or when running the example library on the IBT server (because the example library should not contain config information about the IBT server localstorage details).

This PR suggests using environment variables, specifically the XDG Base Directory specification to choose the tmp and cache folders.

I think this PR might cause problems if two optimization problems with the same name are run at the same time on the same system. Is that a use-case we want to allow?