### PR TITLE
Clean up __init__.py to increase import speed

### DIFF
--- a/CADETProcess/__init__.py
+++ b/CADETProcess/__init__.py
@@ -16,30 +16,6 @@ __version__ = "0.11.0"
 # Imports
 from .CADETProcessError import *
 
-from . import log
-
 from .settings import Settings
 
 settings = Settings()
-
-from . import sysinfo
-from . import numerics
-from . import dataStructure
-from . import transform
-from . import plotting
-from . import dynamicEvents
-from . import processModel
-from . import smoothing
-from . import solution
-from . import reference
-from .simulationResults import SimulationResults
-from . import metric
-from . import performance
-from . import optimization
-from . import comparison
-from . import stationarity
-from . import simulator
-from . import fractionation
-from . import equilibria
-from . import modelBuilder
-from . import tools

--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -9,11 +9,14 @@ import numpy.typing as npt
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from CADETProcess import CADETProcessError, SimulationResults, plotting
+from CADETProcess import CADETProcessError, plotting
 from CADETProcess.comparison import DifferenceBase
 from CADETProcess.dataStructure import String, Structure, get_nested_value
 from CADETProcess.numerics import round_to_significant_digits
+from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.solution import SolutionBase
+
+__all__ = ["Comparator"]
 
 
 class Comparator(Structure):

--- a/CADETProcess/dataStructure/aggregator.py
+++ b/CADETProcess/dataStructure/aggregator.py
@@ -7,6 +7,13 @@ import numpy.typing as npt
 
 from .dataStructure import Aggregator
 
+__all__ = [
+    "NumpyProxyArray",
+    "SizedAggregator",
+    "ClassDependentAggregator",
+    "SizedClassDependentAggregator"
+]
+
 
 class NumpyProxyArray(np.ndarray):
     """A numpy array that dynamically updates attributes of container elements."""

--- a/CADETProcess/dataStructure/cache.py
+++ b/CADETProcess/dataStructure/cache.py
@@ -3,6 +3,11 @@ from typing import Any, Optional
 from .dataStructure import Structure
 from .parameter import Bool
 
+__all__ = [
+    "CachedPropertiesMixin",
+    "cached_property_if_locked",
+]
+
 
 class cached_property_if_locked(property):
     """

--- a/CADETProcess/dataStructure/dataStructure.py
+++ b/CADETProcess/dataStructure/dataStructure.py
@@ -9,6 +9,16 @@ from warnings import warn
 
 from addict import Dict
 
+__all__ = [
+    "Descriptor",
+    "ProxyList",
+    "Aggregator",
+    "StructMeta",
+    "AbstractStructMeta",
+    "Structure",
+    "frozen_attributes",
+]
+
 
 # %% Descriptors
 class Descriptor(ABC):

--- a/CADETProcess/dataStructure/encoder.py
+++ b/CADETProcess/dataStructure/encoder.py
@@ -3,6 +3,8 @@ from typing import Any
 
 import numpy as np
 
+__all__ = ["NumpyArrayEncoder"]
+
 
 class NumpyArrayEncoder(json.JSONEncoder):
     """

--- a/CADETProcess/dataStructure/parameter_group.py
+++ b/CADETProcess/dataStructure/parameter_group.py
@@ -2,6 +2,8 @@ from typing import Any
 
 from CADETProcess import CADETProcessError
 
+__all__ = ["ParameterWrapper"]
+
 
 class ParameterWrapper:
     """

--- a/CADETProcess/equilibria/buffer_capacity.py
+++ b/CADETProcess/equilibria/buffer_capacity.py
@@ -9,6 +9,14 @@ from matplotlib.axes import Axes
 from CADETProcess import CADETProcessError, plotting
 from CADETProcess.processModel import ComponentSystem, MassActionLaw, ReactionBaseClass
 
+__all__ = [
+    "buffer_capacity",
+    "ionic_strength",
+    "charge_distribution",
+    "plot_buffer_capacity",
+    "plot_charge_distribution",
+]
+
 
 def preprocessing(
     reaction_system: ReactionBaseClass,

--- a/CADETProcess/equilibria/initial_conditions.py
+++ b/CADETProcess/equilibria/initial_conditions.py
@@ -14,6 +14,8 @@ from CADETProcess.processModel import (
 )
 from CADETProcess.simulator import Cadet
 
+__all__ = ["simulate_solid_equilibria"]
+
 
 def simulate_solid_equilibria(
     binding_model: BindingBaseClass,

--- a/CADETProcess/equilibria/ptc.py
+++ b/CADETProcess/equilibria/ptc.py
@@ -10,6 +10,7 @@ This code was written by Samuel Leweke (University of Cologne) in 2020.
 __author__ = "Samuel Leweke"
 __contact__ = "leweke@math.uni-koeln.de"
 __copyright__ = "Copyright 2020, University of Cologne"
+__all__ = ["ptc"]
 
 import math
 from typing import Callable, Optional

--- a/CADETProcess/equilibria/reaction_equilibria.py
+++ b/CADETProcess/equilibria/reaction_equilibria.py
@@ -6,6 +6,8 @@ from CADETProcess.processModel import MassActionLaw
 
 from . import ptc
 
+__all__ = ["calculate_buffer_equilibrium"]
+
 
 def calculate_buffer_equilibrium(
     buffer: Sequence[float],

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -3,7 +3,7 @@ from typing import Callable, Optional
 
 import numpy as np
 
-from CADETProcess import CADETProcessError, SimulationResults
+from CADETProcess import CADETProcessError
 from CADETProcess.fractionation import Fractionator
 from CADETProcess.optimization import (
     COBYLA,
@@ -12,6 +12,7 @@ from CADETProcess.optimization import (
     OptimizerBase,
 )
 from CADETProcess.performance import Mass, Performance, Purity
+from CADETProcess.simulationResults import SimulationResults
 
 __all__ = ["FractionationOptimizer"]
 

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -7,12 +7,13 @@ import numpy as np
 from addict import Dict
 from matplotlib.axes import Axes
 
-from CADETProcess import CADETProcessError, SimulationResults, plotting, settings
+from CADETProcess import CADETProcessError, plotting, settings
 from CADETProcess.dataStructure import String
 from CADETProcess.dynamicEvents import Event, EventHandler
 from CADETProcess.fractionation.fractions import Fraction, FractionPool
 from CADETProcess.performance import Performance
 from CADETProcess.processModel import ComponentSystem, Process
+from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.solution import SolutionIO, slice_solution
 
 __all__ = ["Fractionator"]

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -10,7 +10,7 @@ from addict import Dict
 from matplotlib.axes import Axes
 from matplotlib.figure import Figure
 
-from CADETProcess import CADETProcessError, SimulationResults, plotting
+from CADETProcess import CADETProcessError, plotting
 from CADETProcess.dataStructure import (
     Integer,
     Structure,
@@ -31,6 +31,7 @@ from CADETProcess.processModel import (
     TubularReactorBase,
     UnitBaseClass,
 )
+from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.solution import SolutionBase
 
 __all__ = [

--- a/CADETProcess/modelBuilder/compartmentBuilder.py
+++ b/CADETProcess/modelBuilder/compartmentBuilder.py
@@ -19,6 +19,8 @@ from CADETProcess.processModel import (
     ReactionBaseClass,
 )
 
+__all__ = ["CompartmentBuilder"]
+
 
 class CompartmentBuilder(metaclass=StructMeta):
     """

--- a/CADETProcess/optimization/cache.py
+++ b/CADETProcess/optimization/cache.py
@@ -8,6 +8,8 @@ from diskcache import Cache, FanoutCache
 
 from CADETProcess.dataStructure import DillDisk
 
+__all__ = ["ResultsCache"]
+
 
 class ResultsCache:
     """

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -8,6 +8,8 @@ from addict import Dict
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import Bool, Float, Structure, Vector
 
+__all__ = ["hash_array", "Individual"]
+
 
 def hash_array(array: np.ndarray) -> str:
     """

--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -11,7 +11,7 @@ from CADETProcess.dataStructure import (
 
 cpu_count = multiprocessing.cpu_count()
 
-__all__ = ["ParallelizationBackendBase", "SequentialBackend"]
+__all__ = ["ParallelizationBackendBase", "SequentialBackend", "Joblib", "Pathos",]
 
 
 class ParallelizationBackendBase(Structure):

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -17,6 +17,8 @@ from pymoo.visualization.scatter import Scatter
 from CADETProcess import CADETProcessError, plotting
 from CADETProcess.optimization.individual import Individual, hash_array
 
+__all__ = ["Population", "ParetoFront"]
+
 
 class Population:
     """

--- a/CADETProcess/optimization/pymooAdapter.py
+++ b/CADETProcess/optimization/pymooAdapter.py
@@ -19,6 +19,8 @@ from CADETProcess.optimization import (
     ParallelizationBackendBase,
 )
 
+__all__ = ["NSGA2", "U_NSGA3"]
+
 
 class PymooInterface(OptimizerBase):
     """Wrapper around pymoo."""

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -34,6 +34,8 @@ if TYPE_CHECKING:
 cmap_feas = plt.get_cmap("winter_r")
 cmap_infeas = plt.get_cmap("autumn_r")
 
+__all__ = ["OptimizationResults"]
+
 
 class OptimizationResults(Structure):
     """

--- a/CADETProcess/processModel/flowSheet.py
+++ b/CADETProcess/processModel/flowSheet.py
@@ -15,6 +15,8 @@ from .binding import NoBinding
 from .componentSystem import ComponentSystem
 from .unitOperation import Cstr, Inlet, Outlet, SourceMixin, UnitBaseClass
 
+__all__ = ["FlowSheet"]
+
 
 @frozen_attributes
 class FlowSheet(Structure):

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -15,6 +15,8 @@ from .componentSystem import ComponentSystem
 from .flowSheet import FlowSheet
 from .unitOperation import Inlet, Outlet
 
+__all__ = ["Process"]
+
 
 class Process(EventHandler):
     """

--- a/CADETProcess/simulator/__init__.py
+++ b/CADETProcess/simulator/__init__.py
@@ -52,5 +52,5 @@ After simulation, the ``Simulator`` returns a ``SimulationResults`` object.
 
 """
 
-from .simulator import *
-from .cadetAdapter import *
+from .simulator import SimulatorBase
+from .cadetAdapter import Cadet

--- a/CADETProcess/simulator/cadetAdapter.py
+++ b/CADETProcess/simulator/cadetAdapter.py
@@ -15,7 +15,7 @@ import numpy as np
 from addict import Dict
 from cadet import Cadet as CadetAPI
 
-from CADETProcess import CADETProcessError, SimulationResults, settings
+from CADETProcess import CADETProcessError, settings
 from CADETProcess.dataStructure import (
     Bool,
     ParameterWrapper,
@@ -38,6 +38,7 @@ from CADETProcess.processModel import (
     TubularReactor,
     UnitBaseClass,
 )
+from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.solution import (
     SolutionBulk,
     SolutionIO,

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -3,11 +3,14 @@ from typing import Any, Optional
 
 import numpy as np
 
-from CADETProcess import CADETProcessError, SimulationResults
+from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import Bool, Structure, UnsignedFloat, UnsignedInteger
 from CADETProcess.log import get_logger, log_exceptions, log_results, log_time
 from CADETProcess.processModel import Process
+from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.stationarity import NRMSE, RelativeArea, StationarityEvaluator
+
+__all__ = ["SimulatorBase"]
 
 
 class SimulatorBase(Structure):

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -21,10 +21,11 @@ from typing import Any, Optional
 import numpy as np
 from addict import Dict
 
-from CADETProcess import SimulationResults, log
+from CADETProcess import log
 from CADETProcess.comparison import Comparator
 from CADETProcess.dataStructure import Structure, UnsignedFloat
 from CADETProcess.processModel import Inlet
+from CADETProcess.simulationResults import SimulationResults
 
 __all__ = ["RelativeArea", "NRMSE", "StationarityEvaluator"]
 

--- a/tests/test_cadet_adapter.py
+++ b/tests/test_cadet_adapter.py
@@ -6,9 +6,10 @@ from typing import Optional
 import numpy as np
 import numpy.testing as npt
 import pytest
-from CADETProcess import CADETProcessError, SimulationResults
+from CADETProcess import CADETProcessError
 from CADETProcess.processModel import Process
 from CADETProcess.processModel.discretization import NoDiscretization
+from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.simulator import Cadet
 
 from tests.create_LWE import create_lwe

--- a/tests/test_equilibrium.py
+++ b/tests/test_equilibrium.py
@@ -50,51 +50,53 @@ class TestReactionEquilibrium(unittest.TestCase):
 
     def test_dydx(self):
         buffer = [1, 0]
-        dydx = equilibria.dydx_mal(buffer, self.single_1)
+        dydx = equilibria.reaction_equilibria.dydx_mal(buffer, self.single_1)
         dydx_expected = [-1, 1]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [1, 0, 0]
-        dydx = equilibria.dydx_mal(buffer, self.single_2)
+        dydx = equilibria.reaction_equilibria.dydx_mal(buffer, self.single_2)
         dydx_expected = [-1, 1, 0]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [1, 0, 0]
-        dydx = equilibria.dydx_mal(buffer, self.single_2, constant_indices=[0])
+        dydx = equilibria.reaction_equilibria.dydx_mal(
+            buffer, self.single_2, constant_indices=[0]
+        )
         dydx_expected = [0, 1, 0]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [1, 0, 0]
         buffer_init = [2, 0, 0]
-        dydx = equilibria.dydx_mal(
+        dydx = equilibria.reaction_equilibria.dydx_mal(
             buffer, self.single_2, constant_indices=[0], c_init=buffer_init
         )
         dydx_expected = [0, 2, 0]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [1, 0, 0]
-        dydx = equilibria.dydx_mal(buffer, self.multi)
+        dydx = equilibria.reaction_equilibria.dydx_mal(buffer, self.multi)
         dydx_expected = [-1, 1, 0]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [1, 1, 0]
-        dydx = equilibria.dydx_mal(buffer, self.multi)
+        dydx = equilibria.reaction_equilibria.dydx_mal(buffer, self.multi)
         dydx_expected = [0, -1, 1]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [1, 1, 1]
-        dydx = equilibria.dydx_mal(buffer, self.multi)
+        dydx = equilibria.reaction_equilibria.dydx_mal(buffer, self.multi)
         dydx_expected = [0, 0, 0]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
         buffer = [0, 1, 0]
-        dydx = equilibria.dydx_mal(buffer, self.multi)
+        dydx = equilibria.reaction_equilibria.dydx_mal(buffer, self.multi)
         dydx_expected = [1, -2, 1]
         np.testing.assert_almost_equal(dydx, dydx_expected)
 
     def test_jac(self):
         buffer = [1, 0]
-        jac = equilibria.jac_mal(buffer, self.single_0)
+        jac = equilibria.reaction_equilibria.jac_mal(buffer, self.single_0)
         jac_expected = [[-2, 2], [2, -2]]
         np.testing.assert_almost_equal(jac, jac_expected)
 


### PR DESCRIPTION
Currently, CADET-Process takes quite long to import. To increase import speed, I removed most import statements from the main `__init__.py`. Since we mostly import from the submodules anyways, this should not cause much trouble. AFAIK, only the `SimulationResults` were previously sometimes imported directly from `CADETProcess`.

Moreover, I udated most modules' `__all__` to reduce the number of imports when using wildcards (`*`)

```
python -X importtime -c "import CADETProcess"
```

Now give me ~500 ms, previously, this was ~2-3 s.