### PR TITLE
Sideload examples in documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 .pytest_cache/
 .ipynb_checkpoints
 docs/source/reference/generated/*
+docs/_tmp
 docs/build/*
 docs/jupyter_execute/*
 docs/source/reference/generated/*

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,8 @@ build:
   jobs:
     install:
       - pip install .[all] --group docs
+    build:
+      - python docs/source/load_studies.py
 
 # Build documentation in the docs/ directory with Sphinx
 sphinx:

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -286,7 +286,11 @@ class Fractionator(EventHandler):
             end = np.max(chromatogram.time)
 
         fig, ax = chromatogram.plot(
-            ax=ax, x_axis_in_minutes=x_axis_in_minutes, *args, **kwargs
+            ax=ax,
+            x_axis_in_minutes=x_axis_in_minutes,
+            show=False,
+            *args,
+            **kwargs,
         )
 
         y_max = 1.1 * np.max(chromatogram.solution)

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -269,32 +269,33 @@ class OptimizerBase(Structure):
             if not flag:
                 raise ValueError("x0 contains invalid entries.")
 
-        log.log_time("Optimization", self.logger.level)(self._run)
-        log.log_results("Optimization", self.logger.level)(self._run)
-        log.log_exceptions("Optimization", self.logger.level)(self._run)
+        try:
+            log.log_time("Optimization", self.logger.level)(self._run)
+            log.log_results("Optimization", self.logger.level)(self._run)
+            log.log_exceptions("Optimization", self.logger.level)(self._run)
 
-        backend = plt.get_backend()
-        plt.switch_backend("agg")
+            backend = plt.get_backend()
+            plt.switch_backend("agg")
 
-        start = time.time()
-        self._run(self.optimization_problem, x0, *args, **kwargs)
-        time_elapsed = time.time() - start
+            start = time.time()
+            self._run(self.optimization_problem, x0, *args, **kwargs)
+            time_elapsed = time.time() - start
 
-        self.results.time_elapsed = time_elapsed
-        self.results.cpu_time = self.n_cores * time_elapsed
+            self.results.time_elapsed = time_elapsed
+            self.results.cpu_time = self.n_cores * time_elapsed
 
-        self.run_final_processing()
+            self.run_final_processing()
 
-        if delete_cache:
-            optimization_problem.delete_cache(reinit=True)
-        self._current_cache_entries = []
+            if delete_cache:
+                optimization_problem.delete_cache(reinit=True)
+            self._current_cache_entries = []
 
-        plt.switch_backend(backend)
-
-        if not self.results.success:
-            raise CADETProcessError(
-                f"Optimizaton failed with message: {self.results.exit_message}"
-            )
+            if not self.results.success:
+                raise CADETProcessError(
+                    f"Optimizaton failed with message: {self.results.exit_message}"
+                )
+        finally:
+            plt.switch_backend(backend)
 
         return self.results
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,6 +13,9 @@
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../..'))
+from pathlib import Path
+from glob import glob
+import subprocess
 from datetime import date
 
 # -- Project information -----------------------------------------------------
@@ -36,7 +39,8 @@ extensions = []
 
 ## MyST-NB
 extensions.append("myst_nb")
-nb_execution_mode = "cache"
+nb_execution_mode = "auto"
+nb_execution_excludepatterns = ["case_studies/**"]
 source_suffix = {
     '.rst': 'restructuredtext',
     '.ipynb': 'myst-nb',
@@ -131,7 +135,18 @@ html_sidebars = {
 # so a file named "default.css" will overwrite the builtin "default.css".
 html_static_path = ["_static"]
 
+# -- Case Studies -------------------------------------------------
+
 # Copy examples
 import shutil
 shutil.rmtree('./examples', ignore_errors=True)
 shutil.copytree('../../examples', './examples/')
+
+# Load in studies locally
+if not os.environ.get("READTHEDOCS"):
+    script = Path(__file__).resolve().parent / "load_studies.py"
+    res = subprocess.run([sys.executable, str(script)], capture_output=True, text=True)
+    if res.returncode != 0:
+        print(res.stdout)
+        print(res.stderr)
+        raise RuntimeError("load_studies.py failed")

--- a/docs/source/load_studies.py
+++ b/docs/source/load_studies.py
@@ -313,9 +313,12 @@ def load_study_results(
         nb.resolve().relative_to(DOCS_SOURCE).with_suffix("").as_posix()
         for nb in notebooks
     ]
-    index_docs = [d for d in docnames if d.endswith("/index")]
-    return index_docs if index_docs else docnames
 
+    study_index = (target / "index.ipynb").resolve()
+    if study_index.exists():
+        return [study_index.relative_to(DOCS_SOURCE).with_suffix("").as_posix()]
+
+    return docnames
 
 def main() -> None:
     """
@@ -340,6 +343,7 @@ def main() -> None:
     ]
 
     toc_docnames: list[str] = []
+
     for url, project_ref, output_ref in studies:
         name = url.split("/")[-1].replace(".git", "").replace("RDM-Example-", "")
         toc_docnames.extend(

--- a/docs/source/load_studies.py
+++ b/docs/source/load_studies.py
@@ -1,0 +1,358 @@
+ #!/usr/bin/env python3
+"""
+Load and prepare case study notebooks for documentation builds.
+
+This script is intended to be run before Sphinx builds, both locally and in CI.
+
+Workflow
+--------
+1. Clone or update each study project repository into ``../_tmp/study_root/<name>``.
+2. Check out the requested ``project_ref`` in the project repository.
+3. Check out the requested ``output_ref`` in the corresponding output repository at
+   ``<project>/output``.
+4. Read ``<project>/output/options.json`` to determine the directory containing the
+   case study sources (key: ``source_directory``).
+5. Copy that directory into ``docs/source/case_studies/<name>`` using an atomic replace
+   to avoid stale or mixed content.
+6. Set copied notebook metadata so MyST-NB does not execute them during docs builds.
+7. Update the Case Studies toctree in ``docs/source/index.md`` (visible list).
+
+Notes
+-----
+- Only HTTPS repository URLs are supported.
+- This script only writes to ``docs/source/case_studies`` and does not touch legacy
+  content in ``docs/examples``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import platform
+import re
+import shutil
+import stat
+from glob import glob
+from pathlib import Path
+from typing import Iterable, Sequence
+
+import git
+import nbformat as nbf
+from cadetrdm import ProjectRepo
+
+DOCS_SOURCE = Path(__file__).resolve().parent
+os.chdir(DOCS_SOURCE)
+
+
+def delete_path(path: Path) -> None:
+    """
+    Remove a file or directory if it exists.
+
+    Parameters
+    ----------
+    path
+        File or directory to remove.
+    """
+    if not path.exists():
+        return
+    if path.is_dir():
+        shutil.rmtree(path)
+    else:
+        path.unlink()
+
+
+def checkout_ref(repo_dir: Path, ref: str) -> None:
+    """
+    Check out a ref in an existing git repository directory.
+
+    This supports commit hashes, tags, local branches, and remote branches (fallback
+    to ``origin/<ref>``).
+
+    Parameters
+    ----------
+    repo_dir
+        Path to the git repository directory.
+    ref
+        Ref to check out.
+
+    Raises
+    ------
+    RuntimeError
+        If the ref cannot be checked out.
+    """
+    repo = git.Repo(repo_dir)
+    repo.git.fetch("--prune", "--tags")
+
+    try:
+        repo.git.checkout(ref)
+        return
+    except git.exc.GitCommandError:
+        pass
+
+    try:
+        repo.git.checkout("-B", ref, f"origin/{ref}")
+    except git.exc.GitCommandError as exc:
+        raise RuntimeError(f"Ref not found: {ref} in {repo_dir}") from exc
+
+
+def read_source_directory_from_options(output_dir: Path) -> str:
+    """
+    Read ``options.json`` in the output repository and return the source directory.
+
+    Parameters
+    ----------
+    output_dir
+        Path to the output repository directory (``<project>/output``).
+
+    Returns
+    -------
+    str
+        The value of ``source_directory``.
+
+    Raises
+    ------
+    RuntimeError
+        If ``options.json`` is missing or does not contain a valid ``source_directory``.
+    """
+    options_path = output_dir / "options.json"
+    if not options_path.exists():
+        raise RuntimeError(f"Missing options.json in {output_dir}")
+
+    data = json.loads(options_path.read_text(encoding="utf-8"))
+    source_dir = data.get("source_directory")
+    if not isinstance(source_dir, str) or not source_dir.strip():
+        raise RuntimeError(f"options.json missing valid source_directory in {output_dir}")
+
+    return source_dir
+
+
+def set_execution_mode_to_off(notebooks: Iterable[Path]) -> None:
+    """
+    Disable execution for notebooks by setting MyST-NB metadata.
+
+    Parameters
+    ----------
+    notebooks
+        Iterable of notebook paths to patch.
+    """
+    for nb_path in notebooks:
+        try:
+            mode = nb_path.stat().st_mode
+            os.chmod(nb_path, mode | stat.S_IRUSR | stat.S_IWUSR)
+        except OSError:
+            pass
+
+        ntbk = nbf.read(nb_path, nbf.NO_CONVERT)
+        ntbk.metadata["mystnb"] = {"execution_mode": "off"}
+
+        with open(nb_path, "w", encoding="utf-8") as f:
+            nbf.write(ntbk, f)
+
+
+def update_index_with_study_tocs(docnames: Sequence[str], *, index_path: Path) -> None:
+    """
+    Update the Case Studies toctree in index.md by preserving existing entries and
+    appending generated docnames (without duplicates).
+
+    This keeps manually maintained entries such as `examples/...` and adds the new
+    case studies afterwards.
+
+    Parameters
+    ----------
+    docnames
+        Docnames (relative to docs/source) to include in the Case Studies toctree.
+        Docnames must not include file extensions.
+    index_path
+        Path to docs/source/index.md.
+
+    Raises
+    ------
+    RuntimeError
+        If the Case Studies toctree block cannot be found.
+    """
+    content = index_path.read_text(encoding="utf-8")
+
+    # Find a fenced MyST toctree block that contains ":caption: Case Studies"
+    # We match:
+    #   ```{toctree}
+    #   ... any lines ...
+    #   ```
+    block_re = re.compile(r"```{toctree}\n.*?\n```\n", flags=re.DOTALL)
+    blocks = list(block_re.finditer(content))
+
+    target_match = None
+    for m in blocks:
+        block_text = m.group(0)
+        if ":caption: Case Studies" in block_text:
+            target_match = m
+            break
+
+    if target_match is None:
+        raise RuntimeError("Could not find a ```{toctree} block with ':caption: Case Studies'")
+
+    block = target_match.group(0)
+    lines = block.splitlines(keepends=False)
+
+    # Preserve the opening and closing fences
+    opening = lines[0]  # ```{toctree}
+    closing = lines[-1]  # ```
+
+    middle = lines[1:-1]
+
+    # Separate option lines (start with ":") from entry lines
+    option_lines: list[str] = []
+    entry_lines: list[str] = []
+
+    for line in middle:
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if stripped.startswith("<!--") and stripped.endswith("-->"):
+            continue
+        if stripped.startswith(":"):
+            option_lines.append(stripped)
+        else:
+            entry_lines.append(stripped)
+
+    # Merge entries: keep existing first, then add new docnames not already present
+    merged_entries = list(entry_lines)
+    for d in docnames:
+        if d not in merged_entries:
+            merged_entries.append(d)
+
+    # Rebuild the block.
+    # Keep options exactly as options, and keep the block visible (do not add :hidden:).
+    # If you want to preserve an existing :hidden:, remove the filtering below.
+    option_lines = [opt for opt in option_lines if opt != ":hidden:"]
+
+    rebuilt_lines: list[str] = [opening]
+    rebuilt_lines.extend(option_lines)
+    rebuilt_lines.append("")  # blank line between options and entries
+    rebuilt_lines.extend(merged_entries)
+    rebuilt_lines.append(closing)
+    rebuilt = "\n".join(rebuilt_lines) + "\n"
+
+    updated = content[: target_match.start()] + rebuilt + content[target_match.end() :]
+    index_path.write_text(updated, encoding="utf-8")
+
+
+def _windows_ignore_comparison_plots():
+    if platform.system() != "Windows":
+        return None
+
+    def ignore(_src: str, names: Sequence[str]) -> list[str]:
+        return [n for n in names if "_comparison.png" in n]
+
+    return ignore
+
+
+def load_study_results(
+    *,
+    name: str,
+    study_url: str,
+    project_ref: str,
+    output_ref: str,
+    study_root: Path,
+    case_studies_root: Path,
+) -> list[str]:
+    """
+    Load a single study and return docnames for the Case Studies toctree.
+
+    Parameters
+    ----------
+    name
+        Local study folder name used under ``study_root`` and ``case_studies_root``.
+    study_url
+        HTTPS URL of the study project repository.
+    project_ref
+        Ref to check out in the project repository (typically ``"main"``).
+    output_ref
+        Ref to check out in the output repository at ``<project>/output``.
+    study_root
+        Root directory where project repositories are cloned.
+    case_studies_root
+        Target directory for generated case studies (``docs/source/case_studies``).
+
+    Returns
+    -------
+    list[str]
+        Docnames (relative to ``docs/source``) for notebooks to include in the toctree.
+    """
+    if not study_url.startswith("https://"):
+        raise ValueError(f"Only HTTPS URLs are supported: {study_url}")
+
+    project_repo = ProjectRepo(path=study_root / name, url=study_url, branch="main")
+    project_repo.update()
+
+    checkout_ref(project_repo.path, project_ref)
+
+    output_dir = project_repo.path / "output"
+    if not output_dir.exists():
+        raise RuntimeError(f"Expected output repo at {output_dir}")
+
+    checkout_ref(output_dir, output_ref)
+
+    source_dir_name = read_source_directory_from_options(output_dir)
+    src = output_dir / source_dir_name
+    if not src.exists():
+        raise RuntimeError(f"Source directory not found: {src}")
+
+    target = case_studies_root / name
+    tmp_target = target.with_name(f"{target.name}.__tmp__")
+
+    delete_path(tmp_target)
+    shutil.copytree(src, tmp_target, ignore=_windows_ignore_comparison_plots())
+
+    delete_path(target)
+    tmp_target.rename(target)
+
+    notebooks = [Path(p) for p in glob((target / "**/*.ipynb").as_posix(), recursive=True)]
+    set_execution_mode_to_off(notebooks)
+
+    docnames = [
+        nb.resolve().relative_to(DOCS_SOURCE).with_suffix("").as_posix()
+        for nb in notebooks
+    ]
+    index_docs = [d for d in docnames if d.endswith("/index")]
+    return index_docs if index_docs else docnames
+
+
+def main() -> None:
+    """
+    Run the case study loader for all configured studies and update the documentation index.
+    """
+    index_path = DOCS_SOURCE / "index.md"
+    study_root = DOCS_SOURCE / "../_tmp/study_root"
+    case_studies_root = DOCS_SOURCE / "case_studies"
+    case_studies_root.mkdir(parents=True, exist_ok=True)
+
+    studies: list[tuple[str, str, str]] = [
+        (
+            "https://github.com/cadet/RDM-Example-Multi-State-Steric-Mass-Action.git",
+            "main",
+            "2026-02-11_10-29-35_main_43e61e8",
+        ),
+    ]
+
+    toc_docnames: list[str] = []
+    for url, project_ref, output_ref in studies:
+        name = url.split("/")[-1].replace(".git", "").replace("RDM-Example-", "")
+        toc_docnames.extend(
+            load_study_results(
+                name=name,
+                study_url=url,
+                project_ref=project_ref,
+                output_ref=output_ref,
+                study_root=study_root,
+                case_studies_root=case_studies_root,
+            )
+        )
+
+    update_index_with_study_tocs(toc_docnames, index_path=index_path)
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as exc:
+        raise SystemExit(f"load_studies.py failed: {exc}") from exc

--- a/docs/source/load_studies.py
+++ b/docs/source/load_studies.py
@@ -331,14 +331,19 @@ def main() -> None:
 
     studies: list[tuple[str, str, str]] = [
         (
-            "https://github.com/cadet/RDM-Example-Multi-State-Steric-Mass-Action.git",
+            "https://github.com/cadet/RDM-Example-Multi-State-Steric-Mass-Action",
             "main",
             "2026-02-11_14-11-23_main_406bbee",
         ),
         (
             "https://github.com/cadet/RDM-Example-Rectangular-Pulse",
             "main",
-            "2026-02-03_15-30-39_main_0e5f840",
+            "2026-03-06_10-01-32_main_b2115b3",
+        ),
+        (
+            "https://github.com/cadet/RDM-Example-Simulated-Moving-Bed",
+            "main",
+            "2026-03-26_11-09-10_main_3a25a18_108b0d",
         ),
     ]
 

--- a/docs/source/load_studies.py
+++ b/docs/source/load_studies.py
@@ -332,6 +332,11 @@ def main() -> None:
             "main",
             "2026-02-11_14-11-23_main_406bbee",
         ),
+        (
+            "https://github.com/cadet/RDM-Example-Rectangular-Pulse",
+            "main",
+            "2026-02-03_15-30-39_main_0e5f840",
+        ),
     ]
 
     toc_docnames: list[str] = []

--- a/docs/source/load_studies.py
+++ b/docs/source/load_studies.py
@@ -330,7 +330,7 @@ def main() -> None:
         (
             "https://github.com/cadet/RDM-Example-Multi-State-Steric-Mass-Action.git",
             "main",
-            "2026-02-11_10-29-35_main_43e61e8",
+            "2026-02-11_14-11-23_main_406bbee",
         ),
     ]
 

--- a/examples/load_wash_elute/index.md
+++ b/examples/load_wash_elute/index.md
@@ -40,11 +40,10 @@ process_simulator = Cadet()
 simulation_results = process_simulator.simulate(process)
 
 from CADETProcess.plotting import SecondaryAxis
-sec = SecondaryAxis()
-sec.components = ['Salt']
+sec = SecondaryAxis(components = ['Salt'])
 sec.y_label = '$c_{salt}$'
 
-_ = simulation_results.solution.column.inlet.plot(secondary_axis=sec)
+_ = simulation_results.solution.column.inlet.plot(secondary_axes=sec)
 ```
 
 In **CADET-Process**, gradients can be used by either changing the concentration profile of an {class}`~CADETProcess.processModel.Inlet` or by adding multiple inlets and dynamically adjusting their flow rates.

--- a/examples/load_wash_elute/lwe_concentration.md
+++ b/examples/load_wash_elute/lwe_concentration.md
@@ -110,9 +110,8 @@ if __name__ == '__main__':
     simulation_results = process_simulator.simulate(process)
 
     from CADETProcess.plotting import SecondaryAxis
-    sec = SecondaryAxis()
-    sec.components = ['Salt']
+    sec = SecondaryAxis(components = ['Salt'])
     sec.y_label = '$c_{salt}$'
 
-    simulation_results.solution.column.outlet.plot(secondary_axis=sec)
+    simulation_results.solution.column.outlet.plot(secondary_axes=sec)
 ```

--- a/examples/load_wash_elute/lwe_concentration.py
+++ b/examples/load_wash_elute/lwe_concentration.py
@@ -111,8 +111,7 @@ if __name__ == '__main__':
     simulation_results = process_simulator.simulate(process)
 
     from CADETProcess.plotting import SecondaryAxis
-    sec = SecondaryAxis()
-    sec.components = ['Salt']
+    sec = SecondaryAxis(components = ['Salt'])
     sec.y_label = '$c_{salt}$'
 
-    simulation_results.solution.column.outlet.plot(secondary_axis=sec)
+    simulation_results.solution.column.outlet.plot(secondary_axes=sec)

--- a/examples/load_wash_elute/lwe_flow_rate.md
+++ b/examples/load_wash_elute/lwe_flow_rate.md
@@ -136,9 +136,8 @@ if __name__ == '__main__':
     simulation_results = process_simulator.simulate(process)
 
     from CADETProcess.plotting import SecondaryAxis
-    sec = SecondaryAxis()
-    sec.components = ['Salt']
+    sec = SecondaryAxis(components = ['Salt'])
     sec.y_label = '$c_{salt}$'
 
-    simulation_results.solution.column.outlet.plot(secondary_axis=sec)
+    _ = simulation_results.solution.column.outlet.plot(secondary_axes=sec, setup_figure_kwargs={"layout": "2_col"});
 ```

--- a/examples/load_wash_elute/lwe_flow_rate.py
+++ b/examples/load_wash_elute/lwe_flow_rate.py
@@ -137,8 +137,9 @@ if __name__ == '__main__':
     simulation_results = process_simulator.simulate(process)
 
     from CADETProcess.plotting import SecondaryAxis
-    sec = SecondaryAxis()
-    sec.components = ['Salt']
+    sec = SecondaryAxis(components = ['Salt'])
     sec.y_label = '$c_{salt}$'
 
-    simulation_results.solution.column.outlet.plot(secondary_axis=sec)
+    fig = simulation_results.solution.column.outlet.plot(secondary_axes=sec, setup_figure_kwargs={"layout": "2_col"})
+
+# %%

--- a/examples/load_wash_elute/lwe_hic.md
+++ b/examples/load_wash_elute/lwe_hic.md
@@ -120,9 +120,8 @@ if __name__ == '__main__':
 
     from CADETProcess.plotting import SecondaryAxis
 
-    sec = SecondaryAxis()
-    sec.components = ['Salt']
+    sec = SecondaryAxis(components = ['Salt'])
     sec.y_label = '$c_{salt}$'
 
-    simulation_results.solution.column.outlet.plot(secondary_axis=sec)
+    simulation_results.solution.column.outlet.plot(secondary_axes=sec)
 ```

--- a/examples/load_wash_elute/lwe_hic.py
+++ b/examples/load_wash_elute/lwe_hic.py
@@ -121,8 +121,7 @@ if __name__ == '__main__':
 
     from CADETProcess.plotting import SecondaryAxis
 
-    sec = SecondaryAxis()
-    sec.components = ['Salt']
+    sec = SecondaryAxis(components = ['Salt'])
     sec.y_label = '$c_{salt}$'
 
-    simulation_results.solution.column.outlet.plot(secondary_axis=sec)
+    simulation_results.solution.column.outlet.plot(secondary_axes=sec)

--- a/examples/recycling/clr_process.md
+++ b/examples/recycling/clr_process.md
@@ -166,7 +166,7 @@ if __name__ == '__main__':
     fractionation_optimizer = FractionationOptimizer()
 
     fractionator = fractionation_optimizer.optimize_fractionation(
-        simulation_results, purity_required=[0.95, 0.95]
+        simulation_results, purity_required=[0.9, 0.9]
     )
 
     print(fractionator.performance)

--- a/examples/recycling/clr_process.py
+++ b/examples/recycling/clr_process.py
@@ -168,7 +168,7 @@ if __name__ == '__main__':
     fractionation_optimizer = FractionationOptimizer()
 
     fractionator = fractionation_optimizer.optimize_fractionation(
-        simulation_results, purity_required=[0.95, 0.95]
+        simulation_results, purity_required=[0.9, 0.9]
     )
 
     print(fractionator.performance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ docs = [
     "sphinx_book_theme>=1.0.0",
     "sphinx_copybutton>=0.5.1",
     "sphinx-sitemap>=2.5.0",
+    "cadet-rdm>=1.1.1",
 ]
 dev = [
     {include-group = "docs"},

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -1,3 +1,4 @@
+import random
 import shutil
 import time
 import unittest
@@ -21,6 +22,8 @@ from tests.optimization_problem_fixtures import (
     LinearConstraintsSooTestProblem2,
     LinearEqualityConstraintsSooTestProblem,
 )
+
+seed = random.randint(1, 255)
 
 
 class EvaluationObject(Structure):
@@ -829,7 +832,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         x0_seed_1 = self.optimization_problem.create_initial_values(1, seed=1)
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
-        x0_seed_1_random = self.optimization_problem.create_initial_values(1)
+        x0_seed_1_random = self.optimization_problem.create_initial_values(1, seed)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_1_random, x0_seed_1_expected)
@@ -852,7 +855,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         x0_seed_10 = self.optimization_problem.create_initial_values(10, seed=1)
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
-        x0_seed_10_random = self.optimization_problem.create_initial_values(10)
+        x0_seed_10_random = self.optimization_problem.create_initial_values(10, seed)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_10_random, x0_seed_10_expected)
@@ -971,7 +974,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, include_dependent_variables=False
+            10, seed=seed, include_dependent_variables=False
         )
 
         with self.assertRaises(AssertionError):
@@ -1029,7 +1032,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, include_dependent_variables=True
+            10, seed=seed, include_dependent_variables=True
         )
 
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
## Summary of changes

This PR introduces structured support for sideloading pre-run **RDM case studies** into the documentation build.
### RDM case study loading

A new pre-build script, `docs/source/load_studies.py`, is added. The script:

* clones or updates RDM project repositories via HTTPS
* checks out project and output refs
* reads `output/options.json` to determine the rendered source directory
* copies the study content into `docs/source/case_studies/<study>`
* updates the “Case Studies” toctree in `index.md` while preserving existing entries

---

### Separation of example types

The documentation right now distinguishes between:

* **Original examples** (`docs/source/examples/`)
  The old / original examples which are ultimately to be replaced by sideloaders.

* **Case studies** (`docs/source/case_studies/`)
  Precomputed snapshots copied from RDM output repositories.

---

### Case Studies navigation

The Case Studies section in `index.md` is updated by merging entries:

* existing manually maintained entries are preserved
* generated case studies are appended automatically
* duplicate entries are avoided

---

### MyST-NB execution configuration

The Sphinx configuration is updated to reflect the mixed execution model:

* `nb_execution_mode = "auto"` preserves per-notebook execution metadata
* `nb_execution_excludepatterns = ["case_studies/**"]` prevents execution of generated case studies

Existing notebooks that use cached execution continue to behave unchanged.