### PR TITLE
Update Ax to v1.0.0

### DIFF
--- a/CADETProcess/optimization/__init__.py
+++ b/CADETProcess/optimization/__init__.py
@@ -107,7 +107,7 @@ from .pymooAdapter import NSGA2, U_NSGA3
 import importlib
 
 try:
-    from .axAdapater import BotorchModular, GPEI, NEHVI, qNParEGO
+    from .axAdapater import GPEI
 
     ax_imported = True
 except ImportError:
@@ -115,7 +115,7 @@ except ImportError:
 
 
 def __getattr__(name):
-    if name in ("BotorchModular", "GPEI", "NEHVI", "qNParEGO"):
+    if name in ("GPEI"):
         if ax_imported:
             module = importlib.import_module("axAdapter", package=__name__)
             return getattr(module, name)

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -311,49 +311,51 @@ class AxInterface(OptimizerBase):
             # When returning to batch trials, the Arms can be initialized here
             # and then collectively returned. See commit history
 
-    def _post_processing(self, trial: BaseTrial) -> None:
+    def _post_processing(
+            self,
+            trials: Dict[int, Dict[str, float]],
+            results: Dict[int, Dict[str, float]],
+            generation: int,
+        ) -> None:
         """
         Run post processing.
 
-        Ax holds the data of the model in a dataframe an experiment consists of trials
-        which consist of arms in a sequential experiment, each trial only has one arm.
+        Expects a Dictionary of Dicts that hold the variable names : values pairs
+        the same for results (objective function, nonlinear constraints)
 
-        Arms are evaluated. These hold the parameters.
+        Parameters
+        ----------
+
+        trials: Dict[int, Dict[str, float]]
+            The values (variables) for which the problem was evaluated. Each index
+            corresponds to a complete trial and holds its variable:value pairs
+        results: Dict[int, Dict[str, float]]
+            The values (objective function results) of the problem evaluated at the
+            corresponding variable values. Each index corresponds to a complete trial
+            and holds its variable:value pairs
+        generation: int
+            Index of the batch trial
         """
         op = self.optimization_problem
 
-        # get the trial level data as a dataframe
-        trial_data = self.ax_experiment.fetch_trials_data([trial.index])
-        data = trial_data.df
-
-        # DONE: Update for multi-processing. If n_cores > 1: len(arms) > 1 (oder @Flo?)
-        X = np.array([list(arm.parameters.values()) for arm in trial.arms])
-        objective_labels = [
-            f"{obj_name}_axidx_{i}" for i, obj_name in enumerate(op.objective_labels)
-        ]
-
-        n_ind = len(X)
+        # Get variable value in the order of the optimization problem
+        X = np.array([
+            [trial[var] for var in op.variable_names]
+            for _, trial in trials.items()
+        ])
 
         # Get objective values
-        F_data = data[data["metric_name"].isin(objective_labels)]
-        assert np.all(
-            F_data["metric_name"].values
-            == np.repeat(objective_labels, len(X)).astype(object)
-        )
-        F = F_data["mean"].values.reshape((op.n_objectives, n_ind)).T
+        F = np.array([
+            [result[obj_label] for obj_label in op.objective_labels]
+            for _, result in results.items()
+        ])
 
-        # Get nonlinear constraint values
+        # Get nonlinear constraints values
         if op.n_nonlinear_constraints > 0:
-            nonlincon_labels = [
-                f"{name}_axidx_{i}"
-                for i, name in enumerate(op.nonlinear_constraint_labels)
-            ]
-            G_data = data[data["metric_name"].isin(nonlincon_labels)]
-            assert np.all(
-                G_data["metric_name"].values.tolist()
-                == np.repeat(nonlincon_labels, len(X))
-            )
-            G = G_data["mean"].values.reshape((op.n_nonlinear_constraints, n_ind)).T
+            G = np.array([
+                [result[obj_label] for obj_label in op.nonlinear_constraint_labels]
+                for _, result in results.items()
+            ])
 
             nonlincon_cv_fun = op.evaluate_nonlinear_constraints_violation
             CV = nonlincon_cv_fun(X, untransform=True, get_dependent_values=True)
@@ -371,7 +373,7 @@ class AxInterface(OptimizerBase):
             F_minimized=F,
             G=G,
             CV_nonlincon=CV,
-            current_generation=self.ax_experiment.num_trials,
+            current_generation=generation,
             X_opt_transformed=None,
         )
 
@@ -497,13 +499,14 @@ class AxInterface(OptimizerBase):
 
                 # tell
                 for trial_index, trial in trials.items():
-                    # self._post_processing(trial)
+                    self._post_processing(results=results, trials=trials, generation=n_iter)
 
                     print(f"Completed {trial_index=} with {results[trial_index]=}")
                     client.complete_trial(
                         trial_index=trial_index,
                         raw_data=results[trial_index]
                     )
+
 
                 # # The strategy itself will check if enough trials have already been
                 # # completed.

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -292,24 +292,22 @@ class AxInterface(OptimizerBase):
             trial, F, objective_labels, G, nonlincon_labels
         )
 
-    def _create_manual_trial(self, X: npt.ArrayLike) -> None:
+    def _create_manual_trials(self, X: npt.ArrayLike) -> None:
         """Create trial from pre-evaluated data."""
-        # variables = self.optimization_problem.independent_variable_names
+        variables = self.optimization_problem.independent_variable_names
 
+        trials = {}
         for i, x in enumerate(X):
-            trial = self.ax_experiment.new_trial()
-            # trial_data = {
-            #     "input": {var: x_i for var, x_i in zip(variables, x)},
-            # }
+            par = {var: x_i for var, x_i in zip(variables, x)}
 
-            # arm_name = f"{trial.index}_{0}"
-            # trial.add_arm(Arm(parameters=trial_data["input"], name=arm_name))
-            trial.run()
-            trial.mark_completed()
-            self._post_processing(trial)
+            trial_index = self.client.attach_trial(
+                arm_name=i,
+                parameters=par
+            )
+            trials.update({trial_index: par})
 
-            # When returning to batch trials, the Arms can be initialized here
-            # and then collectively returned. See commit history
+        return trials
+
 
     def _post_processing(
             self,
@@ -399,10 +397,10 @@ class AxInterface(OptimizerBase):
         self, optimization_problem: OptimizationProblem, x0: npt.ArrayLike
     ) -> None:
 
-        client = Client()
+        self.client = Client()
 
         parameters, constraints = self._setup_searchspace(self.optimization_problem)
-        client.configure_experiment(
+        self.client.configure_experiment(
             parameters=parameters,
             parameter_constraints=constraints,
             name=str(optimization_problem),
@@ -413,10 +411,16 @@ class AxInterface(OptimizerBase):
 
         objectives = self._setup_objectives()
         outcome_constraints = self._setup_outcome_constraints()
-        client.configure_optimization(
+        self.client.configure_optimization(
             objective=objectives,
             outcome_constraints=outcome_constraints
         )
+
+        self.runner = CADETProcessRunner(
+            optimization_problem=self.optimization_problem,
+            parallelization_backend=SequentialBackend(),
+        )
+
 
         if False:
             self.global_stopping_strategy = ImprovementGlobalStoppingStrategy(
@@ -426,51 +430,61 @@ class AxInterface(OptimizerBase):
                 inactive_when_pending_trials=True,
             )
 
+            # TODO: remove. Old.
             # Internal storage for tracking data
-            self._data = self.ax_experiment.fetch_data()
+            # self._data = self.ax_experiment.fetch_data()
 
             # Restore previous results from checkpoint
-            if len(self.results.populations) > 0:
-                for pop in self.results.populations:
-                    X, F, G = pop.x, pop.f, pop.g
-                    trial = self._create_manual_trial(X)
-                    trial.mark_running(no_runner_required=True)
+        if len(self.results.populations) > 0:
+            for pop in self.results.populations:
+                X, F, G = pop.x, pop.f, pop.g
+                trials = self._create_manual_trials(X)
 
-                    trial_data = self._create_manual_data(trial, F, G)
-                    trial.run_metadata.update(trial_data)
-                    trial.mark_completed()
+                # trial_data = self._create_manual_data(trial, F, G)
+                # trial.run_metadata.update(trial_data)
+                # trial.mark_completed()
+
+        else:
+            if x0 is not None:
+                x0_init = np.array(x0, ndmin=2)
+
+                if len(x0_init) < self.n_init_evals:
+                    warnings.warn(
+                        "Initial population smaller than popsize. " +
+                        "Creating missing entries."
+                    )
+                    n_remaining = self.n_init_evals - len(x0_init)
+                    x0_remaining = optimization_problem.create_initial_values(
+                        n_remaining, seed=self.seed, include_dependent_variables=False
+                    )
+                    x0_init = np.vstack((x0_init, x0_remaining))
+                elif len(x0_init) > self.n_init_evals:
+                    warnings.warn(
+                        "Initial population larger than popsize. Omitting overhead."
+                    )
+                    x0_init = x0_init[0 : self.n_init_evals]
 
             else:
-                if x0 is not None:
-                    x0_init = np.array(x0, ndmin=2)
+                # Create initial samples if they are not provided
+                x0_init = self.optimization_problem.create_initial_values(
+                    n_samples=self.n_init_evals,
+                    include_dependent_variables=False,
+                    seed=self.seed + 5641,
+                )
 
-                    if len(x0_init) < self.n_init_evals:
-                        warnings.warn(
-                            "Initial population smaller than popsize. "
-                            "Creating missing entries."
-                        )
-                        n_remaining = self.n_init_evals - len(x0_init)
-                        x0_remaining = optimization_problem.create_initial_values(
-                            n_remaining, seed=self.seed, include_dependent_variables=False
-                        )
-                        x0_init = np.vstack((x0_init, x0_remaining))
-                    elif len(x0_init) > self.n_init_evals:
-                        warnings.warn(
-                            "Initial population larger than popsize. Omitting overhead."
-                        )
-                        x0_init = x0_init[0 : self.n_init_evals]
+            x0_init_transformed = np.array(optimization_problem.transform(x0_init))
+            trials = self._create_manual_trials(x0_init_transformed)
+            # print(exp_to_df(self.ax_experiment))
 
-                else:
-                    # Create initial samples if they are not provided
-                    x0_init = self.optimization_problem.create_initial_values(
-                        n_samples=self.n_init_evals,
-                        include_dependent_variables=False,
-                        seed=self.seed + 5641,
-                    )
-
-                x0_init_transformed = np.array(optimization_problem.transform(x0_init))
-                self._create_manual_trial(x0_init_transformed)
-                # print(exp_to_df(self.ax_experiment))
+        # complete initial trials
+        results = self.runner.run_trials(trials=trials)
+        self._post_processing(trials=trials, results=results, generation=0)
+        for trial_index, trial in trials.items():
+            print(f"Completed {trial_index=} with {results[trial_index]=}")
+            self.client.complete_trial(
+                trial_index=trial_index,
+                raw_data=results[trial_index]
+            )
 
         n_iter = self.results.n_gen
         n_evals = self.results.n_evals
@@ -479,30 +493,25 @@ class AxInterface(OptimizerBase):
 
         if n_evals >= self.n_max_evals:
             raise CADETProcessError(
-                f"Initial number of evaluations exceeds `n_max_evals` "
+                "Initial number of evaluations exceeds `n_max_evals` " +
                 f"({self.n_max_evals})."
             )
-
-        runner = CADETProcessRunner(
-            optimization_problem=self.optimization_problem,
-            parallelization_backend=SequentialBackend(),
-        )
 
         with manual_seed(seed=self.seed):
             while not (n_evals >= self.n_max_evals or n_iter >= self.n_max_iter):
                 print(f"Running optimization trial {n_evals + 1}/{self.n_max_evals}...")
 
                 # ask
-                trials = client.get_next_trials(max_trials=3)
+                trials = self.client.get_next_trials(max_trials=3)
 
-                results = runner.run_trials(trials=trials)
+                # compute
+                results = self.runner.run_trials(trials=trials)
+                self._post_processing(results=results, trials=trials, generation=n_iter)
 
                 # tell
                 for trial_index, trial in trials.items():
-                    self._post_processing(results=results, trials=trials, generation=n_iter)
-
                     print(f"Completed {trial_index=} with {results[trial_index]=}")
-                    client.complete_trial(
+                    self.client.complete_trial(
                         trial_index=trial_index,
                         raw_data=results[trial_index]
                     )
@@ -524,7 +533,7 @@ class AxInterface(OptimizerBase):
                 n_iter += 1
                 n_evals += len(trials)
 
-        best_parameters, prediction, index, name = client.get_best_parameterization()
+        best_parameters, prediction, index, name = self.client.get_best_parameterization()
         print("Best Parameters:", best_parameters)
         print("Prediction (mean, variance):", prediction)
 

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -23,7 +23,6 @@ from ax.core import (
 )
 from ax.core.base_trial import BaseTrial
 from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingStrategy
-
 # from ax.models.torch.botorch_defaults import get_qLogNEI
 # from ax.models.torch.botorch_modular.surrogate import Surrogate
 # from ax.service.utils.report_utils import exp_to_df
@@ -31,6 +30,7 @@ from ax.global_stopping.strategies.improvement import ImprovementGlobalStoppingS
 # from botorch.acquisition.analytic import LogExpectedImprovement
 # from botorch.models.gp_regression import SingleTaskGP
 from botorch.utils.sampling import manual_seed
+from botorch.exceptions.errors import CandidateGenerationError
 
 from CADETProcess import CADETProcessError
 from CADETProcess.dataStructure import Float, UnsignedInteger
@@ -44,7 +44,6 @@ from CADETProcess.optimization.parallelizationBackend import (
 __all__ = [
     "GPEI",
 ]
-
 
 # class CADETProcessMetric(IMetric):
 #     def __init__(
@@ -447,7 +446,8 @@ class AxInterface(OptimizerBase):
         # Restore previous results from checkpoint
         if len(self.results.populations) > 0:
             for pop in self.results.populations:
-                X, F, CV = pop.x, pop.f, pop.cv_nonlincon
+                # TODO: @Jo: Is it correct to use transformed x here?
+                X, F, CV = pop.x_transformed, pop.f, pop.cv_nonlincon
                 trials = self._create_manual_trials(X)
                 trial_data = self._create_manual_data(trials, F, CV)
                 self._complete_trials(trials, trial_data)
@@ -496,7 +496,9 @@ class AxInterface(OptimizerBase):
         n_gen = self.results.n_gen  # first generation is the 0-th generation
         n_evals = self.results.n_evals
 
-        global_stopping_message = None
+        msg = None
+        exit_flag = 0
+        success = True
 
         if n_evals >= self.n_max_evals:
             raise CADETProcessError(
@@ -514,7 +516,30 @@ class AxInterface(OptimizerBase):
                 # ask
                 # make sure the max_trials are not overfulfilled due to parallelism
                 max_trials = min(self.n_parallel_evals, self.n_max_evals - n_evals)
-                trials = self.client.get_next_trials(max_trials=max_trials)
+
+                try:
+                    trials = self.client.get_next_trials(max_trials=max_trials)
+                except CandidateGenerationError as err:
+                    # This is currently not 100% stable. The reason is that
+                    # Ax might run into a situation where the acquisition fct. suggests
+                    # values only close to the bounds, which are also the optimum.
+                    # Then botorch accepts values near the linear constraints (bounds) with
+                    # a precision of 1e-6. This limit is hardcoded and cannot be changed
+                    # Repeating the process seems to help, but it is a hotfix.
+                    # A more stable and guaranteed failsafe method would be desirable.
+                    # Perhaps an update to a future version of Ax fixes this. I don't
+                    # think it is good form to provide an optimizert which fails.
+                    # Another option is to catch it and then exit the optimization early
+                    # with success_code = 0
+                    # TODO: @Jo: What do you prefer
+                    msg = (
+                        "Trials could not be generated due to too tight constraints. " +
+                        "This could also indicate that optimization is close to the " +
+                        "optimum and candidates are hard to find. " +
+                        f"Retrying once, failing afterwards. {err}"
+                    )
+                    warnings.warn(msg)
+                    trials = self.client.get_next_trials(max_trials=max_trials)
 
                 # compute
                 # Ax allows trials to be of type str, int, float, bool. This is not supported
@@ -524,7 +549,6 @@ class AxInterface(OptimizerBase):
 
                 # tell
                 self._complete_trials(trials=trials, data=results)
-
 
                 # # The strategy itself will check if enough trials have already been
                 # # completed.
@@ -542,15 +566,14 @@ class AxInterface(OptimizerBase):
                 n_gen += 1
                 n_evals += len(trials)
 
-
         # pareto = self.client.get_pareto_frontier()
         # best_parameters, prediction, index, name = self.client.get_best_parameterization()
         # print("Best Parameters:", best_parameters)
         # print("Prediction (mean, variance):", prediction)
 
-        self.results.success = True
-        self.results.exit_flag = 0
-        self.results.exit_message = global_stopping_message
+        self.results.success = success
+        self.results.exit_flag = exit_flag
+        self.results.exit_message = msg
 
 
 # class SingleObjectiveAxInterface(AxInterface):

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -1,5 +1,5 @@
 import warnings
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Mapping
 
 import numpy as np
 import numpy.typing as npt
@@ -94,7 +94,10 @@ class CADETProcessRunner:
         self.optimization_problem = optimization_problem
         self.parallelization_backend = parallelization_backend
 
-    def run_trials(self, trials: Dict[int, Dict[str, float]]) -> Dict[str, Any]:
+    def run_trials(
+        self,
+        trials: Dict[str | int, Mapping[str, float]]
+    ) -> Dict[str | int, Dict[str, float]]:
         # Get X from arms.
         X = []
         for trial_index, trial in trials.items():
@@ -147,11 +150,11 @@ class CADETProcessRunner:
 
     @staticmethod
     def get_metadata(
-        trials: BaseTrial,
+        trials: Dict[str | int, Mapping[str, float]],
         F: np.ndarray,
         objective_labels: list[str],
-        CV: np.ndarray,
-        nonlincon_labels: list[str],
+        CV: Optional[np.ndarray] = None,
+        nonlincon_labels: Optional[list[str]] = None,
     ) -> dict:
         trial_metadata = {}
 
@@ -162,6 +165,9 @@ class CADETProcessRunner:
             }
             cv_dict = {}
             if CV is not None:
+                assert nonlincon_labels is not None, (
+                    "If CV are given, nonlinear-constraint labels must also be given."
+                )
                 cv_dict = {
                     metric: cv_metric[results_index]
                     for metric, cv_metric in zip(nonlincon_labels, CV.T)
@@ -182,6 +188,7 @@ class AxInterface(OptimizerBase):
 
     early_stopping_improvement_window = UnsignedInteger(default=1000)
     early_stopping_improvement_bar = Float(default=1e-10)
+    n_parallel_evals = UnsignedInteger(default=3)
     n_init_evals = UnsignedInteger(default=10)
     n_max_evals = UnsignedInteger(default=100)
     seed = UnsignedInteger(default=12345)
@@ -240,7 +247,7 @@ class AxInterface(OptimizerBase):
         parameter_constraints = cls._setup_linear_constraints(optimizationProblem)
         return parameters, parameter_constraints
 
-    def _setup_objectives(self) -> list:
+    def _setup_objectives(self) -> str:
         """Parse objective functions from optimization problem."""
         objective_names = self.optimization_problem.objective_labels
 
@@ -280,34 +287,46 @@ class AxInterface(OptimizerBase):
         return outcome_constraints
 
     def _create_manual_data(
-        self, trial: BaseTrial, F: npt.ArrayLike, G: Optional[npt.ArrayLike] = None
+        self, trial: Dict, F: np.ndarray, CV: Optional[np.ndarray] = None
     ) -> dict:
         objective_labels = self.optimization_problem.objective_labels
         nonlincon_labels = self.optimization_problem.nonlinear_constraint_labels
         return CADETProcessRunner.get_metadata(
-            trial, F, objective_labels, G, nonlincon_labels
+            trial, F, objective_labels, CV, nonlincon_labels
         )
 
-    def _create_manual_trials(self, X: npt.ArrayLike) -> None:
+    def _create_manual_trials(self, X: np.ndarray) -> Dict[str | int, Mapping[str, float]]:
         """Create trial from pre-evaluated data."""
         variables = self.optimization_problem.independent_variable_names
 
         trials = {}
-        for i, x in enumerate(X):
+        for x in X:
             par = {var: x_i for var, x_i in zip(variables, x)}
+            _id = self.client._experiment.num_trials
 
             trial_index = self.client.attach_trial(
-                arm_name=i,
+                arm_name=_id,
                 parameters=par
             )
             trials.update({trial_index: par})
 
         return trials
 
+    def _complete_trials(
+        self, trials: Dict[str | int, Mapping[str, float]],
+        data: Dict[str | int, Dict[str, float]]
+    ) -> None:
+        for trial_index, _ in trials.items():
+            print(f"Completed {trial_index=} with {data[trial_index]=}")
+            self.client.complete_trial(
+                trial_index=trial_index,
+                raw_data=data[trial_index]
+            )
+
     def _post_processing(
             self,
-            trials: Dict[int, Dict[str, float]],
-            results: Dict[int, Dict[str, float]],
+            trials: Dict[str | int, Mapping[str, float]],
+            results: Dict[str | int, Dict[str, float]],
             generation: int,
         ) -> None:
         """
@@ -417,6 +436,7 @@ class AxInterface(OptimizerBase):
 
 
         if False:
+            # TODO: Earlier implementation. Needs to be migrated to Ax Client API
             self.global_stopping_strategy = ImprovementGlobalStoppingStrategy(
                 min_trials=self.n_init_evals + self.early_stopping_improvement_window,
                 window_size=self.early_stopping_improvement_window,
@@ -424,19 +444,15 @@ class AxInterface(OptimizerBase):
                 inactive_when_pending_trials=True,
             )
 
-            # TODO: remove. Old.
-            # Internal storage for tracking data
-            # self._data = self.ax_experiment.fetch_data()
-
-            # Restore previous results from checkpoint
+        # Restore previous results from checkpoint
         if len(self.results.populations) > 0:
             for pop in self.results.populations:
-                X, F, G = pop.x, pop.f, pop.g
+                X, F, CV = pop.x, pop.f, pop.cv_nonlincon
                 trials = self._create_manual_trials(X)
-
-                # trial_data = self._create_manual_data(trial, F, G)
-                # trial.run_metadata.update(trial_data)
-                # trial.mark_completed()
+                trial_data = self._create_manual_data(trials, F, CV)
+                self._complete_trials(trials, trial_data)
+                # this starts with N generations, depending how many generation
+                # strategies completed in the previous run
 
         else:
             if x0 is not None:
@@ -468,19 +484,16 @@ class AxInterface(OptimizerBase):
 
             x0_init_transformed = np.array(optimization_problem.transform(x0_init))
             trials = self._create_manual_trials(x0_init_transformed)
-            # print(exp_to_df(self.ax_experiment))
 
-        # complete initial trials
-        results = self.runner.run_trials(trials=trials)
-        self._post_processing(trials=trials, results=results, generation=0)
-        for trial_index, trial in trials.items():
-            print(f"Completed {trial_index=} with {results[trial_index]=}")
-            self.client.complete_trial(
-                trial_index=trial_index,
-                raw_data=results[trial_index]
-            )
+            # complete initial trials
+            results = self.runner.run_trials(trials=trials)
+            self._post_processing(trials=trials, results=results, generation=0)
+            
+            self._complete_trials(trials=trials, data=results)
+            # this starts with 1 generation (the init trials)
 
-        n_iter = self.results.n_gen
+
+        n_gen = self.results.n_gen  # first generation is the 0-th generation
         n_evals = self.results.n_evals
 
         global_stopping_message = None
@@ -492,23 +505,25 @@ class AxInterface(OptimizerBase):
             )
 
         with manual_seed(seed=self.seed):
-            while not (n_evals >= self.n_max_evals or n_iter >= self.n_max_iter):
+            # comparison against self.n_max_iter needs to be < (and not <=) because
+            # the comparison is against the current generation that starts at 0. and the
+            # states are updated at the end of the loop
+            while n_evals < self.n_max_evals and n_gen < self.n_max_iter:
                 print(f"Running optimization trial {n_evals + 1}/{self.n_max_evals}...")
 
                 # ask
-                trials = self.client.get_next_trials(max_trials=3)
+                # make sure the max_trials are not overfulfilled due to parallelism
+                max_trials = min(self.n_parallel_evals, self.n_max_evals - n_evals)
+                trials = self.client.get_next_trials(max_trials=max_trials)
 
                 # compute
+                # Ax allows trials to be of type str, int, float, bool. This is not supported
+                # by ax. Therefore typing suggests an error. We choose to ignore it.
                 results = self.runner.run_trials(trials=trials)
-                self._post_processing(results=results, trials=trials, generation=n_iter)
+                self._post_processing(results=results, trials=trials, generation=n_gen)
 
                 # tell
-                for trial_index, trial in trials.items():
-                    print(f"Completed {trial_index=} with {results[trial_index]=}")
-                    self.client.complete_trial(
-                        trial_index=trial_index,
-                        raw_data=results[trial_index]
-                    )
+                self._complete_trials(trials=trials, data=results)
 
 
                 # # The strategy itself will check if enough trials have already been
@@ -524,7 +539,7 @@ class AxInterface(OptimizerBase):
                 #     print(global_stopping_message)
                 #     break
 
-                n_iter += 1
+                n_gen += 1
                 n_evals += len(trials)
 
 

--- a/CADETProcess/optimization/axAdapater.py
+++ b/CADETProcess/optimization/axAdapater.py
@@ -175,7 +175,7 @@ class AxInterface(OptimizerBase):
     """Wrapper around Ax's bayesian optimization API."""
 
     supports_bounds = True
-    supports_multi_objective = False
+    supports_multi_objective = True
     supports_linear_constraints = True
     supports_linear_equality_constraints = False
     supports_nonlinear_constraints = True
@@ -202,7 +202,7 @@ class AxInterface(OptimizerBase):
 
             if "-" in var.name or "+" in var.name:
                 raise CADETProcessError(
-                    f"Bad parameter name: '{var.name}'. Ax does not "
+                    f"Bad parameter name: '{var.name}'. Ax does not " +
                     "support dashes ('-','+') in parameter names."
                 )
 
@@ -246,12 +246,6 @@ class AxInterface(OptimizerBase):
 
         objectives = []
         for i, obj_name in enumerate(objective_names):
-            # ax_metric = CADETProcessMetric(
-            #     name=f"{obj_name}_axidx_{i}",
-            #     lower_is_better=True,
-            # )
-            # obj = Objective(metric=ax_metric, minimize=True)
-
             # TODO: add +
             if "-" in obj_name:
                 raise CADETProcessError(
@@ -266,18 +260,20 @@ class AxInterface(OptimizerBase):
 
     def _setup_outcome_constraints(self) -> list:
         """Parse nonliear constraint functions from optimization problem."""
-        nonlincon_names = self.optimization_problem.nonlinear_constraint_labels
-
         outcome_constraints = []
-        for i_constr, name in enumerate(nonlincon_names):
-            raise NotImplementedError("Migrate to ax 1.0.0")
-            # ax_metric = CADETProcessMetric(name=f"{name}_axidx_{i_constr}")
-
-            nonlincon = OutcomeConstraint(
-                # metric=ax_metric,
-                op=ComparisonOp.LEQ,
-                bound=0.0,
-                relative=False,
+        for constr_label, constr_bound in zip(
+            self.optimization_problem.nonlinear_constraint_labels,
+            self.optimization_problem.nonlinear_constraints_bounds,
+        ):
+            if "<lambda>" in constr_label:
+                raise CADETProcessError(
+                    "lambda functions are not allowed as nonlinear constraints " +
+                    "under Ax usage."
+                )
+            # TODO: @Jo is it correct that the operator is always leq?
+            nonlincon = "{constraint} <= {bound}".format(
+                constraint=constr_label,
+                bound=constr_bound,
             )
             outcome_constraints.append(nonlincon)
 
@@ -308,7 +304,6 @@ class AxInterface(OptimizerBase):
 
         return trials
 
-
     def _post_processing(
             self,
             trials: Dict[int, Dict[str, float]],
@@ -323,7 +318,6 @@ class AxInterface(OptimizerBase):
 
         Parameters
         ----------
-
         trials: Dict[int, Dict[str, float]]
             The values (variables) for which the problem was evaluated. Each index
             corresponds to a complete trial and holds its variable:value pairs
@@ -334,7 +328,7 @@ class AxInterface(OptimizerBase):
         generation: int
             Index of the batch trial
         """
-        op = self.optimization_problem
+        op: OptimizationProblem = self.optimization_problem
 
         # Get variable value in the order of the optimization problem
         X = np.array([
@@ -533,9 +527,11 @@ class AxInterface(OptimizerBase):
                 n_iter += 1
                 n_evals += len(trials)
 
-        best_parameters, prediction, index, name = self.client.get_best_parameterization()
-        print("Best Parameters:", best_parameters)
-        print("Prediction (mean, variance):", prediction)
+
+        # pareto = self.client.get_pareto_frontier()
+        # best_parameters, prediction, index, name = self.client.get_best_parameterization()
+        # print("Best Parameters:", best_parameters)
+        # print("Prediction (mean, variance):", prediction)
 
         self.results.success = True
         self.results.exit_flag = 0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ dev = [
 
 [project.optional-dependencies]
 ax = [
-    "ax-platform >=0.3.5,<0.5.0"
+    "ax-platform >=1.0.0,<2.0.0"
 ]
 all = [
    "CADET-Process[ax]",

--- a/tests/optimization_problem_fixtures.py
+++ b/tests/optimization_problem_fixtures.py
@@ -252,7 +252,9 @@ class NonlinearConstraintsSooTestProblem(TestProblem):
         constraints.
         TODO: Bounds are probably redundant
         """
-        nlc_fun_0 = lambda x: -1 * x[0] - 0.5 * x[1]
+        def nlc_fun_0(x):
+            return -1 * x[0] - 0.5 * x[1]
+
         self.add_nonlinear_constraint(
             nlc_fun_0,
             bounds=0,

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -15,8 +15,6 @@ skip_ax = False
 try:
     from CADETProcess.optimization import (
         GPEI,
-        NEHVI,
-        qNParEGO,
     )
 except ImportError:
     skip_ax = True
@@ -121,19 +119,19 @@ if not skip_ax:
         early_stopping_improvement_window = 10
         n_max_evals = 50
 
-    class NEHVI(NEHVI):
-        cv_lincon_tol = CV_LINCON_TOL
-        n_init_evals = 50
-        early_stopping_improvement_bar = 1e-4
-        early_stopping_improvement_window = 10
-        n_max_evals = 60
+    # class NEHVI(NEHVI):
+    #     cv_lincon_tol = CV_LINCON_TOL
+    #     n_init_evals = 50
+    #     early_stopping_improvement_bar = 1e-4
+    #     early_stopping_improvement_window = 10
+    #     n_max_evals = 60
 
-    class qNParEGO(qNParEGO):
-        cv_lincon_tol = CV_LINCON_TOL
-        n_init_evals = 50
-        early_stopping_improvement_bar = 1e-4
-        early_stopping_improvement_window = 10
-        n_max_evals = 70
+    # class qNParEGO(qNParEGO):
+    #     cv_lincon_tol = CV_LINCON_TOL
+    #     n_init_evals = 50
+    #     early_stopping_improvement_bar = 1e-4
+    #     early_stopping_improvement_window = 10
+    #     n_max_evals = 70
 
 
 # %% Test problem factory
@@ -174,8 +172,6 @@ if not skip_ax:
     params.extend(
         [
             GPEI,
-            NEHVI,
-            qNParEGO,
         ]
     )
     EXCLUDE_COMBINATIONS.append(
@@ -183,9 +179,9 @@ if not skip_ax:
     )
 
     # this helps to test optimizers for hard problems
-    NON_DEFAULT_PARAMETERS.append(
-        (NEHVI, LinearConstraintsMooTestProblem, {"n_init_evals": 20, "n_max_evals": 40})
-    )
+    # NON_DEFAULT_PARAMETERS.append(
+    #     (NEHVI, LinearConstraintsMooTestProblem, {"n_init_evals": 20, "n_max_evals": 40})
+    # )
 
 
 @pytest.fixture(params=params)

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -65,6 +65,9 @@ EXCLUDE_COMBINATIONS = [
 NON_DEFAULT_PARAMETERS = [
     (U_NSGA3, NonlinearConstraintsMooTestProblem, {"pop_size": 300, "n_max_gen": 40}),
     (U_NSGA3, Rosenbrock, {"pop_size": 300, "n_max_gen": 20}),
+    (COBYLA, Rosenbrock, {"rhobeg": 0.1, "tol": 0.00001}),
+    (SLSQP, Rosenbrock, {"ftol": 0.0001}),
+    (GPEI, LinearConstraintsMooTestProblem, {"n_max_evals": 60}),
 ]
 
 
@@ -161,11 +164,11 @@ def optimization_problem(request):
 
 
 params = [
-    TrustConstr,
-    COBYLA,
-    SLSQP,
-    NelderMead,
-    U_NSGA3,
+    # TrustConstr,
+    # COBYLA,
+    # SLSQP,
+    # NelderMead,
+    # U_NSGA3,
 ]
 
 if not skip_ax:
@@ -199,6 +202,9 @@ def test_convergence(optimization_problem: TestProblem, optimizer: OptimizerBase
     # pytest.skip()
 
     if optimizer.check_optimization_problem(optimization_problem):
+        set_non_default_parameters(optimizer, optimization_problem)
+        skip_if_combination_excluded(optimizer, optimization_problem)
+
         results = optimizer.optimize(
             optimization_problem=optimization_problem,
             save_results=False,
@@ -207,7 +213,8 @@ def test_convergence(optimization_problem: TestProblem, optimizer: OptimizerBase
             optimization_problem.test_if_solved(results, SOO_TEST_KWARGS)
         else:
             optimization_problem.test_if_solved(results, MOO_TEST_KWARGS)
-
+    else:
+        pytest.skip()
 
 @pytest.mark.slow
 def test_from_initial_values(
@@ -254,11 +261,13 @@ class AbortingCallback:
 def test_resume_from_checkpoint(
     optimization_problem: TestProblem, optimizer: OptimizerBase
 ):
-    pytest.skip()
+    # pytest.skip()
+
+    n_obj = optimization_problem.n_objectives
 
     # TODO: Do we need to run this for all problems?
     if optimizer.check_optimization_problem(optimization_problem):
-        callback = AbortingCallback(n_max_evals=2, abort=True)
+        callback = AbortingCallback(n_max_evals=2 * n_obj, abort=True)
         optimization_problem.add_callback(callback)
 
         # TODO: How would this work for evaluation based optimizers (vs generation based)?
@@ -297,8 +306,9 @@ def test_resume_from_checkpoint(
         np.testing.assert_almost_equal(
             results_full.populations[1].x, results_aborted.populations[1].x
         )
-        # Assert callback was only called 3 times
-        assert callback.n_calls == 3
+        # Assert callback was only called 3 times + 1 final post processing
+        # Callbacks are called four times it used to be three times
+        assert callback.n_calls == 3 + 1
 
 
 if __name__ == "__main__":

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -164,11 +164,11 @@ def optimization_problem(request):
 
 
 params = [
-    # TrustConstr,
-    # COBYLA,
-    # SLSQP,
-    # NelderMead,
-    # U_NSGA3,
+    TrustConstr,
+    COBYLA,
+    SLSQP,
+    NelderMead,
+    U_NSGA3,
 ]
 
 if not skip_ax:

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -226,6 +226,8 @@ def test_from_initial_values(
             optimization_problem.test_if_solved(results, SOO_TEST_KWARGS)
         else:
             optimization_problem.test_if_solved(results, MOO_TEST_KWARGS)
+    else:
+        pytest.skip()
 
 
 class AbortingCallback:

--- a/tests/test_optimizer_behavior.py
+++ b/tests/test_optimizer_behavior.py
@@ -196,7 +196,7 @@ def optimizer(request):
 def test_convergence(optimization_problem: TestProblem, optimizer: OptimizerBase):
     # only test problems that the optimizer can handle. The rest of the tests
     # will be marked as passed
-    pytest.skip()
+    # pytest.skip()
 
     if optimizer.check_optimization_problem(optimization_problem):
         results = optimizer.optimize(


### PR DESCRIPTION
[Ax v1.0.0](https://github.com/facebook/Ax/releases/tag/1.0.0)  was currently released which introduced a new, unified Client / "Ask and Tell" API.
This PR updates CADET-Process to the new interface.

## Todo
- [x] Initial values @flo-schu 
- [x] CADET-Process / post processing @flo-schu 
- [x] Nonlinear-constraints @flo-schu 
- [x] Multi-objective
- [x] Running in batches (out of the box)
- [x] Restore from checkpoints @flo-schu 
- [ ] GPEI / NEHVI / qNParEGO @schmoelder 
- [ ] Early stopping (nice to have, probably later)

Note, a lot of the previously pre-configured Algorithms (e.g. GPEI) are not provided any more. As far as we understood, Ax analyses the problem at hand and tries to configure a suitable set of tools (which we still need to better understand). 

Users can build [custom Generators via the Modular BoTorch Interface](https://ax.dev/docs/tutorials/modular_botorch). We're not quite sure yet how to expose this.

Another alternative is to checkout the testing / documentation of Ax where some of the older algorithms are still configured:
- https://github.com/facebook/Ax/blob/28ad3d6c1a26db9862ac45aadf4f57958cd88cb3/ax/storage/botorch_modular_registry
- https://github.com/facebook/Ax/blob/28ad3d6c1a26db9862ac45aadf4f57958cd88cb3/ax/generators/torch/botorch_moo_defaults.py
- https://github.com/facebook/Ax/blob/28ad3d6c1a26db9862ac45aadf4f57958cd88cb3/ax/utils/testing/modeling_stubs.py
- https://github.com/facebook/Ax/blob/28ad3d6c1a26db9862ac45aadf4f57958cd88cb3/ax/generators/tests/test_botorch_moo_model.py#L106
- ...
