### PR TITLE
Split optional dependencies and dependency groups

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install -e ./[testing,coverage]
+          pip install -e ./[ax] --group testing
 
         # Push event doesn't have input context => inputs.notslows is empty => false
       - name: Coverage Run

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install
         run: |
-          pip install -e ./[ax] --group testing
+          pip install -e ./[all] --group testing
 
         # Push event doesn't have input context => inputs.notslows is empty => false
       - name: Coverage Run

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install
         run: |
-          conda run pip install -e ./[ax] --group testing
+          conda run pip install -e ./[all] --group testing
 
       - name: Test
         run: |

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -64,7 +64,7 @@ jobs:
 
       - name: Install
         run: |
-          conda run pip install -e ./[testing]
+          conda run pip install -e ./[ax] --group testing
 
       - name: Test
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,10 +40,8 @@ dependencies = [
 
 [dependency-groups]
 testing = [
-    "certifi", # tries to prevent certificate problems on windows
-    "pytest",
-    "pre-commit", # system tests run pre-commit
     "coverage",
+    "pytest",
     "pytest-cov"
 ]
 docs = [
@@ -56,14 +54,19 @@ docs = [
     "sphinx-sitemap>=2.5.0",
 ]
 dev = [
-    {include-group = "testing"},
     {include-group = "docs"},
+    {include-group = "testing"},
+    "certifi", # tries to prevent certificate problems on windows
+    "pre-commit",
     "ruff",
 ]
 
 [project.optional-dependencies]
 ax = [
     "ax-platform >=0.3.5,<1.0.0"
+]
+all = [
+   "CADET-Process[ax]",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,12 +38,13 @@ dependencies = [
     "scipy>=1.11",
 ]
 
-[project.optional-dependencies]
+[dependency-groups]
 testing = [
     "certifi", # tries to prevent certificate problems on windows
     "pytest",
     "pre-commit", # system tests run pre-commit
-    "ax-platform >=0.3.5,<1.0.0"
+    "coverage",
+    "pytest-cov"
 ]
 docs = [
     "myst-nb>=0.17.1",
@@ -54,12 +55,15 @@ docs = [
     "sphinx_copybutton>=0.5.1",
     "sphinx-sitemap>=2.5.0",
 ]
-ax = [
-    "ax-platform >=0.3.5"
+dev = [
+    {include-group = "testing"},
+    {include-group = "docs"},
+    "ruff",
 ]
-coverage = [
-    "coverage",
-    "pytest-cov",
+
+[project.optional-dependencies]
+ax = [
+    "ax-platform >=0.3.5,<1.0.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
Adding dependency groups and splitting optional dependencies so that optional dependencies like ax are actual additional optional features where as dependency groups are dependencies used for special use cases like for developing. To install dependency groups like dev in the future you have to use ```pip install CADET-process --group  dev```