### PR TITLE
Update pearson / shape computation

### DIFF
--- a/CADETProcess/comparison/difference.py
+++ b/CADETProcess/comparison/difference.py
@@ -21,7 +21,7 @@ from CADETProcess.solution import (
 )
 
 from .peaks import find_breakthroughs, find_peaks
-from .shape import pearson, pearson_offset
+from .shape import determine_optimal_offset, shape
 
 __all__ = [
     "DifferenceBase",
@@ -624,7 +624,7 @@ class Shape(DifferenceBase):
         np.ndarray
             Array of similarity metrics.
         """
-        corr, offset_original = pearson(
+        corr, offset_original = determine_optimal_offset(
             self.reference.time,
             self.reference.solution_interpolated.solutions[0],
             solution.solution_interpolated.solutions[0],
@@ -640,11 +640,12 @@ class Shape(DifferenceBase):
         if not self.use_derivative:
             return np.array([corr, offset])
 
-        corr_der = pearson_offset(
+        corr_der = shape(
             self.reference_der.time,
             self.reference_der.solution_interpolated.solutions[0],
             solution.derivative.solution_interpolated.solutions[0],
             offset_original,
+            flip=True,
         )
 
         return np.array(
@@ -745,7 +746,7 @@ class ShapeFront(Shape):
             return_indices=True,
         )
 
-        corr, offset_original = pearson(
+        corr, offset_original = determine_optimal_offset(
             times,
             self.reference_front.solution_interpolated.solutions[0],
             solution_front.solution_interpolated.solutions[0],
@@ -770,11 +771,12 @@ class ShapeFront(Shape):
         )
         solution_der_front.update_solution()
 
-        corr_der = pearson_offset(
+        corr_der = shape(
             self.reference_der_front.time,
             self.reference_der_front.solution_interpolated.solutions[0],
             solution_der_front.solution_interpolated.solutions[0],
             offset_original,
+            flip=True,
         )
 
         return np.array(

--- a/CADETProcess/comparison/shape.py
+++ b/CADETProcess/comparison/shape.py
@@ -1,262 +1,160 @@
 import warnings
+from typing import Optional
 
-import numba
 import numpy as np
-import numpy.typing as npt
 import scipy
+import scipy.optimize as optimize
 from scipy.interpolate import PchipInterpolator
-
-from CADETProcess import CADETProcessError
-
-
-def linear_coeff(x1: float, y1: float, x2: float, y2: float) -> tuple[float, float]:
-    """Return paramters that fit y = a*x+b."""
-    a = (y2 - y1) / (x2 - x1)
-    b = y2 - a * x2
-    return a, b
-
-
-def exponential_coeff(
-    x1: float, y1: float, x2: float, y2: float
-) -> tuple[float, float]:
-    """Return paramaters that fit y = b*exp(m*x)."""
-    b = (np.log(y2) - np.log(y1)) / (x2 - x1)
-    a = y1 * np.exp(-b * x1)
-    return a, b
-
-
-def exponential(x: float, a: float, b: float) -> float:
-    """Evaluate exponential function."""
-    return a * np.exp(b * x)
-
-
-def linear(x: float, a: float, b: float) -> float:
-    """Evaluate linear function."""
-    return a * x + b
-
-
-def find_opt_poly(
-    x: np.ndarray,
-    y: np.ndarray,
-    index: int,
-) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """
-    Find optimal overlap between x (offset) and y (pearson).
-
-    Given a curve, find highest point.
-    """
-    if index == 0:
-        indices = np.array([index, index + 1, index + 2])
-    elif index == (len(x) - 1):
-        indices = np.array([index - 2, index - 1, index])
-    else:
-        indices = np.array([index - 1, index, index + 1])
-
-    x = x[indices]
-    y = y[indices]
-
-    if x[0] > x[-1]:  # need to invert order
-        x = x[::-1]
-        y = y[::-1]
-
-    try:
-        poly, res = np.polynomial.Polynomial.fit(x, y, 2, full=True)
-    except np.linalg.LinAlgError:
-        raise CADETProcessError(f"Polyfit failed for {x}, {y}")
-    try:
-        root = poly.deriv().roots()[0]
-    except IndexError:
-        # If all y values are equal, use center value.
-        root = x[0]
-    root = np.clip(root, x[0], x[1])
-    return root, x, y
-
-
-def pear_corr(cr: float) -> float:
-    """Flip pearson correlation s.t. 0 is best and 1 is worst."""
-    # handle the case where a nan is returned
-    if np.isnan(cr):
-        return 1.0
-    if cr < 0.0:
-        return 1.0
-    else:
-        return 1 - cr
-
-
-@numba.njit(fastmath=True)
-def pearsonr_mat(x: np.ndarray, Y: np.ndarray, times: np.ndarray) -> np.ndarray:
-    """
-    High performance implementation of the pearson correlation.
-
-    This is to simultaneously evaluate the pearson correlation between a vector and a
-    matrix. Scipy can only evaluate vector/vector.
-    """
-    r = np.zeros(Y.shape[0])
-    xm = x - x.mean()
-
-    r_x_den = np.linalg.norm(xm)
-
-    for i in range(Y.shape[0]):
-        ym = Y[i] - np.mean(Y[i])
-
-        r_num = np.dot(xm, ym)
-        r_y_den = np.linalg.norm(ym)
-
-        denominator = r_x_den * r_y_den
-
-        if denominator == 0.0:
-            r[i] = -1.0
-        else:
-            min_fun = 0
-            for j in range(x.shape[0]):
-                min_fun += min(x[j], Y[i, j])
-
-            r[i] = min(max(r_num / denominator, -1.0), 1.0) * min_fun
-    return r
-
-
-def pearson_offset(
-    time: npt.ArrayLike,
-    reference_spline: PchipInterpolator,
-    simulation_spline: PchipInterpolator,
-    offset: float,
-) -> float:
-    """Calculate single pearson correlation at offset."""
-    simulation_data_offset = simulation_spline(time - offset)
-    reference_data = reference_spline(time)
-    try:
-        pear = scipy.stats.pearsonr(reference_data, simulation_data_offset)[0]
-    except ValueError:
-        warnings.warn(
-            f"Pearson correlation failed to do NaN or InF in array exp_array: "
-            f"{list(reference_data)}, sim_array: {list(simulation_data_offset)}"
-        )
-        pear = 0
-    score_local = pear_corr(pear)
-
-    return score_local
-
-
-def eval_offsets(
-    time: float,
-    reference_spline: PchipInterpolator,
-    simulation_spline: PchipInterpolator,
-    offsets: np.ndarray,
-) -> np.ndarray:
-    """Calculate pearson correlation for each offset."""
-    rol_mat = np.zeros([len(offsets), len(time)])
-
-    for idx, offset in enumerate(offsets):
-        rol_mat[idx, :] = simulation_spline(time - offset)
-
-    reference_data = reference_spline(time)
-    scores = pearsonr_mat(reference_data, rol_mat, time)
-    return scores
 
 
 def pearson(
     time: np.ndarray,
     reference_spline: PchipInterpolator,
     simulation_spline: PchipInterpolator,
-    size: int = 20,
-    nest: int = 50,
-    bounds: int = 2,
-    tol: float = 1e-13,
-) -> tuple[float, float]:
+    offset: Optional[float] = 0,
+) -> float:
     """
-    Find highest correlation between reference and simulation.
+    Calculate Pearson correlation.
 
-    The two signals are shifted in time to find the time offset which
-    corresponds to highest correlation. To ensure deterministic results, a
-    a bisection scheme is used to refine the offset instead of an optimizer.
+    Optionally, an offset can be specified that shifts the signal in time. This can be
+    a helpful metric in parameter estimation.
 
     Parameters
     ----------
     time: np.ndarray
-        Time points.
-    reference_spline : PchipInterpolator
-        Reference data points.
-    simulation_spline : PchipInterpolator
-        Simulation Data points.
-    size : int, optional
-        Number of points to be generated between upper and lower bounds.
-        The default is 20.
-    nest : int, optional
-        Maximum number of recursions. The default is 50.
-    bounds : int, optional
-        Number of indices allowed for shifting signal outside bounds.
-        The default is 2.
-    tol : float, optional
-        Tolerance for difference between lb and ub. The default is 1e-13.
+        The time array
+    reference_spline: PchipInterpolator
+        The reference data.
+    simulation_spline: PchipInterpolator
+        The simulated data.
+    offset: float, optional
+        A time offset to be applied to the simulation spline.
 
     Returns
     -------
-    score_local : float
-        pearson correlation (inverted).
-    dt : float
-        time offset.
+    float
+        The pearson correlation given the current offset.
     """
-    for i in range(nest + 1):
-        if i == 0:
-            lb = -time[-1]
-            ub = time[-1]
-            local_size = min(100 + 1, int((ub - lb) * 2 + 1))
-        else:
-            idx_max = np.argmax(pearson)
+    shifted_time = time - offset
 
-            try:
-                lb = offsets[idx_max - bounds]  # noqa: F821
-            except IndexError:
-                lb = offsets[0]  # noqa: F821
+    # restrict to the valid domain of reference_spline
+    t_min, t_max = time[0], time[-1]
+    valid_mask = (shifted_time >= t_min) & (shifted_time <= t_max)
 
-            try:
-                ub = offsets[idx_max + bounds]  # noqa: F821
-            except IndexError:
-                ub = offsets[-1]  # noqa: F821
-            local_size = size
+    time_eval = time[valid_mask]
+    shifted_eval = shifted_time[valid_mask]
 
-        if ub - lb < tol:
-            break
+    ref_vals = reference_spline(time_eval)
+    sim_vals = simulation_spline(shifted_eval)
 
-        offsets = np.linspace(lb, ub, local_size)
+    try:
+        pear = scipy.stats.pearsonr(ref_vals, sim_vals)[0]
+    except ValueError:
+        warnings.warn(
+            f"Pearson correlation failed due to NaN or Inf in array reference: "
+            f"{reference_spline.x}, simulation: {simulation_spline.x}"
+        )
+        pear = -1
 
-        pearson = eval_offsets(time, reference_spline, simulation_spline, offsets)
+    return pear
 
-        idx_max = np.argmax(pearson)
 
-        expand_lb = max(bounds - idx_max, 0)
-        expand_ub = max(bounds - (len(pearson) - 1 - idx_max), 0)
+def flip_pearson(pear: float) -> float:
+    """Flip value s.t. 0 is best and 1 is worst."""
+    return 0.5 * (1 - pear)
 
-        if expand_lb or expand_ub:
-            expand_lb = expand_lb * 2
-            expand_ub = expand_ub * 2
-            dt = offsets[1] - offsets[0]
-            if expand_lb:
-                local_offsets = np.linspace(offsets[0] - expand_lb * dt, offsets[0] - dt, expand_lb)
-                local_pearson = eval_offsets(
-                    time, reference_spline, simulation_spline, local_offsets
-                )
 
-                offsets = np.concatenate([local_offsets, offsets])
-                pearson = np.concatenate([local_pearson, pearson])
+def shape(
+    time: np.ndarray,
+    reference_spline: PchipInterpolator,
+    simulation_spline: PchipInterpolator,
+    offset: Optional[float] = 0,
+    flip: Optional[bool] = True,
+) -> float:
+    """
+    Calculate shape metric.
 
-            if expand_ub:
-                local_offsets = np.linspace(
-                    offsets[-1] + dt, offsets[-1] + expand_ub * dt, expand_ub
-                )
+    Parameters
+    ----------
+    time: np.ndarray
+        The time array
+    reference_spline: PchipInterpolator
+        The reference data.
+    simulation_spline: PchipInterpolator
+        The simulated data.
+    offset: float, optional
+        A time offset to be applied to the simulation spline.
+    flip: bool, optional
+        If True, flip value s.t. 0 is best and 1 is worst.
+        The default is True.
 
-                local_pearson = eval_offsets(
-                    time, reference_spline, simulation_spline, local_offsets
-                )
+    Returns
+    -------
+    float
+        The pearson correlation given the current offset.
+    """
+    pear = pearson(time, reference_spline, simulation_spline, offset)
+    if flip:
+        pear = flip_pearson(pear)
 
-                offsets = np.concatenate([offsets, local_offsets])
-                pearson = np.concatenate([pearson, local_pearson])
+    return pear
 
-    idx = np.argmax(pearson)
 
-    dt, time_found, goal_found = find_opt_poly(offsets, pearson, idx)
+def determine_optimal_offset(
+    time: np.ndarray,
+    reference_spline: PchipInterpolator,
+    simulation_spline: PchipInterpolator,
+) -> tuple[float, float]:
+    """
+    Determine the optimal time offset s.t. Pearson correlation is maximixed.
 
-    # calculate pearson correlation at the new time
-    score_local = pearson_offset(time, reference_spline, simulation_spline, dt)
+    Uses scipy.optimize.minimize to find the optimal time offset.
 
-    return score_local, dt
+    Parameters
+    ----------
+    time: np.ndarray
+        The time array
+    reference_spline: PchipInterpolator
+        The reference data.
+    simulation_spline: PchipInterpolator
+        The simulated data.
+
+    Returns
+    -------
+    tuple[float, float]
+        The maximum pearson correlation and the corresponding time offset.
+    """
+    x0 = 0
+    window = 0.05 * (time[-1] - time[0])
+    bounds = (-time[-1] + window, time[-1] - window)  # Limit offset to avoid issues
+
+    # Brute force for screening
+    _, _, offsets, scores = optimize.brute(
+        lambda x: shape(time, reference_spline, simulation_spline, x, True),
+        [bounds],
+        Ns=101,
+        full_output=True,
+        finish=None,
+    )
+    ind = np.nanargmin(scores)
+    f = scores[ind]
+    x = offsets[ind]
+
+    # Update for refinement
+    x0 = x
+    window = 0.01 * (time[-1] - time[0])
+    bounds = (max(bounds[0], x0 - window), min(bounds[1], x0 + window))
+
+    # Refinement
+    result = optimize.minimize(
+        lambda x: shape(time, reference_spline, simulation_spline, x, True),
+        x0=x0,
+        bounds=[bounds],
+        method="Powell",
+        options={"xtol": 1e-12},
+    )
+
+    f = result.fun
+    x = result.x[0]
+
+    return f, x

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -285,7 +285,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak
         difference = Shape(
@@ -294,9 +294,9 @@ class TestShape(unittest.TestCase):
             components=["A"],
             normalize_metrics=False,
         )
-        metrics_expected = [5.5511151e-16, 10]
+        metrics_expected = [0, 10]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak, normalize_metrics
         difference = Shape(
@@ -307,7 +307,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 4.6211716e-01]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak, include derivative
         difference = Shape(
@@ -318,7 +318,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 10, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak, include derivative, normalize metrics
         difference = Shape(
@@ -329,7 +329,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 4.6211716e-01, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Multi-component, currently not implemented
         with self.assertRaises(CADETProcessError):
@@ -372,7 +372,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak
         difference = ShapeFront(
@@ -383,7 +383,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 10]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak, normalize_metrics
         difference = ShapeFront(
@@ -394,7 +394,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 4.6211716e-01]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak, include derivative
         difference = ShapeFront(
@@ -405,7 +405,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 10, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Compare with other Gauss Peak, include derivative, normalize metrics
         difference = ShapeFront(
@@ -414,9 +414,9 @@ class TestShapeFront(unittest.TestCase):
             components=["A"],
             normalize_metrics=True,
         )
-        metrics_expected = [0, 4.6211716e-01, 0]
+        metrics_expected = [0.0, 4.6211716e-01, 0.0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         # Use maximum slope
         difference = ShapeFront(
@@ -426,9 +426,9 @@ class TestShapeFront(unittest.TestCase):
             components=["A"],
             normalize_metrics=False,
         )
-        metrics_expected = [0, 0]
+        metrics_expected = [0.0, 0.0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
 
         difference = ShapeFront(
             self.reference_switched,
@@ -437,14 +437,14 @@ class TestShapeFront(unittest.TestCase):
             components=["A"],
             normalize_metrics=False,
         )
-        metrics_expected = [0, 10]
+        metrics_expected = [0.0, 10.0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Multi-component, currently not implemented
         with self.assertRaises(CADETProcessError):
             difference = ShapeFront(self.reference, use_derivative=False)
-            metrics_expected = [0, 0]
+            metrics_expected = [0.0, 0.0]
         with self.assertRaises(CADETProcessError):
             difference = ShapeFront(self.reference_single)
             metrics = difference.evaluate(self.reference)


### PR DESCRIPTION
This PR fixes an issue where the shape metric would fail if peaks / breakthrough curves were shifted too much.

Note, since this PR also replaces the algorithm to determine the offset (which was ported from CADET-Match) by a proper optimization, I had to increase the tolerances of the tests a bit (1e-7 -> 1e-6). I hope that this does not cause too many issues for any top-level optimization.