### PR TITLE
Do not change labels when using log scale

### DIFF
--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -559,7 +559,6 @@ class Population:
                 if autoscale and np.min(x_all) > 0:
                     if np.max(x_all) / np.min(x_all[x_all > 0]) > 100.0:
                         ax.set_xscale("log")
-                        layout.x_label = f"$log_{{10}}$({var})"
 
                 y_min = np.nanmin(v_all)
                 y_max = np.nanmax(v_all)
@@ -568,7 +567,6 @@ class Population:
                 if autoscale and np.min(v_all) > 0:
                     if np.max(v_all) / np.min(v_all[v_all > 0]) > 100.0:
                         ax.set_yscale("log")
-                        layout.y_label = f"$log_{{10}}$({label})"
                         y_lim = (y_min / 2, y_max * 2)
                 if y_min != y_max:
                     layout.y_lim = y_lim

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -807,7 +807,6 @@ class OptimizationResults(Structure):
                 if autoscale and y_min > 0:
                     if y_max / y_min > 100.0:
                         ax.set_yscale("log")
-                        layout.y_label = f"$log_{{10}}$({label})"
 
                 try:
                     plotting.set_layout(ax, layout)


### PR DESCRIPTION
This PR addresses an issue where axis labels were incorrectly modified in plots with log scale axes. The modification was unnecessary because, although the axis is plotted on a log scale, the actual values represented remain regular.