### PR TITLE
Account for bound states in SolutionSolid

### DIFF
--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -1489,6 +1489,11 @@ class SolutionSolid(SolutionBase):
         return sum(self.bound_states)
 
     @property
+    def n_comp(self) -> int:
+        """int: Number of bound states."""
+        return self.n_bound
+
+    @property
     def ncol(self) -> int:
         """int: Number of axial discretization points."""
         if self.axial_coordinates is None:


### PR DESCRIPTION
This PR fixes an issue originally posted in our [Forum](https://forum.cadet-web.de/t/write-solution-solid-error-with-spreading-binding-model/1251).

Apparently, we had never tested the solid solution for binding models with multiple states.
Here, this is fixed by simply expanding the `component_coordinates`. 

Note, this is more of a quick-fix / hacky solution (no pun intended) which comes with some limitations. E.g. slicing the solution might not work properly.

Instead, we should consider something like a `BoundComponentSystem` which maps the bound states to the actual components. Maybe we could simply create a derived instance of the regular `ComponentSystem` or make use of the `Species`?

In any case, this is not very high priority until we have addressed some other issues:
- Multiple particle types (with individual binding models / bound states)
- General overhaul of solution class (@hannahlanzrath)