### PR TITLE
Add parameter_space module

### DIFF
--- a/CADETProcess/normalize.py
+++ b/CADETProcess/normalize.py
@@ -1,0 +1,613 @@
+
+
+"""
+=========================================
+ (:mod:`CADETProcess.normalize`)
+=========================================
+
+.. currentmodule:: CADETProcess.normalize
+
+This module provides functionality for normalizing data.
+
+
+.. autosummary::
+    :toctree: generated/
+
+    NormalizerBase
+    NullNormalizer
+    LinearNormalizer
+    LogNormalizer
+    AutoNormalizer
+
+"""  # noqa
+
+from abc import ABC, abstractmethod
+from typing import Any, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+
+from CADETProcess import plotting
+from CADETProcess.numerics import round_to_significant_digits
+
+
+class NormalizerBase(ABC):
+    """
+    Base class for parameter normalization.
+
+    This class provides an interface for normalizing an input parameter space to some
+    output parameter space.
+
+    Attributes
+    ----------
+    lb_input : float or np.ndarray
+        Lower bounds of the input parameter space.
+    ub_input : float or np.ndarray
+        Upper bounds of the input parameter space.
+    lb : float or np.ndarray
+        Lower bounds of the output parameter space.
+    ub : float or np.ndarray
+        Upper bounds of the output parameter space.
+    allow_extended_input : bool
+        If True, the input value may exceed the lower/upper bounds.
+        Else, an exception is thrown.
+    allow_extended_output : bool
+        If True, the output value may exceed the lower/upper bounds.
+        Else, an exception is thrown.
+
+    Raises
+    ------
+    ValueError
+        If lb_input and ub_input have different shapes.
+
+    Notes
+    -----
+    - This is an abstract base class and cannot be instantiated directly.
+    - The `normalize` method must be implemented by a subclass.
+
+    Examples
+    --------
+    >>> class MyNormalizer(NormalizerBase):
+    ...     def normalize(self, x: float) -> float:
+    ...         return x**2
+    >>> t = MyNormalizer(lb_input=0, ub_input=10, lb=-100, ub=100)
+    >>> t.normalize(3)
+    9
+    """
+
+    def __init__(
+        self,
+        lb_input: float | np.ndarray = -np.inf,
+        ub_input: float | np.ndarray = np.inf,
+        allow_extended_input: Optional[bool] = False,
+        allow_extended_output: Optional[bool] = False,
+    ) -> None:
+        """
+        Initialize NormalizerBase.
+
+        Parameters
+        ----------
+        lb_input : float or np.ndarray, optional
+            Lower bounds of the input parameter space. Default is -inf.
+        ub_input : float or np.ndarray, optional
+            Upper bounds of the input parameter space. Default is inf.
+        allow_extended_input : bool, optional
+            If True, the input value may exceed the lower/upper bounds.
+            Else, an exception is thrown. Default is False.
+        allow_extended_output : bool, optional
+            If True, the output value may exceed the lower/upper bounds.
+            Else, an exception is thrown. Default is False.
+        """
+        self.lb_input = lb_input
+        self.ub_input = ub_input
+        self.allow_extended_input = allow_extended_input
+        self.allow_extended_output = allow_extended_output
+
+    @property
+    @abstractmethod
+    def is_linear(self) -> bool:
+        """Return whether the normalizion is linear."""
+        pass
+
+    @property
+    def lb_input(self) -> float | np.ndarray:
+        """Return the lower bounds of the input parameter space."""
+        return self._lb_input
+
+    @lb_input.setter
+    def lb_input(self, lb_input: float | np.ndarray) -> None:
+        self._lb_input = lb_input
+
+    @property
+    def ub_input(self) -> float | np.ndarray:
+        """Return the upper bounds of the input parameter space."""
+        return self._ub_input
+
+    @ub_input.setter
+    def ub_input(self, ub_input: float | np.ndarray) -> None:
+        self._ub_input = ub_input
+
+    @property
+    @abstractmethod
+    def lb(self) -> float | np.ndarray:
+        """Return the lower bounds of the output parameter space."""
+        pass
+
+    @property
+    @abstractmethod
+    def ub(self) -> float | np.ndarray:
+        """Return the upper bounds of the output parameter space."""
+        pass
+
+    def normalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Normalize the input parameter space to the output parameter space.
+
+        Applies the normalizion function `_normalize` to `x` after performing input
+        bounds checking. If the normalized value exceeds the output bounds, an error
+        is raised.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            Input parameter values.
+
+        Returns
+        -------
+        float or np.ndarray
+            normalized parameter values.
+
+        Raises
+        ------
+        ValueError
+            If `x` exceeds input or output bounds and `allow_extended_*` is False.
+        """
+        if not self.allow_extended_input and not np.all(
+            (self.lb_input <= x) & (x <= self.ub_input)
+        ):
+            raise ValueError("Value exceeds input bounds.")
+
+        x = self._normalize(x)
+
+        if not self.allow_extended_output and not np.all(
+            (self.lb <= x) & (x <= self.ub)
+        ):
+            raise ValueError("Value exceeds output bounds.")
+
+        return x
+
+    @abstractmethod
+    def _normalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Apply the normalizion from input to output parameter space.
+
+        Must be implemented in the child class.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            Input parameter values.
+
+        Returns
+        -------
+        float or np.ndarray
+            normalized parameter values.
+        """
+        pass
+
+    def denormalize(
+        self,
+        x: float | np.ndarray,
+        significant_digits: Optional[int] = None,
+    ) -> float | np.ndarray:
+        """
+        Normalize the output parameter space back to the input parameter space.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            Output parameter values.
+        significant_digits : int, optional
+            float | np.ndarray of significant figures to which variable can be rounded.
+            If None, variable is not rounded.
+
+        Returns
+        -------
+        float or np.ndarray
+            normalized parameter values.
+        """
+        x_ = round_to_significant_digits(x, digits=significant_digits)
+
+        if not self.allow_extended_output and not np.all(
+            (self.lb <= x_) & (x_ <= self.ub)
+        ):
+            raise ValueError("Value exceeds output bounds.")
+
+        x_ = self._denormalize(x_)
+        x_ = round_to_significant_digits(x_, digits=significant_digits)
+
+        if not self.allow_extended_input and not np.all(
+            (self.lb_input <= x_) & (x_ <= self.ub_input)
+        ):
+            raise ValueError("Value exceeds input bounds.")
+
+        return x_
+
+    @abstractmethod
+    def _denormalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Apply the inverse normalizion from output to input parameter space.
+
+        Must be implemented in the child class.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            Output parameter values.
+
+        Returns
+        -------
+        float or np.ndarray
+            Normalized parameter values.
+        """
+        pass
+
+    @plotting.create_and_save_figure
+    def plot(self, ax: plt.Axes, use_log_scale: bool = False) -> None:
+        """
+        Plot the normalized space against the input space.
+
+        Parameters
+        ----------
+        ax : plt.Axes
+            The axes object to plot on.
+        use_log_scale : bool, optional
+            If True, use a logarithmic scale for the x-axis.
+        """
+        allow_extended_input = self.allow_extended_input
+        self.allow_extended_input = True
+
+        y = np.linspace(self.lb, self.ub)
+        x = self.denormalize(y)
+
+        ax.plot(x, y)
+        ax.set_xlabel("Input Space")
+        ax.set_ylabel("normalized Space")
+
+        if use_log_scale:
+            ax.set_xscale("log")
+
+        self.allow_extended_input = allow_extended_input
+
+    def __str__(self) -> str:
+        """Return the class name as a string."""
+        return self.__class__.__name__
+
+
+class NullNormalizer(NormalizerBase):
+    """
+    A normalizer that performs no normalizion.
+
+    This class simply returns the input values as output without modification.
+
+    See Also
+    --------
+    NormalizerBase : The base class for parameter normalizion.
+    """
+
+    @property
+    def is_linear(self) -> bool:
+        """Return True, as this is a linear normalizion."""
+        return True
+
+    @property
+    def lb(self) -> float | np.ndarray:
+        """Return the lower bound of the output space (same as input lower bound)."""
+        return self.lb_input
+
+    @property
+    def ub(self) -> float | np.ndarray:
+        """Return the upper bound of the output space (same as input upper bound)."""
+        return self.ub_input
+
+    def _normalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Return the input value(s) as output without modification.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The input value(s) to be normalized.
+
+        Returns
+        -------
+        float or np.ndarray
+            The normalized output value(s) (same as input).
+        """
+        return x
+
+    def _denormalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Return the output value(s) as input without modification.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The output value(s) to be unnormalized.
+
+        Returns
+        -------
+        float or np.ndarray
+            The unnormalized input value(s) (same as output).
+        """
+        return x
+
+
+class LinearNormalizer(NormalizerBase):
+    """
+    A normalizer that normalizes values linearly to the range [0, 1].
+
+    This normalizion scales the input value between the given lower
+    and upper bounds into a normalized range of [0,1].
+
+    See Also
+    --------
+    NormalizerBase : The base class for parameter normalizion.
+    """
+
+    @property
+    def is_linear(self) -> bool:
+        """Return True, as this is a linear normalizion."""
+        return True
+
+    @property
+    def lb(self) -> float:
+        """Return the lower bound of the output space (0)."""
+        return 0.0
+
+    @property
+    def ub(self) -> float:
+        """Return the upper bound of the output space (1)."""
+        return 1.0
+
+    def _normalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Normalize input values to the range [0,1].
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The input value(s) to be normalized.
+
+        Returns
+        -------
+        float or np.ndarray
+            The normalized output value(s) in the range [0,1].
+        """
+        return (x - self.lb_input) / (self.ub_input - self.lb_input)
+
+    def _denormalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Denormalize output values back to the original range.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The output value(s) in the normalized range [0,1].
+
+        Returns
+        -------
+        float or np.ndarray
+            The unnormalized input value(s) in the original range.
+        """
+        return (self.ub_input - self.lb_input) * x + self.lb_input
+
+
+class LogNormalizer(NormalizerBase):
+    """
+    A normalizer that normalizes values logarithmically to the range [0, 1].
+
+    This normalizion scales input values logarithmically between the given lower
+    and upper bounds into a normalized range of [0,1].
+
+    See Also
+    --------
+    NormalizerBase : The base class for parameter normalizion.
+    """
+
+    @property
+    def is_linear(self) -> bool:
+        """Return False, as this is a non-linear normalizion."""
+        return False
+
+    @property
+    def lb(self) -> float:
+        """Return the lower bound of the output space (0)."""
+        return 0.0
+
+    @property
+    def ub(self) -> float:
+        """Return the upper bound of the output space (1)."""
+        return 1.0
+
+    def _normalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Normalize input values to the range [0,1] using a logarithmic normalizion.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The input value(s) to be normalized.
+
+        Returns
+        -------
+        float or np.ndarray
+            The normalized output value(s) in the range [0,1].
+
+        Raises
+        ------
+        ValueError
+            If `lb_input` is non-positive, the normalizion shifts all values accordingly.
+        """
+        if self.lb_input <= 0:
+            x_ = x + (abs(self.lb_input) + 1)
+            ub = 1 + (self.ub_input - self.lb_input)
+            return np.log(x_) / np.log(ub)
+        else:
+            return np.log(x / self.lb_input) / np.log(self.ub_input / self.lb_input)
+
+    def _denormalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Denormalize output values back to the original range using logarithmic inverse.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The output value(s) in the normalized range [0,1].
+
+        Returns
+        -------
+        float or np.ndarray
+            The unnormalized input value(s) in the original range.
+        """
+        if self.lb_input <= 0:
+            return (
+                np.exp(x * np.log(self.ub_input - self.lb_input + 1))
+                + self.lb_input
+                - 1
+            )
+        else:
+            return self.lb_input * np.exp(x * np.log(self.ub_input / self.lb_input))
+
+
+class AutoNormalizer(NormalizerBase):
+    """
+    A normalizer that automatically selects between linear and logarithmic normalizions.
+
+    Normalizes the input value to the range [0, 1] using either
+    the :class:`LinearNormalizer` or the :class:`LogNormalizer`
+    based on the input parameter space.
+
+    Attributes
+    ----------
+    linear : LinearNormalizer
+        Instance of the linear normalization transform.
+    log : LogNormalizater
+        Instance of the logarithmic normalization transform.
+    threshold : int
+        The maximum threshold to switch from linear to logarithmic normalizion.
+
+    See Also
+    --------
+    NormalizerBase
+    LinearNormalizer
+    LogNormalizer
+    """
+
+    def __init__(self, *args: Any, threshold: int = 100, **kwargs: Any) -> None:
+        """
+        Initialize an AutoNormalizer object.
+
+        Parameters
+        ----------
+        *args : tuple
+            Arguments for the :class:`NormalizerBase` class.
+        threshold : int, optional
+            The maximum threshold to switch from linear to logarithmic
+            normalizion. The default is 100.
+        **kwargs : dict
+            Keyword arguments for the :class:`NormalizerBase` class.
+        """
+        self.linear = LinearNormalizer()
+        self.log = LogNormalizer()
+
+        super().__init__(*args, **kwargs)
+        self.threshold = threshold
+
+        self.linear.allow_extended_input = self.allow_extended_input
+        self.linear.allow_extended_output = self.allow_extended_output
+        self.log.allow_extended_input = self.allow_extended_input
+        self.log.allow_extended_output = self.allow_extended_output
+
+    @property
+    def is_linear(self) -> bool:
+        """Return True if linear normalizion is used, otherwise False."""
+        return self.use_linear
+
+    @property
+    def use_linear(self) -> bool:
+        """Determine whether linear normalizion should be used."""
+        if self.lb_input <= 0:
+            return np.log10(self.ub_input - self.lb_input) < np.log10(self.threshold)
+        return (self.ub_input / self.lb_input) < self.threshold
+
+    @property
+    def use_log(self) -> bool:
+        """Return True if logarithmic normalizion is used, otherwise False."""
+        return not self.use_linear
+
+    @property
+    def lb(self) -> float:
+        """Return the lower bound of the output parameter space (0)."""
+        return 0.0
+
+    @property
+    def ub(self) -> float:
+        """Return the upper bound of the output parameter space (1)."""
+        return 1.0
+
+    @property
+    def lb_input(self) -> float | np.ndarray:
+        """Return the lower bounds of the input parameter space."""
+        return self._lb_input
+
+    @lb_input.setter
+    def lb_input(self, lb_input: float | np.ndarray) -> None:
+        """Set the lower bounds of the input parameter space."""
+        self.linear.lb_input = lb_input
+        self.log.lb_input = lb_input
+        self._lb_input = lb_input
+
+    @property
+    def ub_input(self) -> float | np.ndarray:
+        """Return the upper bounds of the input parameter space."""
+        return self._ub_input
+
+    @ub_input.setter
+    def ub_input(self, ub_input: float | np.ndarray) -> None:
+        """Set the upper bounds of the input parameter space."""
+        self.linear.ub_input = ub_input
+        self.log.ub_input = ub_input
+        self._ub_input = ub_input
+
+    def _normalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Normalize the input value to an output value in the range [0, 1].
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The input value(s) to be normalized.
+
+        Returns
+        -------
+        float or np.ndarray
+            The normalized output value(s).
+        """
+        return self.log._normalize(x) if self.use_log else self.linear._normalize(x)
+
+    def _denormalize(self, x: float | np.ndarray) -> float | np.ndarray:
+        """
+        Denormalize the output value back to the input parameter space.
+
+        Parameters
+        ----------
+        x : float or np.ndarray
+            The output value(s) in the normalized range.
+
+        Returns
+        -------
+        float or np.ndarray
+            The denormalized input value(s).
+        """
+        return self.log._denormalize(x) if self.use_log else self.linear._denormalize(x)

--- a/CADETProcess/parameter_space/__init__.py
+++ b/CADETProcess/parameter_space/__init__.py
@@ -1,0 +1,1 @@
+from .parameters import *

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -56,7 +56,6 @@ class ParameterBase:
     """
 
     name: str
-    dependency: ParameterDependency | None = None
 
     def validate(self, value: Any) -> None:
         """

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -56,6 +56,7 @@ class ParameterBase:
     """
 
     name: str
+    mapping: ParameterMapping | None = None
 
     def validate(self, value: Any) -> None:
         """
@@ -77,11 +78,13 @@ class ParameterBase:
         Set the value in the mapped objects.
 
         Iterates over parameter mappers and sets the value.
-        TODO: implement this method.
-        TODO: What's the purpose of this method? Call the mapper?
-        TODO: Raise error if value is not independent?
         """
-        pass
+        self.validate(value)
+
+        if self.mapping is None:
+            return
+
+        self.mapping.set_value(value)
 
 
 @dataclass
@@ -296,6 +299,11 @@ class ParameterMapping:
     parameter: ParameterBase
     evaluation_objects: list[Any]
     setter: Callable
+
+    def set_value(self, x: list[Any]) -> None:
+        """Set value in evaluation objects."""
+        for obj in self.evaluation_objects:
+            self.setter(obj, x)
 
 
 @dataclass

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -355,7 +355,10 @@ class ParameterDotPathSetter(ParameterMapperBase):
 
 @dataclass
 class ParameterSpace:
-    """Container for managing parameters and constraints."""
+    """Container for managing parameters and constraints.
+
+    @TODO add methods to check and evaluate bounds and linear cons
+    """
 
     parameters: list[ParameterBase] = field(default_factory=list)
     linear_constraints: list[LinearConstraint] = field(default_factory=list)
@@ -423,8 +426,6 @@ class ParameterSpace:
         parameter_dependency : ParameterDependency,
             The parameter dependency.
 
-        TODO: Check that parameter is not already dependent.
-        TODO: Should we add the dependency to the Parameter itself?
         """
         if any(
             d.dependent_parameter == parameter_dependency.dependent_parameter
@@ -501,3 +502,177 @@ class ParameterSpace:
 
         ordered = self.independent_parameters + self.dependent_parameters
         return np.asarray([param_values[p.name] for p in ordered], dtype=object)
+
+    @property
+    def n_variables(self) -> int:
+        """Number of independent (optimization) variables."""
+        return len(self.independent_parameters)
+
+    @property
+    def lower_bounds(self) -> np.ndarray:
+        """
+        Lower bounds for independent variables.
+
+        Returns
+        -------
+        np.ndarray
+            Vector of length `n_variables`; parameters without explicit bounds are
+            treated as unbounded (-inf).
+        """
+        lbs: list[float] = []
+        for p in self.independent_parameters:
+            lb = getattr(p, "lb", None)
+            lbs.append(-np.inf if lb is None else float(lb))
+        return np.asarray(lbs, dtype=float)
+
+    @property
+    def upper_bounds(self) -> np.ndarray:
+        """
+        Upper bounds for independent variables.
+
+        Returns
+        -------
+        np.ndarray
+            Vector of length `n_variables`; parameters without explicit bounds are
+            treated as unbounded (+inf).
+        """
+        ubs: list[float] = []
+        for p in self.independent_parameters:
+            ub = getattr(p, "ub", None)
+            ubs.append(+np.inf if ub is None else float(ub))
+        return np.asarray(ubs, dtype=float)
+
+    def check_bounds(
+        self,
+        x: npt.ArrayLike,
+        cv_bounds_tol: Optional[float | npt.ArrayLike] = 0.0,
+    ) -> bool:
+        """
+        Check if all bound constraints are satisfied for the **independent** variables.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Values of the independent optimization variables (untransformed space)
+            in the order of ``self.independent_parameters``.
+        cv_bounds_tol : float or ArrayLike, optional
+            Tolerance for checking bound constraints. If a scalar is provided, the
+            same tolerance is applied to all variables; otherwise must match
+            ``n_variables``. Default is 0.0.
+
+        Returns
+        -------
+        flag : bool
+            ``True`` if every variable satisfies ``lb - tol <= x <= ub + tol``,
+            ``False`` otherwise.
+
+        Raises
+        ------
+        ValueError
+            If the length of ``x`` (or of ``cv_bounds_tol`` when array-like) does
+            not match the number of independent variables.
+
+        """
+        vals = np.asarray(x, dtype=float).ravel()
+        n = self.n_variables
+        if vals.size != n:
+            raise ValueError(f"Length of `x` ({vals.size}) does not match {n}.")
+
+        if np.isscalar(cv_bounds_tol):
+            tol = np.full(n, float(cv_bounds_tol), dtype=float)
+        else:
+            tol = np.asarray(cv_bounds_tol, dtype=float).ravel()
+            if tol.size != n:
+                raise ValueError(
+                    f"Length of `cv_bounds_tol` ({tol.size}) does not match {n}."
+                )
+
+        lbs = self.lower_bounds
+        ubs = self.upper_bounds
+
+        below = vals < (lbs - tol)
+        above = vals > (ubs + tol)
+        return not (np.any(below) or np.any(above))
+
+    @property
+    def ordered_parameters(self) -> list[ParameterBase]:
+        """
+        Independent parameters followed by dependent parameters.
+
+        This mirrors the ordering returned by `get_dependent_variables`.
+        """
+        return self.independent_parameters + self.dependent_parameters
+
+    def set_values(
+        self,
+        x_independent: npt.ArrayLike,
+        *,
+        compute_dependents: bool = True,
+        validate_bounds: bool = False,
+        cv_bounds_tol: Optional[float | npt.ArrayLike] = 0.0,
+    ) -> None:
+        """
+        Set values on all parameters (independent first, then dependent).
+
+        Parameters
+        ----------
+        x_independent : ArrayLike
+            Values for the independent parameters, in the order of
+            `self.independent_parameters`.
+        compute_dependents : bool, default=True
+            If True (recommended), compute dependent parameter values using
+            `get_dependent_variables` before setting. If False, `x_independent`
+            is assumed to already contain values for *all* parameters in the
+            order `independent + dependent`.
+        validate_bounds : bool, default=False
+            If True, check bound feasibility on the independent variables using
+            `check_bounds` before setting.
+        cv_bounds_tol : float or ArrayLike, default=0.0
+            Tolerance passed to `check_bounds` when `validate_bounds` is True.
+
+        Notes
+        -----
+        - This calls each parameter's own `set_value`, which in turn runs its
+          `validate` method and writes into its mappers.
+        - Ordering: independent parameters first, then dependent parameters.
+        """
+        if validate_bounds:
+            ok = self.check_bounds(x_independent, cv_bounds_tol=cv_bounds_tol)
+            if not ok:
+                raise ValueError("Independent values violate bound constraints.")
+
+        if compute_dependents:
+            all_values = self.get_dependent_variables(x_independent)
+            if all_values.size != len(self.ordered_parameters):
+                raise RuntimeError(
+                    "Computed number of parameter values does not match the number of parameters."
+                )
+        else:
+            all_values = np.asarray(x_independent, dtype=object).ravel()
+            expected = len(self.ordered_parameters)
+            if all_values.size != expected:
+                raise ValueError(
+                    f"When compute_dependents=False, expected {expected} values "
+                    f"(independent + dependent), got {all_values.size}."
+                )
+
+        for param, value in zip(self.ordered_parameters, all_values):
+            param.set_value(value)
+
+    @property
+    def evaluation_objects(self) -> set[Any]:
+        """
+        Unique evaluation objects gathered from all parameter mappers.
+
+        Returns
+        -------
+        set[Any]
+            A set of unique evaluation objects found across all parameters'
+            mappers.
+        """
+        return {
+            evaluation_object
+            for p in self.parameters if p.mappers
+            for m in p.mappers if m.evaluation_objects
+            for evaluation_object in m.evaluation_objects
+        }

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Mapping
 from dataclasses import dataclass, field
-from typing import Any, Callable, Literal, Optional
+from typing import Any, Callable, Literal, Optional, Sequence
 
 import numpy as np
+import numpy.typing as npt
 
 from CADETProcess.normalize import (
     AutoNormalizer,
@@ -20,7 +22,7 @@ __all__ = [
     "ChoiceParameter",
     "LinearConstraint",
     "LinearEqualityConstraint",
-    "ParameterMapping",
+    "ParameterMapperBase",
     "ParameterSpace",
 ]
 
@@ -53,10 +55,31 @@ class ParameterBase:
     ----------
     name : str
         Name of the parameter.
+    mappers: ParameterMapper
+        Parameter mapper.
     """
 
     name: str
-    mapping: ParameterMapping | None = None
+    mappers: ParameterMapperBase | list[ParameterMapperBase] | None = None
+
+    def __post_init__(self) -> None:
+        """
+        Normalise *mappers* to a list so the rest of the class can iterate.
+
+        without type-checking.
+        """
+        if self.mappers is None:
+            return
+
+        if not isinstance(self.mappers, list):
+            self.mappers = [self.mappers]
+
+        for mapper in self.mappers:
+            if not isinstance(mapper, ParameterMapperBase):
+                raise TypeError(
+                    f"All mappers must inherit from ParameterMapperBase, "
+                    f"got {type(mapper).__name__!r}"
+                )
 
     def validate(self, value: Any) -> None:
         """
@@ -81,10 +104,10 @@ class ParameterBase:
         """
         self.validate(value)
 
-        if self.mapping is None:
+        if self.mappers is None:
             return
-
-        self.mapping.set_value(value)
+        for mapper in self.mappers:
+            mapper.set_value(value)
 
 
 @dataclass
@@ -281,29 +304,68 @@ class LinearEqualityConstraint:
         self.b = float(self.b)
 
 
-@dataclass
-class ParameterMapping:
+def _traverse_mixed_path(root: Any, keys: Sequence[str]) -> tuple[Any, str]:
     """
-    Maps a parameter to an evaluation path and function.
+    Follow *keys* up to the parent of the leaf and return (parent, leaf_key).
 
-    Attributes
-    ----------
-    parameter : ParameterBase
-        The parameter being mapped.
-    evaluation_objects : list[Any]
-        The objects to which the parameter is mapped.
-    setter: Callable
-        Function to set mapped parameter.
+    Traverses dict keys *or* object attributes at each hop.
+    Raises KeyError / AttributeError if the path is incomplete.
     """
+    current = root
+    for k in keys[:-1]:
+        current = current[k] if isinstance(current, Mapping) else getattr(current, k)
+    return current, keys[-1]
 
-    parameter: ParameterBase
-    evaluation_objects: list[Any]
-    setter: Callable
 
-    def set_value(self, x: list[Any]) -> None:
-        """Set value in evaluation objects."""
+@dataclass(slots=True)
+class ParameterMapperBase:
+    """Abstract base that writes a single parameter into multiple targets."""
+
+    evaluation_objects: list[Any] = field(repr=False)
+
+    def set_value(self, value: Any) -> None:
+        """
+        Broadcast a parameter value to every evaluation object in.
+
+        ``self.evaluation_objects``.
+
+        The method loops over the list of *evaluation objects* and delegates the
+        actual write-operation to the subclass-specific :py:meth:`_set_value`
+        implementation.
+
+        Parameters
+        ----------
+        value : Any
+            The value that should be written into each evaluation object.
+
+        """
         for obj in self.evaluation_objects:
-            self.setter(obj, x)
+            self._set_value(obj, value)
+
+    def _set_value(self, evaluation_object: Any, value: Any) -> None:
+        raise NotImplementedError
+
+
+@dataclass(slots=True)
+class ParameterDotPathSetter(ParameterMapperBase):
+    """
+    Writes *value* to the leaf referenced by a dot-separated path.
+
+    • Traverses dicts *and* objects in the same path.
+    """
+
+    path: str
+
+    def __post_init__(self) -> None:
+        self._keys: Sequence[str] = self.path.split(".")
+
+    def _set_value(self, evaluation_object: Any, value: Any) -> None:
+        parent, leaf = _traverse_mixed_path(evaluation_object, self._keys)
+
+        if isinstance(parent, Mapping):
+            parent[leaf] = value
+        else:
+            setattr(parent, leaf, value)
 
 
 @dataclass
@@ -412,58 +474,45 @@ class ParameterSpace:
         """
         return [p for p in self.parameters if p not in self.dependent_parameters]
 
-    def get_dependent_variables(self, x_independent: list[Any]) -> list:
+    def get_dependent_variables(
+        self,
+        x_independent: npt.ArrayLike
+    ) -> npt.NDArray[Any]:
         """
-        Compute dependent variable values.
+        Compute values for all parameters.
 
         Parameters
         ----------
-        x_independent: list[Any]
-            Values of the independent variables
+        x_independent : ArrayLike
+            Values of the independent parameters (list, tuple, ndarray …).
 
         Returns
         -------
-        list[Any]
-            Values of all variable.
-
-        TODO
-        - Add tests
-        - Consider using numpy arrays instead of lists.
+        npt.NDArray[Any]
+            Independent values first, then dependent values.
         """
-        # Create a dictionary to map parameter names to their values
-        param_values = {}
+        x_independent = np.asarray(x_independent, dtype=object).ravel()
 
-        # Set the values for independent parameters
+        param_values: dict[str, Any] = {}
         for param, value in zip(self.independent_parameters, x_independent):
             param_values[param.name] = value
 
-        # Resolve dependencies in a loop until all dependencies are met
-        # Since dependencies can have their own dependencies
         changed = True
         while changed:
             changed = False
             for dep in self.parameter_dependencies:
-                # Check if the dependent parameter is already calculated
                 if dep.dependent_parameter.name in param_values:
                     continue
-
-                # Attempt to gather independent values
                 try:
-                    indep_values = [
-                        param_values[param.name] for param in dep.independent_parameters
-                    ]
+                    indep_vals = [param_values[p.name]
+                                  for p in dep.independent_parameters
+                                  ]
                 except KeyError:
-                    continue  # Skip if dependencies are not yet available
-
-                # Compute the dependent parameter value
-                dependent_value = dep.transform(*indep_values)
-                if (
-                    dep.dependent_parameter.name not in param_values
-                    or param_values[dep.dependent_parameter.name] != dependent_value
-                ):
-                    param_values[dep.dependent_parameter.name] = dependent_value
+                    continue
+                val = dep.transform(*indep_vals)
+                if param_values.get(dep.dependent_parameter.name) != val:
+                    param_values[dep.dependent_parameter.name] = val
                     changed = True
 
-        # Extract values in the order of parameters
-        result = list(param_values.values())
-        return result
+        ordered = self.independent_parameters + self.dependent_parameters
+        return np.asarray([param_values[p.name] for p in ordered], dtype=object)

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -1,0 +1,406 @@
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from typing import Any, Callable, Literal, Optional
+
+import numpy as np
+
+from CADETProcess.normalize import (
+    AutoNormalizer,
+    LinearNormalizer,
+    LogNormalizer,
+    NormalizerBase,
+    NullNormalizer,
+)
+
+__all__ = [
+    "ParameterBase",
+    "RangedParameter",
+    "ChoiceParameter",
+    "LinearConstraint",
+    "LinearEqualityConstraint",
+    "ParameterMapping",
+    "ParameterSpace",
+]
+
+
+@dataclass
+class ParameterDependency:
+    """
+    Class to specify a parameter depdendency.
+
+    Attributes
+    ----------
+    independent_parameters: list[ParameterBase]
+        list of dependent parameters
+    transform : callable
+        Transformation function to derive the value from dependencies.
+    """
+
+    dependent_parameter: ParameterBase
+    independent_parameters: list[ParameterBase]
+    transform: Callable
+
+
+@dataclass
+class ParameterBase:
+    """
+
+    Base class for a parameter. Subclasses may override `validate` to apply constraints.
+
+    Attributes
+    ----------
+    name : str
+        Name of the parameter.
+    """
+
+    name: str
+    dependency: ParameterDependency | None = None
+
+    def validate(self, value: Any) -> None:
+        """
+        Validate a value against the parameter's constraints.
+
+        Parameters
+        ----------
+        value : Any
+            The value to validate.
+
+        Notes
+        -----
+        Subclasses must implement `validate` to enforce parameter rules.
+        """
+        pass
+
+    def set_value(self, value: Any) -> None:
+        """
+        Set the value in the mapped objects.
+
+        Iterates over parameter mappers and sets the value.
+        TODO: implement this method.
+        TODO: What's the purpose of this method? Call the mapper?
+        TODO: Raise error if value is not independent?
+        """
+        pass
+
+
+@dataclass
+class RangedParameter(ParameterBase):
+    """
+    A scalar parameter bounded by a lower and upper limit.
+
+    Attributes
+    ----------
+    parameter_type : type, default=int
+        Expected type of the parameter value (int or float).
+    lb : float, default=-inf
+        Lower bound (inclusive).
+    ub : float, default=inf
+        Upper bound (inclusive).
+    normalizer : NormalizerBase
+        Normalization method.
+    """
+
+    parameter_type: type[float | int] = int
+    lb: float = -math.inf
+    ub: float = math.inf
+    normalization: Literal["auto", "linear", "log"] | None = None
+    normalizer: Optional[NormalizerBase] = field(init=False, default=None)
+
+    def __post_init__(self) -> None:
+        """
+        Validate bounds after initialization.
+
+        Raises
+        ------
+        ValueError
+            If lower bound is greater than or equal to upper bound.
+        ValueError
+            If infinite bounds input for normalization.
+        """
+        if self.lb >= self.ub:
+            raise ValueError("Lower bound must be < upper bound.")
+
+        self.normalizer = self._build_normalizer()
+
+    def _build_normalizer(self) -> NormalizerBase:
+        if self.normalization is None:
+            return NullNormalizer(lb_input=self.lb, ub_input=self.ub)
+
+        if np.isinf(self.lb) or np.isinf(self.ub):
+            raise ValueError("Normalization requires finite bounds.")
+
+        if self.normalization == "linear":
+            return LinearNormalizer(lb_input=self.lb, ub_input=self.ub)
+        elif self.normalization == "log":
+            return LogNormalizer(lb_input=self.lb, ub_input=self.ub)
+        elif self.normalization == "auto":
+            return AutoNormalizer(lb_input=self.lb, ub_input=self.ub)
+        else:
+            raise ValueError(f"Unknown normalization type: {self.normalization}")
+
+    def validate(self, value: Any) -> None:
+        """
+        Validate that the value matches the type and lies within bounds.
+
+        Parameters
+        ----------
+        value : Any
+            The value to check.
+
+        Raises
+        ------
+        TypeError
+            If the value type is not correct.
+        ValueError
+            If the value is outside the specified bounds.
+        """
+        if not isinstance(value, self.parameter_type):
+            raise TypeError("Unexpected Type")
+
+        if not self.lb <= value <= self.ub:
+            raise ValueError("Value exceeds bounds")
+
+    def normalize(self, value: float) -> float:
+        """Normalize a parameter."""
+        return self.normalizer.normalize(value)
+
+    def denormalize(self, value: float) -> float:
+        """Denormalize a parameter."""
+        return self.normalizer.denormalize(value)
+
+
+@dataclass(kw_only=True)
+class ChoiceParameter(ParameterBase):
+    """
+    A parameter constrained to a finite set of valid values.
+
+    Attributes
+    ----------
+    valid_values : list of Any
+        List of allowed choices.
+    """
+
+    valid_values: list[Any]
+
+    def validate(self, value: Any) -> None:
+        """
+        Validate that the value is one of the allowed choices.
+
+        Parameters
+        ----------
+        value : Any
+            The value to check.
+
+        Raises
+        ------
+        ValueError
+            If value is not in the list of valid values.
+        """
+        if value not in self.valid_values:
+            raise ValueError(
+                f"{value!r} is not a valid choice; "
+                f"must be one of {self.valid_values!r}."
+            )
+
+
+@dataclass
+class LinearConstraint:
+    """
+    Represents a linear inequality constraint of the form: lhs · parameters <= b.
+
+    Attributes
+    ----------
+    parameters : list of RangedParameter
+        Parameters involved in the constraint.
+    lhs : list of float or float
+        Coefficients applied to parameters.
+    b : float
+        Right-hand side of the inequality.
+    """
+
+    parameters: list[RangedParameter]
+    lhs: list[float] = 1.0
+    b: float = 0.0
+
+    def __post_init__(self) -> None:
+        """
+        Normalize and validate the constraint structure.
+
+        Raises
+        ------
+        ValueError
+            If number of coefficients does not match number of parameters.
+        """
+        if not isinstance(self.parameters, list):
+            self.parameters = [self.parameters]
+        if np.isscalar(self.lhs):
+            self.lhs = [float(self.lhs)] * len(self.parameters)
+        if len(self.lhs) != len(self.parameters):
+            raise ValueError("Length of lhs must match number of parameters.")
+        self.b = float(self.b)
+
+
+@dataclass
+class LinearEqualityConstraint:
+    """
+    Represents a linear equality constraint of the form: lhs · parameters = b.
+
+    Attributes
+    ----------
+    parameters : list of RangedParameter
+        Parameters involved in the constraint.
+    lhs : list of float or float
+        Coefficients applied to parameters.
+    b : float
+        Right-hand side of the equation.
+    """
+
+    parameters: list[RangedParameter]
+    lhs: list[float] = 1.0
+    b: float = 0.0
+
+    def __post_init__(self) -> None:
+        """
+        Normalize and validate the constraint structure.
+
+        Raises
+        ------
+        ValueError
+            If number of coefficients does not match number of parameters.
+        """
+        if not isinstance(self.parameters, list):
+            self.parameters = [self.parameters]
+        if np.isscalar(self.lhs):
+            self.lhs = [float(self.lhs)] * len(self.parameters)
+        if len(self.lhs) != len(self.parameters):
+            raise ValueError("Length of lhs must match number of parameters.")
+        self.b = float(self.b)
+
+
+@dataclass
+class ParameterMapping:
+    """
+    Maps a parameter to an evaluation path and function.
+
+    Attributes
+    ----------
+    parameter : ParameterBase
+        The parameter being mapped.
+    evaluation_objects : list[Any]
+        The objects to which the parameter is mapped.
+    setter: Callable
+        Function to set mapped parameter.
+    """
+
+    parameter: ParameterBase
+    evaluation_objects: list[Any]
+    setter: Callable
+
+
+@dataclass
+class ParameterSpace:
+    """Container for managing parameters and constraints."""
+
+    parameters: list[ParameterBase] = field(default_factory=list)
+    linear_constraints: list[LinearConstraint] = field(default_factory=list)
+    linear_equality_constraints: list[LinearEqualityConstraint] = field(
+        default_factory=list
+    )
+    parameter_dependencies: list[ParameterDependency] = field(default_factory=list)
+
+    @property
+    def n_parameters(self) -> int:
+        """Returns the number of parameters in the space."""
+        return len(self.parameters)
+
+    def add_parameter(self, parameter: ParameterBase) -> None:
+        """
+        Add a parameter to the parameter space.
+
+        Parameters
+        ----------
+        parameters: ParameterBase
+            The parameter to be added.
+
+        Raises
+        ------
+        ValueError
+            If a parameter with the same name already exists.
+        """
+        if any(p.name == parameter.name for p in self.parameters):
+            raise ValueError(f"Parameter name '{parameter.name}' already used.")
+        self.parameters.append(parameter)
+
+    def add_linear_constraint(self, linear_constraint: LinearConstraint) -> None:
+        """
+        Add a linear constraint to the parameter space.
+
+        Parameters
+        ----------
+        linear_constraint: LinearConstraint,
+            Linear constraint.
+
+        """
+        self.linear_constraints.append(linear_constraint)
+
+    def add_linear_equality_constraint(
+        self, linear_equality_constraint: LinearEqualityConstraint
+    ) -> None:
+        """
+        Add a linear equality constraint to the parameter space.
+
+        Parameters
+        ----------
+        linear_equality_constraint: LinearEqualityConstraint,
+            Linear equality constraint.
+        """
+        self.linear_equality_constraints.append(linear_equality_constraint)
+
+    def add_parameter_dependency(
+        self, parameter_dependency: ParameterDependency
+    ) -> None:
+        """
+        Add a parameter dependency to the parameter space.
+
+        Parameters
+        ----------
+        parameter_dependency : ParameterDependency,
+            The parameter dependency.
+
+        TODO: Check that parameter is not already dependent.
+        TODO: Should we add the dependency to the Parameter itself?
+        """
+        if any(
+            d.dependent_parameter == parameter_dependency.dependent_parameter
+            for d in self.parameter_dependencies
+        ):
+            raise ValueError(
+    f"Parameter {parameter_dependency.dependent_parameter.name} is already dependent."
+            )
+        self.parameter_dependencies.append(parameter_dependency)
+
+    @property
+    def dependent_parameters(self) -> list[ParameterBase]:
+        """
+        Get all dependent parameters.
+
+        Returns
+        -------
+        list of ParameterBase
+            Parameters that depend on others.
+        """
+        return [param.dependent_parameter for param in self.parameter_dependencies]
+
+    @property
+    def independent_parameters(self) -> list[ParameterBase]:
+        """
+        Get all independent parameters.
+
+        Returns
+        -------
+        list of ParameterBase
+            Parameters that are independent of others.
+        """
+        return [p for p in self.parameters if p not in self.dependent_parameters]

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -305,16 +305,10 @@ class LinearEqualityConstraint:
 
 
 def _traverse_mixed_path(root: Any, keys: Sequence[str]) -> tuple[Any, str]:
-    """
-    Follow *keys* up to the parent of the leaf and return (parent, leaf_key).
-
-    Traverses dict keys *or* object attributes at each hop.
-    Raises KeyError / AttributeError if the path is incomplete.
-    """
-    current = root
+    cur = root
     for k in keys[:-1]:
-        current = current[k] if isinstance(current, Mapping) else getattr(current, k)
-    return current, keys[-1]
+        cur = cur[k] if isinstance(cur, Mapping) else getattr(cur, k)
+    return cur, keys[-1]
 
 
 @dataclass(slots=True)
@@ -325,25 +319,15 @@ class ParameterMapperBase:
 
     def set_value(self, value: Any) -> None:
         """
-        Broadcast a parameter value to every evaluation object in.
-
-        ``self.evaluation_objects``.
-
-        The method loops over the list of *evaluation objects* and delegates the
-        actual write-operation to the subclass-specific :py:meth:`_set_value`
-        implementation.
+        Broadcast *value* into every object listed in ``self.evaluation_objects``.
 
         Parameters
         ----------
         value : Any
-            The value that should be written into each evaluation object.
-
+            The parameter value to write into each evaluation object.
         """
         for obj in self.evaluation_objects:
             self._set_value(obj, value)
-
-    def _set_value(self, evaluation_object: Any, value: Any) -> None:
-        raise NotImplementedError
 
 
 @dataclass(slots=True)
@@ -351,17 +335,18 @@ class ParameterDotPathSetter(ParameterMapperBase):
     """
     Writes *value* to the leaf referenced by a dot-separated path.
 
-    • Traverses dicts *and* objects in the same path.
+    Traverses dicts **and** objects in the same path; missing hops raise.
     """
 
     path: str
 
+    _keys: Sequence[str] = field(init=False, repr=False)
+
     def __post_init__(self) -> None:
-        self._keys: Sequence[str] = self.path.split(".")
+        self._keys = self.path.split(".")
 
     def _set_value(self, evaluation_object: Any, value: Any) -> None:
         parent, leaf = _traverse_mixed_path(evaluation_object, self._keys)
-
         if isinstance(parent, Mapping):
             parent[leaf] = value
         else:

--- a/CADETProcess/parameter_space/parameters.py
+++ b/CADETProcess/parameter_space/parameters.py
@@ -403,3 +403,59 @@ class ParameterSpace:
             Parameters that are independent of others.
         """
         return [p for p in self.parameters if p not in self.dependent_parameters]
+
+    def get_dependent_variables(self, x_independent: list[Any]) -> list:
+        """
+        Compute dependent variable values.
+
+        Parameters
+        ----------
+        x_independent: list[Any]
+            Values of the independent variables
+
+        Returns
+        -------
+        list[Any]
+            Values of all variable.
+
+        TODO
+        - Add tests
+        - Consider using numpy arrays instead of lists.
+        """
+        # Create a dictionary to map parameter names to their values
+        param_values = {}
+
+        # Set the values for independent parameters
+        for param, value in zip(self.independent_parameters, x_independent):
+            param_values[param.name] = value
+
+        # Resolve dependencies in a loop until all dependencies are met
+        # Since dependencies can have their own dependencies
+        changed = True
+        while changed:
+            changed = False
+            for dep in self.parameter_dependencies:
+                # Check if the dependent parameter is already calculated
+                if dep.dependent_parameter.name in param_values:
+                    continue
+
+                # Attempt to gather independent values
+                try:
+                    indep_values = [
+                        param_values[param.name] for param in dep.independent_parameters
+                    ]
+                except KeyError:
+                    continue  # Skip if dependencies are not yet available
+
+                # Compute the dependent parameter value
+                dependent_value = dep.transform(*indep_values)
+                if (
+                    dep.dependent_parameter.name not in param_values
+                    or param_values[dep.dependent_parameter.name] != dependent_value
+                ):
+                    param_values[dep.dependent_parameter.name] = dependent_value
+                    changed = True
+
+        # Extract values in the order of parameters
+        result = list(param_values.values())
+        return result

--- a/projects/pipelines/batch_elution.py
+++ b/projects/pipelines/batch_elution.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import copy
-import inspect
 from typing import Any, Callable, Optional, Sequence
 
 from CADETProcess.fractionation import FractionationOptimizer
@@ -25,8 +24,8 @@ class EvaluationPipeline:
     parameter_space : ParameterSpace
         Parameter space that knows how to set values on the evaluation objects.
     root_input_name : str, optional
-        Explicit name of the first evaluator's root input argument.
-        If not given, inferred from the first evaluator's signature.
+        Explicit name of the root input argument that receives the evaluation object.
+        If not given, it is inferred via `Pipeline.all_root_args(target)`.
 
     Attributes
     ----------
@@ -107,31 +106,35 @@ class EvaluationPipeline:
             )
         return self._pipeline
 
-    def _infer_root_input_name(self) -> str:
+    def _get_root_arg_from_pipeline(self, target: str) -> str:
         """
-        Determine the name of the root input argument for the first evaluator.
+        Ask the Pipeline which root argument(s) are needed to compute `target`.
 
-        Returns
-        -------
-        str
-            The inferred parameter name.
+        Then choose the one that should receive the evaluation object.
 
-        Raises
-        ------
-        RuntimeError
-            If it cannot locate a suitable callable/parameter.
+        If user provided `self._root_input_name`, ensure it's in roots and return it.
         """
+        roots_map = self.pipeline.all_root_args
+        if target not in roots_map:
+            available = list(roots_map.keys())
+            raise RuntimeError(
+                f"Target '{target}' not found in pipeline outputs with root args. "
+                f"Available targets: {available}"
+            )
+
+        roots = roots_map[target]
+        roots = list(roots)
+
         if self._root_input_name:
+            if self._root_input_name not in roots:
+                raise RuntimeError(
+                    f"Provided root_input_name='{self._root_input_name}' is not among "
+                    f"pipeline roots for target '{target}': {roots}"
+                )
             return self._root_input_name
-        first_node = next(iter(self.evaluators.values()))
-        fn = getattr(first_node, "func", None) or getattr(first_node, "__call__", None)
-        if fn is None:
-            raise RuntimeError("Could not locate the underlying callable of the first evaluator.")
-        sig = inspect.signature(fn)
-        for p in sig.parameters.values():
-            if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
-                return p.name
-        raise RuntimeError("No suitable input parameter found on the first evaluator.")
+
+        if len(roots) == 1:
+            return roots[0]
 
     def __call__(self, target: str, x: Sequence[float], **kwargs: Any) -> list[Any]:
         """
@@ -151,19 +154,20 @@ class EvaluationPipeline:
         -------
         list[Any]
             List of results, one per evaluation object in
-            parameter_space.evaluation_objects`.
+            `parameter_space.evaluation_objects`.
         """
+        # Push x into all evaluation objects via ParameterSpace
         self.parameter_space.set_values(x)
-        root_kw = self._infer_root_input_name()
+
+        # Discover which kwarg name the pipeline expects at the root for `target`
+        root_kw = self._get_root_arg_from_pipeline(target)
 
         results: list[Any] = []
         for evaluation_object in self.parameter_space.evaluation_objects:
+            # Call the pipeline, passing the evaluation object under the discovered root kwarg.
             result = self.pipeline(target, **{root_kw: evaluation_object}, **kwargs)
             results.append(result)
         return results
-
-
-new_process = copy.deepcopy(process)
 
 
 def build_parameter_space(new_process: Any) -> ParameterSpace:
@@ -200,7 +204,7 @@ def build_parameter_space(new_process: Any) -> ParameterSpace:
     ps.add_parameter(cycle)
     ps.add_parameter(feed)
     ps.add_linear_constraint(
-        LinearConstraint(parameters=[feed, cycle], lhs=[1.0, -1.0], b=-1e-9)  # feed < cycle
+        LinearConstraint(parameters=[feed, cycle], lhs=[1.0, -1.0], b=-1e-9)
     )
     return ps
 
@@ -299,6 +303,8 @@ def eval_eluentcons(frac: Any) -> float:
     """
     return frac.eluent_consumption
 
+
+new_process = copy.deepcopy(process)
 
 parameter_space = build_parameter_space(new_process)
 batch_elution_evaluation_pipeline = EvaluationPipeline(parameter_space)

--- a/projects/pipelines/batch_elution.py
+++ b/projects/pipelines/batch_elution.py
@@ -1,0 +1,338 @@
+from __future__ import annotations
+
+import copy
+import inspect
+from typing import Any, Callable, Optional, Sequence
+
+from CADETProcess.fractionation import FractionationOptimizer
+from CADETProcess.parameter_space.parameters import (
+    LinearConstraint,
+    ParameterDotPathSetter,
+    ParameterSpace,
+    RangedParameter,
+)
+from CADETProcess.simulator import Cadet
+from examples.batch_elution.process import process
+from pipefunc import PipeFunc, Pipeline
+
+
+class EvaluationPipeline:
+    """
+    Lightweight evaluation pipeline wrapper around `pipefunc.Pipeline`.
+
+    Parameters
+    ----------
+    parameter_space : ParameterSpace
+        Parameter space that knows how to set values on the evaluation objects.
+    root_input_name : str, optional
+        Explicit name of the first evaluator's root input argument.
+        If not given, inferred from the first evaluator's signature.
+
+    Attributes
+    ----------
+    evaluators : dict[str, PipeFunc]
+        Mapping from evaluator name to `PipeFunc`.
+    pipeline : Pipeline
+        Lazily constructed `Pipeline` over the added evaluators.
+    """
+
+    def __init__(self, parameter_space: ParameterSpace,
+                 root_input_name: Optional[str] = None) -> None:
+        self.parameter_space = parameter_space
+        self.evaluators: dict[str, PipeFunc] = {}
+        self._pipeline: Optional[Pipeline] = None
+        self._root_input_name = root_input_name
+
+    def add_evaluator(
+        self,
+        evaluator: Callable[..., Any],
+        output_name: str,
+        name: Optional[str] = None,
+        cache: bool = True
+    ) -> None:
+        """
+        Register an evaluator node.
+
+        Parameters
+        ----------
+        evaluator : callable
+            Function to add to the pipeline. Its input should match the previous
+            node's output.
+        output_name : str
+            Name for this node's output within the pipeline DAG.
+        name : str, optional
+            Stable identifier for the node; defaults to `evaluator.__name__`.
+        cache : bool, default=True
+            Whether to enable LRU caching for this node.
+
+        Raises
+        ------
+        TypeError
+            If `evaluator` is not callable.
+        ValueError
+            If `name` already exists.
+        """
+        if not callable(evaluator):
+            raise TypeError("Expected callable evaluator.")
+        if name is None:
+            name = evaluator.__name__ if hasattr(evaluator, "__name__") else str(evaluator)
+        if name in self.evaluators:
+            raise ValueError(f"Evaluator with name '{name}' already exists.")
+        self.evaluators[name] = PipeFunc(evaluator, output_name=output_name, cache=cache)
+        self._pipeline = None  # invalidate so it rebuilds with the new node
+
+    @property
+    def pipeline(self) -> Pipeline:
+        """
+        Build (once) and return the underlying `Pipeline`.
+
+        Returns
+        -------
+        Pipeline
+            Configured pipeline with all registered evaluators.
+
+        Raises
+        ------
+        RuntimeError
+            If no evaluators have been added.
+        """
+        if self._pipeline is None:
+            if not self.evaluators:
+                raise RuntimeError("No evaluators added.")
+            self._pipeline = Pipeline(
+                self.evaluators.values(),
+                cache_type="lru",
+                cache_kwargs={"shared": False},
+                profile=True,
+            )
+        return self._pipeline
+
+    def _infer_root_input_name(self) -> str:
+        """
+        Determine the name of the root input argument for the first evaluator.
+
+        Returns
+        -------
+        str
+            The inferred parameter name.
+
+        Raises
+        ------
+        RuntimeError
+            If it cannot locate a suitable callable/parameter.
+        """
+        if self._root_input_name:
+            return self._root_input_name
+        first_node = next(iter(self.evaluators.values()))
+        fn = getattr(first_node, "func", None) or getattr(first_node, "__call__", None)
+        if fn is None:
+            raise RuntimeError("Could not locate the underlying callable of the first evaluator.")
+        sig = inspect.signature(fn)
+        for p in sig.parameters.values():
+            if p.kind in (inspect.Parameter.POSITIONAL_OR_KEYWORD, inspect.Parameter.KEYWORD_ONLY):
+                return p.name
+        raise RuntimeError("No suitable input parameter found on the first evaluator.")
+
+    def __call__(self, target: str, x: Sequence[float], **kwargs: Any) -> list[Any]:
+        """
+        Evaluate the pipeline for all evaluation objects after setting parameter values.
+
+        Parameters
+        ----------
+        target : str
+            Name of the terminal output to compute (must match an `output_name`).
+        x : Sequence[float]
+            Vector of parameter values in *untransformed* space for
+            `ParameterSpace.set_values`.
+        **kwargs
+            Forwarded keyword arguments to the pipeline call.
+
+        Returns
+        -------
+        list[Any]
+            List of results, one per evaluation object in
+            parameter_space.evaluation_objects`.
+        """
+        self.parameter_space.set_values(x)
+        root_kw = self._infer_root_input_name()
+
+        results: list[Any] = []
+        for evaluation_object in self.parameter_space.evaluation_objects:
+            result = self.pipeline(target, **{root_kw: evaluation_object}, **kwargs)
+            results.append(result)
+        return results
+
+
+new_process = copy.deepcopy(process)
+
+
+def build_parameter_space(new_process: Any) -> ParameterSpace:
+    """
+    Construct a `ParameterSpace` for batch elution with basic constraints.
+
+    Parameters
+    ----------
+    new_process : Any
+        Process-like object whose attributes will be set by parameter mappers.
+
+    Returns
+    -------
+    ParameterSpace
+        Space with `cycle_time` and `feed_duration` and constraint `feed < cycle`.
+    """
+    ps = ParameterSpace()
+    cycle = RangedParameter(
+        name="cycle_time",
+        parameter_type=float,
+        lb=60.0,
+        ub=1800.0,
+        normalization="auto",
+        mappers=[ParameterDotPathSetter([new_process], "cycle_time")],
+    )
+    feed = RangedParameter(
+        name="feed_duration",
+        parameter_type=float,
+        lb=5.0,
+        ub=300.0,
+        normalization="auto",
+        mappers=[ParameterDotPathSetter([new_process], "feed_duration.time")],
+    )
+    ps.add_parameter(cycle)
+    ps.add_parameter(feed)
+    ps.add_linear_constraint(
+        LinearConstraint(parameters=[feed, cycle], lhs=[1.0, -1.0], b=-1e-9)  # feed < cycle
+    )
+    return ps
+
+
+def run_simulation(new_process: Any) -> Any:
+    """
+    Simulate the process with CADET.
+
+    Parameters
+    ----------
+    new_process : Any
+        Configured process instance.
+
+    Returns
+    -------
+    Any
+        Simulation results returned by `Cadet.simulate`.
+    """
+    process_simulator = Cadet()
+    process_simulator.evaluate_stationarity = True
+    simulation_results = process_simulator.simulate(new_process)
+    return simulation_results
+
+
+def fractionate(simulation_results: Any) -> Any:
+    """
+    Optimize fractionation given simulation results.
+
+    Parameters
+    ----------
+    simulation_results : Any
+        Output from the simulator.
+
+    Returns
+    -------
+    Any
+        Fractionation result object with productivity, recovery, etc.
+    """
+    frac_opt = FractionationOptimizer()
+    frac = frac_opt.optimize_fractionation(
+        simulation_results,
+        purity_required=[0.95, 0.95],
+        ignore_failed=False,
+        allow_empty_fractions=True,
+    )
+    return frac
+
+
+def eval_prod(frac: Any) -> float:
+    """
+    Extract productivity from a fractionation result.
+
+    Parameters
+    ----------
+    frac : Any
+        Fractionation result.
+
+    Returns
+    -------
+    float
+        Productivity metric.
+    """
+    return frac.productivity
+
+
+def eval_recovery(frac: Any) -> float:
+    """
+    Extract recovery from a fractionation result.
+
+    Parameters
+    ----------
+    frac : Any
+        Fractionation result.
+
+    Returns
+    -------
+    float
+        Recovery metric.
+    """
+    return frac.recovery
+
+
+def eval_eluentcons(frac: Any) -> float:
+    """
+    Extract eluent consumption from a fractionation result.
+
+    Parameters
+    ----------
+    frac : Any
+        Fractionation result.
+
+    Returns
+    -------
+    float
+        Eluent consumption.
+    """
+    return frac.eluent_consumption
+
+
+parameter_space = build_parameter_space(new_process)
+batch_elution_evaluation_pipeline = EvaluationPipeline(parameter_space)
+
+batch_elution_evaluation_pipeline.add_evaluator(
+    run_simulation,
+    output_name="simulation_results",
+    cache=True,
+)
+
+batch_elution_evaluation_pipeline.add_evaluator(
+    fractionate,
+    output_name="frac",
+    cache=True,
+)
+
+batch_elution_evaluation_pipeline.add_evaluator(
+    eval_prod,
+    output_name="prod",
+    cache=True,
+)
+
+batch_elution_evaluation_pipeline.add_evaluator(
+    eval_recovery,
+    output_name="recovery",
+    cache=True,
+)
+
+batch_elution_evaluation_pipeline.add_evaluator(
+    eval_eluentcons,
+    output_name="eluent",
+    cache=True,
+)
+
+print("Productivity:", batch_elution_evaluation_pipeline("prod", x=[600.0, 60.0]))
+print("Recovery:", batch_elution_evaluation_pipeline("recovery", x=[600.0, 60.0]))
+print("Eluent consumption:", batch_elution_evaluation_pipeline("eluent", x=[600.0, 60.0]))

--- a/tests/parameter_space/test_evaluation.py
+++ b/tests/parameter_space/test_evaluation.py
@@ -1,0 +1,52 @@
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from CADETProcess.projects.pipelines.batch_elution import EvaluationPipeline
+
+
+@dataclass
+class DummyProcess:
+    value: float = 0.0
+
+
+class DummyParameterSpace:
+    """
+    Minimal double for your real ParameterSpace.
+    - Has .evaluation_objects
+    - Has .set_values(x) to write values into each object
+    - Optional: .size / .describe for better error messages if you add guards later
+    """
+    def __init__(self, evaluation_objects):
+        self.evaluation_objects = list(evaluation_objects)
+
+    @property
+    def size(self) -> int:
+        return 1
+
+    def describe(self):
+        return ["value"]
+
+    def set_values(self, x):
+        if len(x) != 1:
+            raise ValueError(f"Expected x of length 1, got {len(x)}")
+        v = float(x[0])
+        for obj in self.evaluation_objects:
+            obj.value = v
+
+
+@pytest.fixture
+def evaluation_objects():
+    return [DummyProcess(), DummyProcess()]
+
+
+@pytest.fixture
+def parameter_space(evaluation_objects):
+    return DummyParameterSpace(evaluation_objects)
+
+
+@pytest.fixture
+def pipeline(parameter_space):
+    return EvaluationPipeline(parameter_space)

--- a/tests/parameter_space/test_parameters.py
+++ b/tests/parameter_space/test_parameters.py
@@ -1,18 +1,108 @@
 import sys
+from dataclasses import dataclass
 from pathlib import Path
+from typing import Any
 
+import numpy as np
 import pytest
-
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
 from CADETProcess.parameter_space.parameters import (
     ChoiceParameter,
     LinearConstraint,
     LinearEqualityConstraint,
     ParameterDependency,
+    ParameterDotPathSetter,
     ParameterSpace,
     RangedParameter,
 )
+from numpy.typing import NDArray
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+
+@dataclass
+class ObjWithDict:
+    """Object that contains a dict so we can test object → dict traversal."""
+    store: dict
+
+
+@dataclass
+class ObjLeaf:
+    """Object whose attribute will act as the leaf value."""
+    ka: float = 1e-5
+
+
+@pytest.fixture
+def dict_to_obj():
+    """Root dict ⟶ object.attr leaf."""
+    column = ObjLeaf(ka=1e-5)
+    return {"column": column}
+
+
+@pytest.fixture
+def obj_to_dict():
+    """Root object ⟶ dict['ka'] leaf."""
+    obj = ObjWithDict(store={"ka": 2e-5})
+    return obj
+
+
+def test_dict_to_object_traversal(dict_to_obj):
+    setter = ParameterDotPathSetter(
+        [dict_to_obj],
+        "column.ka"     # dict key → object attribute
+    )
+    new_val = 3.3e-4
+    setter.set_value(new_val)
+    assert dict_to_obj["column"].ka == new_val
+
+
+def test_object_to_dict_traversal(obj_to_dict):
+    setter = ParameterDotPathSetter(
+        [obj_to_dict],
+        "store.ka"      # object attribute → dict key
+    )
+    new_val = 4.4e-4
+    setter.set_value(new_val)
+    assert obj_to_dict.store["ka"] == new_val
+
+
+def test_missing_path_raises(dict_to_obj):
+    """No auto-creation: missing hop should raise KeyError or AttributeError."""
+    setter = ParameterDotPathSetter([dict_to_obj], "column.missing.leaf")
+    with pytest.raises(AttributeError):
+        setter.set_value(0.0)
+
+
+@pytest.fixture
+def random_dict():
+    """Dictionary mimicking a flowsheet‐like structure."""
+    return {
+        "unit_1": {
+            "parameters": {
+                "k_a": 1e-5,
+                "temperature": 300,
+            }
+        },
+        "unit_2": {
+            "parameters": {
+                "k_a": 2e-5,
+                "pressure": 5.0,
+            }
+        },
+    }
+
+
+def test_parameter_dot_path_setter_updates_only_target(random_dict):
+    """`set_value` should update the targeted leaf and leave others untouched."""
+    mapper = ParameterDotPathSetter(
+        evaluation_objects=[random_dict],
+        path="unit_1.parameters.k_a",
+    )
+
+    new_value = 3.1e-4
+    mapper.set_value(new_value)
+
+    assert random_dict["unit_1"]["parameters"]["k_a"] == pytest.approx(new_value)
+    assert random_dict["unit_2"]["parameters"]["k_a"] == pytest.approx(2e-5)
 
 
 @pytest.fixture
@@ -161,9 +251,8 @@ def test_parameter_is_dependent():
     )
 
     space = ParameterSpace()
-    space.add_parameter(a)
-    space.add_parameter(b)
-    space.add_parameter(c)
+    for p in (a, b, c):
+        space.add_parameter(p)
     space.add_parameter_dependency(dep)
 
     assert c in space.dependent_parameters
@@ -171,7 +260,25 @@ def test_parameter_is_dependent():
     assert b not in space.dependent_parameters
 
 
-# TODO: Test calculating the actual dependent value.
+def test_get_dependent_variables_typing() -> None:
+    a = RangedParameter("a", int, 0, 10)
+    b = RangedParameter("b", int, 0, 5)
+    c = RangedParameter("c", int, 0, 20)
+    d = RangedParameter("d", int, 0, 40)
+
+    space = ParameterSpace()
+    for p in (a, b, c, d):
+        space.add_parameter(p)
+
+    space.add_parameter_dependency(
+        ParameterDependency(c, [a, b], lambda x, y: x + y)
+    )
+    space.add_parameter_dependency(
+        ParameterDependency(d, [c], lambda z: 2 * z)
+    )
+
+    out: NDArray[Any] = space.get_dependent_variables((2, 3))
+    np.testing.assert_array_equal(out, np.array([2, 3, 5, 10], dtype=object))
 
 
 @pytest.mark.parametrize(
@@ -235,8 +342,8 @@ def test_normalize_without_normalizer_raises():
         ub=1.0,
         normalization="linear",
     )
-    param.normalizer = None  # forcefully break internal state
-    with pytest.raises(AttributeError):  # might raise AttributeError or RuntimeError
+    param.normalizer = None
+    with pytest.raises(AttributeError):
         param.normalize(0.5)
 
 

--- a/tests/parameter_space/test_parameters.py
+++ b/tests/parameter_space/test_parameters.py
@@ -162,3 +162,83 @@ def test_parameter_is_dependent():
     assert c in space.dependent_parameters
     assert a not in space.dependent_parameters
     assert b not in space.dependent_parameters
+
+
+@pytest.mark.parametrize(
+    "norm_type, lb, ub, value, expected",
+    [
+        ("linear", 0.0, 10.0, 5.0, 0.5),
+        ("log", 1.0, 100.0, 10.0, 0.5),
+        ("auto", 1.0, 100.0, 10.0, pytest.approx(0.5, abs=0.1)),
+        (None, 0.0, 10.0, 5.0, 5.0),
+    ],
+)
+def test_ranged_parameter_normalization(norm_type, lb, ub, value, expected):
+    param = RangedParameter(
+        name="test_param",
+        parameter_type=float,
+        lb=lb,
+        ub=ub,
+        normalization=norm_type,
+    )
+    normalized = param.normalize(value)
+    denormalized = param.denormalize(normalized)
+
+    if isinstance(expected, float):
+        assert normalized == pytest.approx(expected)
+    else:
+        assert normalized == expected
+
+    assert denormalized == pytest.approx(value, rel=1e-5)
+
+
+def test_normalization_requires_finite_bounds():
+    """Ensure normalization raises if bounds are infinite."""
+    with pytest.raises(ValueError, match="Normalization requires finite bounds"):
+        RangedParameter(
+            name="test_inf",
+            parameter_type=float,
+            lb=0.0,
+            ub=float("inf"),
+            normalization="linear",
+        )
+
+
+def test_invalid_normalization_type():
+    """Check error is raised for unknown normalization type."""
+    with pytest.raises(ValueError, match="Unknown normalization type"):
+        RangedParameter(
+            name="invalid_norm",
+            parameter_type=float,
+            lb=1.0,
+            ub=10.0,
+            normalization="invalid_type",
+        )
+
+
+def test_normalize_without_normalizer_raises():
+    """Manually unset normalizer and ensure it raises at runtime."""
+    param = RangedParameter(
+        name="manual_fail",
+        parameter_type=float,
+        lb=0.0,
+        ub=1.0,
+        normalization="linear",
+    )
+    param.normalizer = None  # forcefully break internal state
+    with pytest.raises(AttributeError):  # might raise AttributeError or RuntimeError
+        param.normalize(0.5)
+
+
+def test_denormalize_without_normalizer_raises():
+    """Manually unset normalizer and ensure denormalization fails."""
+    param = RangedParameter(
+        name="manual_fail",
+        parameter_type=float,
+        lb=0.0,
+        ub=1.0,
+        normalization="linear",
+    )
+    param.normalizer = None
+    with pytest.raises(AttributeError):
+        param.denormalize(0.5)

--- a/tests/parameter_space/test_parameters.py
+++ b/tests/parameter_space/test_parameters.py
@@ -1,0 +1,164 @@
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from CADETProcess.parameter_space.parameters import (
+    ChoiceParameter,
+    LinearConstraint,
+    LinearEqualityConstraint,
+    ParameterDependency,
+    ParameterSpace,
+    RangedParameter,
+)
+
+
+@pytest.fixture
+def int_param():
+    return RangedParameter(name="int_param", parameter_type=int, lb=0, ub=10)
+
+
+@pytest.fixture
+def float_param():
+    return RangedParameter(name="float_param", parameter_type=float, lb=0.0, ub=5.0)
+
+
+@pytest.fixture
+def choice_param():
+    return ChoiceParameter(name="mode", valid_values=["fast", "slow", "medium"])
+
+
+@pytest.mark.parametrize("value", [0, 5, 10])
+def test_ranged_param_accepts_valid(value, int_param):
+    int_param.validate(value)  # Should not raise
+
+
+@pytest.mark.parametrize("value", [-1, 11])
+def test_ranged_param_out_of_bounds(value, int_param):
+    with pytest.raises(ValueError):
+        int_param.validate(value)
+
+
+@pytest.mark.parametrize("value", [3.5, "five", None])
+def test_ranged_param_type_error(value, int_param):
+    with pytest.raises(TypeError):
+        int_param.validate(value)
+
+
+def test_ranged_param_invalid_bounds():
+    with pytest.raises(ValueError):
+        _ = RangedParameter(name="bad", parameter_type=int, lb=10, ub=5)
+
+
+@pytest.mark.parametrize("value", ["fast", "slow", "medium"])
+def test_choice_param_accepts(value, choice_param):
+    choice_param.validate(value)  # Should not raise
+
+
+@pytest.mark.parametrize("value", ["ultra", "", 5, None])
+def test_choice_param_rejects(value, choice_param):
+    with pytest.raises(ValueError):
+        choice_param.validate(value)
+
+
+def test_parameter_space_rejects_duplicate_names():
+    space = ParameterSpace()
+    p1 = RangedParameter(name="x", parameter_type=int, lb=0, ub=1)
+    p2 = RangedParameter(name="x", parameter_type=int, lb=1, ub=2)
+    space.add_parameter(p1)
+    with pytest.raises(ValueError):
+        space.add_parameter(p2)
+
+
+def test_parameter_space_counts_parameters():
+    space = ParameterSpace()
+    p1 = RangedParameter(name="foo", parameter_type=int, lb=1, ub=2)
+    p2 = ChoiceParameter(name="bar", valid_values=["a", "b"])
+    space.add_parameter(p1)
+    space.add_parameter(p2)
+    assert space.n_parameters == 2
+
+
+def test_linear_constraint_valid():
+    p1 = RangedParameter(name="p1", parameter_type=float, lb=0, ub=1)
+    p2 = RangedParameter(name="p2", parameter_type=float, lb=0, ub=1)
+    con = LinearConstraint(parameters=[p1, p2], lhs=[1.0, 2.0], b=5.0)
+    assert con.b == 5.0
+    assert len(con.lhs) == 2
+
+
+def test_linear_constraint_invalid_length():
+    p1 = RangedParameter(name="p1", parameter_type=float, lb=0, ub=1)
+    with pytest.raises(ValueError):
+        LinearConstraint(parameters=[p1], lhs=[1.0, 2.0], b=5.0)
+
+
+def test_linear_constraint_scalar_lhs():
+    p1 = RangedParameter(name="p1", parameter_type=float, lb=0, ub=1)
+    con = LinearConstraint(parameters=[p1], lhs=3.0, b=9.0)
+    assert con.lhs == [3.0]
+    assert con.b == 9.0
+
+
+def test_linear_equality_constraint_valid():
+    p1 = RangedParameter(name="p1", parameter_type=float, lb=0, ub=1)
+    p2 = RangedParameter(name="p2", parameter_type=float, lb=0, ub=1)
+    con = LinearEqualityConstraint(parameters=[p1, p2], lhs=[1.0, 2.0], b=3.0)
+    assert con.b == 3.0
+    assert len(con.lhs) == 2
+
+
+def test_parameter_space_add_multiple_parameters():
+    pspace = ParameterSpace()
+    pspace.add_parameter(RangedParameter(name="foo", lb=1, ub=2))
+    pspace.add_parameter(RangedParameter(name="bar", lb=-10, ub=0))
+    assert pspace.n_parameters == 2
+
+
+def test_linear_equality_constraint_invalid_length():
+    p1 = RangedParameter(name="p1", parameter_type=float, lb=0, ub=1)
+    with pytest.raises(ValueError):
+        LinearEqualityConstraint(parameters=[p1], lhs=[1.0, 2.0], b=3.0)
+
+
+def test_linear_equality_constraint_scalar_lhs():
+    p1 = RangedParameter(name="p1", parameter_type=float, lb=0, ub=1)
+    con = LinearEqualityConstraint(parameters=[p1], lhs=4.0, b=4.0)
+    assert con.lhs == [4.0]
+    assert con.b == 4.0
+
+
+def test_parameter_space_add_linear_equality_constraint():
+    pspace = ParameterSpace()
+    p = RangedParameter(name="x", lb=0, ub=10, parameter_type=float)
+    pspace.add_parameter(p)
+
+    constraint = LinearEqualityConstraint(parameters=p, lhs=3.0, b=6.0)
+    pspace.add_linear_equality_constraint(constraint)
+
+    assert len(pspace.linear_equality_constraints) == 1
+    assert pspace.linear_equality_constraints[0].lhs == [3.0]
+
+
+def test_parameter_is_dependent():
+    a = RangedParameter(name="a", parameter_type=int, lb=0, ub=10)
+    b = RangedParameter(name="b", parameter_type=int, lb=0, ub=5)
+    c = RangedParameter(name="c", parameter_type=int, lb=0, ub=20)
+
+    dep = ParameterDependency(
+        dependent_parameter=c,
+        independent_parameters=[a, b],
+        transform=lambda x, y: x + y,
+    )
+
+    space = ParameterSpace()
+    space.add_parameter(a)
+    space.add_parameter(b)
+    space.add_parameter(c)
+    space.add_parameter_dependency(dep)
+
+    assert c in space.dependent_parameters
+    assert a not in space.dependent_parameters
+    assert b not in space.dependent_parameters

--- a/tests/parameter_space/test_parameters.py
+++ b/tests/parameter_space/test_parameters.py
@@ -30,6 +30,13 @@ def choice_param():
     return ChoiceParameter(name="mode", valid_values=["fast", "slow", "medium"])
 
 
+@pytest.fixture
+def mapped_param():
+    return RangedParameter(
+        name="mapped_param", parameter_type=float, lb=0.0, ub=5.0
+    )
+
+
 @pytest.mark.parametrize("value", [0, 5, 10])
 def test_ranged_param_accepts_valid(value, int_param):
     int_param.validate(value)  # Should not raise

--- a/tests/parameter_space/test_parameters.py
+++ b/tests/parameter_space/test_parameters.py
@@ -171,6 +171,9 @@ def test_parameter_is_dependent():
     assert b not in space.dependent_parameters
 
 
+# TODO: Test calculating the actual dependent value.
+
+
 @pytest.mark.parametrize(
     "norm_type, lb, ub, value, expected",
     [

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,107 @@
+import numpy as np
+import pytest
+from CADETProcess.normalize import (
+    AutoNormalizer,
+    LinearNormalizer,
+    LogNormalizer,
+    NullNormalizer,
+)
+
+
+@pytest.mark.parametrize("value", [-10, 1000])
+def test_linear_normalization_input_range_raises(value):
+    norm = LinearNormalizer(0, 100)
+    with pytest.raises(ValueError):
+        norm.normalize(value)
+
+
+@pytest.mark.parametrize("value", [-1, 2])
+def test_linear_denormalization_output_range_raises(value):
+    norm = LinearNormalizer(0, 100)
+    with pytest.raises(ValueError):
+        norm.denormalize(value)
+
+
+def test_null_normalizer_identity_behavior():
+    norm = NullNormalizer(0, 100)
+    assert norm.lb == 0
+    assert norm.ub == 100
+    assert norm.normalize(0) == 0
+    assert norm.denormalize(0) == 0
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output", [
+        (0, 0.0),
+        (10, 0.1),
+        (100, 1.0),
+    ]
+)
+def test_linear_normalization(input_value, expected_output):
+    norm = LinearNormalizer(0, 100)
+    out = norm.normalize(input_value)
+    assert np.isclose(out, expected_output)
+
+
+@pytest.mark.parametrize(
+    "norm_value, expected_input", [
+        (0.0, 0),
+        (0.1, 10),
+        (1.0, 100),
+    ]
+)
+def test_linear_denormalization(norm_value, expected_input):
+    norm = LinearNormalizer(0, 100)
+    out = norm.denormalize(norm_value)
+    assert np.isclose(out, expected_input)
+
+
+@pytest.mark.parametrize(
+    "input_value, expected_output", [
+        (1, 0.0),
+        (10, 1 / 3),
+        (100, 2 / 3),
+        (1000, 1.0),
+    ]
+)
+def test_log_normalization(input_value, expected_output):
+    norm = LogNormalizer(1, 1000)
+    out = norm.normalize(input_value)
+    assert np.isclose(out, expected_output)
+
+
+@pytest.mark.parametrize(
+    "norm_value, expected_input", [
+        (0.0, 1),
+        (1 / 3, 10),
+        (2 / 3, 100),
+        (1.0, 1000),
+    ]
+)
+def test_log_denormalization(norm_value, expected_input):
+    norm = LogNormalizer(1, 1000)
+    out = norm.denormalize(norm_value)
+    assert np.isclose(out, expected_input)
+
+
+def test_log_normalizer_handles_lb_input_leq_zero():
+    norm = LogNormalizer(-5, 95)
+    x = 5
+    out = norm.normalize(x)
+    expected = np.log(11) / np.log(101)
+    assert np.isclose(out, expected)
+
+
+@pytest.mark.parametrize(
+    "lb, ub, threshold, expected_linear",
+    [
+        (1, 100, 1000, True),
+        (1, 1001, 1000, False),
+        (-5, 95, 1000, True),  # shifted range is < threshold
+        (-5, 999, 1000, False),  # shifted range is > threshold
+    ]
+)
+def test_auto_normalizer_behavior(lb, ub, threshold, expected_linear):
+    norm = AutoNormalizer(lb, ub, threshold=threshold)
+    assert norm.use_linear == expected_linear
+    assert norm.use_log != expected_linear


### PR DESCRIPTION
See also #272 

## Todo
- [x] Bounds
- [x] Parameter normalization
- [x] Linear constraints
- [x] Linear equality constraints
- [~] Parameter dependencies
- [ ] Parameter mapping (i.e. how to map parameters to actual model parameters, providing different setter methods etc.)
- [ ] Mapping with indices, see also: [forum post](https://forum.cadet-web.de/t/specifying-indices-of-multidimensional-parameters-for-events-and-optimizationvariables/755) 
    - [ ] multidimensional arrays
    - [ ] `np.s_`
    - [ ] polynomial parameters
- [ ] Modularize parameter_space.py 
- [ ] Modularize tests for parameter_space.py
- [ ] Add NormalizedParameterSpace class
- [ ] Sampling methods (e.g. with hopsy)


## Open questions
- [x ] Where does normalization "live"? Parameter vs ParameterSpace? -> Parameter (e.g. choice parameters cannot be normalized anyway)
- [x] Where do dependencies "live"? Parameter vs ParameterSpace? Currently, they live in the Parameter. But we could consider moving them to the Parameter space to keep the Parameter class simple.
- [ ] Do we want to allow a more "dynamic" configuration? E.g. add_dependencies after instantiation?
