### PR TITLE
Add modelBuilder for BatchElution, Flip-Flop, CLR, SSR, and LWE

### DIFF
--- a/CADETProcess/modelBuilder/__init__.py
+++ b/CADETProcess/modelBuilder/__init__.py
@@ -36,3 +36,9 @@ A module for building compartment model systems.
 from . import carouselBuilder
 from .carouselBuilder import *
 from .compartmentBuilder import *
+
+from .batchElutionBuilder import BatchElution
+from .clrBuilder import CLR
+from .flipFlopBuilder import FlipFlop
+from .lweBuilder import LWE
+from .mrssrBuilder import MRSSR

--- a/CADETProcess/modelBuilder/batchElutionBuilder.py
+++ b/CADETProcess/modelBuilder/batchElutionBuilder.py
@@ -1,0 +1,113 @@
+from typing import Optional
+
+from CADETProcess.processModel import (
+    ChromatographicColumnBase,
+    FlowSheet,
+    Inlet,
+    Outlet,
+    Process,
+)
+
+
+class BatchElution(Process):
+    """
+    Batch elution process.
+
+    The flowsheet is configured with the following unit operations:
+    - feed: Inlet
+    - eluent: Inlet
+    - column: ChromatographicColumnBase
+    - outlet: Outlet
+
+    The following durations/events are configured:
+    - `feed_duration`: The length of the feed injection.
+    - `feed_on`: Set `feed.flow_rate` to `flow_rate`.
+    - `eluent_off`: Set `eluent.flow_rate` to 0.0; triggered by `feed_on`.
+    - `feed_off`: Set `feed.flow_rate` to 0.0; triggered by `feed_on` and `feed_duration`.
+    - `eluent_on`: Set `eluent.flow_rate` to `flow_rate`; triggered by `feed_off`.
+    """
+
+    def __init__(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        flow_rate: float,
+        feed_duration: float,
+        cycle_time: float,
+        c_eluent: Optional[list[float] | float] = 0.0,
+    ) -> None:
+        """
+        Initialize batch elution process.
+
+        Parameters
+        ----------
+        column : ChromatographicColumnBase
+            Chromatographic column object to be used in process.
+        c_feed : list[float]
+            Feed concentration.
+        flow_rate : float
+            Flow rate.
+        feed_duration : float
+            Feed duration.
+        cycle_time : float
+            Cycle time.
+        c_eluent : list[float] | float, optional
+            Eluent concentration. The default is 0.0.
+        """
+        if not isinstance(column, ChromatographicColumnBase):
+            raise TypeError("Expected ChromatographicColumnBase.")
+
+        flow_sheet = self._build_flow_sheet(
+            column,
+            c_feed,
+            c_eluent,
+        )
+
+        super().__init__(flow_sheet, "Batch Elution")
+        self.cycle_time = cycle_time
+
+        # Durations
+        self.add_duration("feed_duration", feed_duration)
+
+        # Injection
+        self.add_event("feed_on", "flow_sheet.feed.flow_rate", flow_rate)
+        self.add_event("eluent_off", "flow_sheet.eluent.flow_rate", 0.0)
+        self.add_event_dependency("eluent_off", ["feed_on"])
+
+        # Elution
+        self.add_event("feed_off", "flow_sheet.feed.flow_rate", 0.0)
+        self.add_event_dependency("feed_off", ["feed_on", "feed_duration"], [1, 1])
+        self.add_event("eluent_on", "flow_sheet.eluent.flow_rate", flow_rate)
+        self.add_event_dependency("eluent_on", ["feed_off"])
+
+    def _build_flow_sheet(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        c_eluent: list[float] | float | None = 0.0,
+    ) -> FlowSheet:
+        """Build and return the flow sheet for batch elution process."""
+        component_system = column.component_system
+
+        # Unit Operations
+        feed = Inlet(component_system, name="feed")
+        feed.c = c_feed
+
+        eluent = Inlet(component_system, name="eluent")
+        eluent.c = c_eluent
+
+        outlet = Outlet(component_system, name="outlet")
+
+        # Flow Sheet
+        flow_sheet = FlowSheet(component_system)
+
+        flow_sheet.add_unit(feed, feed_inlet=True)
+        flow_sheet.add_unit(eluent, eluent_inlet=True)
+        flow_sheet.add_unit(column)
+        flow_sheet.add_unit(outlet, product_outlet=True)
+
+        flow_sheet.add_connection(feed, column)
+        flow_sheet.add_connection(eluent, column)
+        flow_sheet.add_connection(column, outlet)
+
+        return flow_sheet

--- a/CADETProcess/modelBuilder/clrBuilder.py
+++ b/CADETProcess/modelBuilder/clrBuilder.py
@@ -1,0 +1,137 @@
+from CADETProcess.processModel import (
+    ChromatographicColumnBase,
+    Cstr,
+    FlowSheet,
+    Inlet,
+    Outlet,
+    Process,
+)
+
+
+class CLR(Process):
+    """
+    Closed loop recycling (CLR) process.
+
+    The flowsheet includes:
+    - feed: Inlet
+    - eluent: Inlet
+    - column: ChromatographicColumnBase
+    - pump: Cstr (auxiliary pump unit)
+    - outlet: Outlet
+
+    The process is configured with the following events:
+    - Feed injection (duration: `feed_duration`).
+    - Recycling (ends at `recycle_off`).
+    - Elution after recycling.
+    """
+
+    def __init__(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        flow_rate: float,
+        feed_duration: float,
+        recycle_off: float,
+        cycle_time: float,
+        c_eluent: list[float] | float = 0.0,
+        pump_volume: float = 1e-9,
+    ) -> None:
+        """
+        Initialize CLR process.
+
+        Parameters
+        ----------
+        column : ChromatographicColumnBase
+            Chromatographic column object.
+        c_feed : list[float]
+            Feed concentration.
+        flow_rate : float
+            Flow rate.
+        feed_duration : float
+            Feed injection duration.
+        recycle_off : float
+            Time at which recycling ends.
+        cycle_time : float
+            Total cycle time.
+        c_eluent : list[float] | float | None, optional
+            Eluent concentration. Defaults to 0.0.
+        pump_volume : float, optional
+            Volume of the auxiliary pump unit. Defaults to 1e-9.
+        """
+        flow_sheet = self._build_flow_sheet(
+            column=column,
+            c_feed=c_feed,
+            c_eluent=c_eluent,
+            pump_volume=pump_volume,
+        )
+        super().__init__(flow_sheet, "CLR")
+        self.cycle_time = cycle_time
+
+        # 0: Start feeding, no eluent, no recycle
+        self.add_event("feed_on", "flow_sheet.feed.flow_rate", flow_rate, 0.0)
+        self.add_event("eluent_off", "flow_sheet.eluent.flow_rate", 0.0)
+        self.add_event_dependency("eluent_off", ["feed_on"])
+
+        # t_inj / t_rec_start: End feeding, no eluent, start recycle
+        self.add_event("feed_off", "flow_sheet.feed.flow_rate", 0.0)
+        self.add_duration("feed_duration", feed_duration)
+        self.add_event_dependency("feed_off", ["feed_on", "feed_duration"], [1, 1])
+        self.add_event(
+            "recycle_on_output_state",
+            f"flow_sheet.output_states.{column.name}",
+            {"pump": 1},
+        )
+        self.add_event_dependency("recycle_on_output_state", ["feed_off"])
+        self.add_event("recycle_on_pump", "flow_sheet.pump.flow_rate", flow_rate)
+        self.add_event_dependency("recycle_on_pump", ["recycle_on_output_state"])
+
+        # t_rec_end: End recycle, start eluent
+        self.add_event(
+            "recycle_off_output_state",
+            f"flow_sheet.output_states.{column.name}",
+            {"outlet": 1},
+            recycle_off,
+        )
+        self.add_event("recycle_off_pump", "flow_sheet.pump.flow_rate", 0)
+        self.add_event_dependency("recycle_off_pump", ["recycle_off_output_state"])
+        self.add_event("eluent_on", "flow_sheet.eluent.flow_rate", flow_rate)
+        self.add_event_dependency("eluent_on", ["recycle_off_output_state"])
+
+    def _build_flow_sheet(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        c_eluent: list[float] | float = 0.0,
+        pump_volume: float = 1e-9,
+    ) -> FlowSheet:
+        """Build and return the flow sheet for CLR process."""
+        component_system = column.component_system
+
+        # Unit Operations
+        feed = Inlet(component_system, name="feed")
+        feed.c = c_feed
+
+        eluent = Inlet(component_system, name="eluent")
+        eluent.c = c_eluent if c_eluent is not None else 0.0
+
+        pump = Cstr(component_system, name="pump")
+        pump.V = pump_volume
+
+        outlet = Outlet(component_system, name="outlet")
+
+        # Flow Sheet
+        flow_sheet = FlowSheet(component_system)
+
+        flow_sheet.add_unit(feed, feed_inlet=True)
+        flow_sheet.add_unit(eluent, eluent_inlet=True)
+        flow_sheet.add_unit(pump)
+        flow_sheet.add_unit(column)
+        flow_sheet.add_unit(outlet, product_outlet=True)
+
+        flow_sheet.add_connection(feed, column)
+        flow_sheet.add_connection(eluent, column)
+        flow_sheet.add_connection(column, outlet)
+        flow_sheet.add_connection(column, pump)
+        flow_sheet.add_connection(pump, column)
+
+        return flow_sheet

--- a/CADETProcess/modelBuilder/compartmentBuilder.py
+++ b/CADETProcess/modelBuilder/compartmentBuilder.py
@@ -5,7 +5,7 @@ import numpy as np
 import numpy.typing as npt
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import String, StructMeta, UnsignedInteger
+from CADETProcess.dataStructure import String, Structure, UnsignedInteger
 from CADETProcess.processModel import (
     BindingBaseClass,
     BulkReactionBase,
@@ -22,7 +22,7 @@ from CADETProcess.processModel import (
 __all__ = ["CompartmentBuilder"]
 
 
-class CompartmentBuilder(metaclass=StructMeta):
+class CompartmentBuilder(Structure):
     """
     Class to build complex compartment models of bioreactors.
 

--- a/CADETProcess/modelBuilder/flipFlopBuilder.py
+++ b/CADETProcess/modelBuilder/flipFlopBuilder.py
@@ -1,0 +1,135 @@
+from CADETProcess.processModel import (
+    ChromatographicColumnBase,
+    FlowSheet,
+    Inlet,
+    Outlet,
+    Process,
+)
+
+
+class FlipFlop(Process):
+    """
+    Flip-flop process.
+
+    The flowsheet includes:
+    - feed: Inlet
+    - eluent: Inlet
+    - column: ChromatographicColumnBase
+    - outlet: Outlet
+
+    The process is configured with two injections and column flow direction flips:
+    - Injection 1 (duration: `feed_duration`)
+    - Flip column flow direction after `delay_flip`
+    - Injection 2 (delayed by `delay_injection`)
+    - Flip column flow direction back
+    """
+
+    def __init__(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        flow_rate: float,
+        feed_duration: float,
+        delay_flip: float,
+        delay_injection: float,
+        c_eluent: list[float] | float = 0.0,
+    ) -> None:
+        """
+        Initialize flip-flop process.
+
+        Parameters
+        ----------
+        column : ChromatographicColumnBase
+            Chromatographic column object.
+        c_feed : list[float]
+            Feed concentration.
+        flow_rate : float
+            Flow rate.
+        feed_duration : float
+            Feed injection duration.
+        delay_flip : float
+            Time delay before flipping column flow direction.
+        delay_injection : float
+            Time delay before second injection.
+        c_eluent : list[float] | float | None, optional
+            Eluent concentration. Defaults to 0.0.
+        """
+        flow_sheet = self._build_flow_sheet(
+            column=column,
+            c_feed=c_feed,
+            c_eluent=c_eluent,
+        )
+        super().__init__(flow_sheet, "FlipFlop")
+        self.cycle_time = 2 * (feed_duration + delay_flip + delay_injection)
+
+        # Durations
+        self.add_duration("feed_duration", feed_duration)
+        self.add_duration("delay_flip", delay_flip)
+        self.add_duration("delay_injection", delay_injection)
+
+        # Injection 1
+        self.add_event("feed_on_1", "flow_sheet.feed.flow_rate", flow_rate, 0)
+        self.add_event("eluent_off_1", "flow_sheet.eluent.flow_rate", 0.0)
+        self.add_event_dependency("eluent_off_1", ["feed_on_1"])
+        self.add_event("feed_off_1", "flow_sheet.feed.flow_rate", 0.0)
+        self.add_event_dependency("feed_off_1", ["feed_on_1", "feed_duration"], [1, 1])
+        self.add_event("eluent_on_1", "flow_sheet.eluent.flow_rate", flow_rate)
+        self.add_event_dependency("eluent_on_1", ["feed_off_1"])
+
+        # Flip backwards
+        self.add_event(
+            "backward_flow",
+            f"flow_sheet.{column.name}.flow_direction",
+            -1,
+        )
+        self.add_event_dependency("backward_flow", ["feed_off_1", "delay_flip"], [1, 1])
+
+        # Injection 2
+        self.add_event("feed_on_2", "flow_sheet.feed.flow_rate", flow_rate)
+        self.add_event_dependency("feed_on_2", ["backward_flow", "delay_injection"], [1, 1])
+        self.add_event("eluent_off_2", "flow_sheet.eluent.flow_rate", 0.0)
+        self.add_event_dependency("eluent_off_2", ["feed_on_2"])
+        self.add_event("feed_off_2", "flow_sheet.feed.flow_rate", 0.0)
+        self.add_event_dependency("feed_off_2", ["feed_on_2", "feed_duration"], [1, 1])
+        self.add_event("eluent_on_2", "flow_sheet.eluent.flow_rate", flow_rate)
+        self.add_event_dependency("eluent_on_2", ["feed_off_2"])
+
+        # Flip forwards
+        self.add_event(
+            "forward_flow",
+            f"flow_sheet.{column.name}.flow_direction",
+            1,
+        )
+        self.add_event_dependency("forward_flow", ["eluent_on_2", "delay_flip"], [1, 1])
+
+    def _build_flow_sheet(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        c_eluent: list[float] | float = 0.0,
+    ) -> FlowSheet:
+        """Build and return the flow sheet for flip-flop process."""
+        component_system = column.component_system
+
+        # Unit Operations
+        feed = Inlet(component_system, name="feed")
+        feed.c = c_feed
+
+        eluent = Inlet(component_system, name="eluent")
+        eluent.c = c_eluent if c_eluent is not None else 0.0
+
+        outlet = Outlet(component_system, name="outlet")
+
+        # Flow Sheet
+        flow_sheet = FlowSheet(component_system)
+
+        flow_sheet.add_unit(feed, feed_inlet=True)
+        flow_sheet.add_unit(eluent, eluent_inlet=True)
+        flow_sheet.add_unit(column)
+        flow_sheet.add_unit(outlet, product_outlet=True)
+
+        flow_sheet.add_connection(feed, column)
+        flow_sheet.add_connection(eluent, column)
+        flow_sheet.add_connection(column, outlet)
+
+        return flow_sheet

--- a/CADETProcess/modelBuilder/lweBuilder.py
+++ b/CADETProcess/modelBuilder/lweBuilder.py
@@ -1,0 +1,177 @@
+from CADETProcess.processModel import (
+    ChromatographicColumnBase,
+    FlowSheet,
+    Inlet,
+    Outlet,
+    Process,
+)
+
+
+class LWE(Process):
+    """
+    Load-Wash-Elute (LWE) process.
+
+    The flowsheet includes:
+    - load: Inlet (feed)
+    - salt_low: Inlet (low salt buffer)
+    - salt_high: Inlet (high salt buffer)
+    - column: ChromatographicColumnBase
+    - outlet: Outlet
+
+    The process is configured with the following phases:
+    - Load (duration: `load_duration`)
+    - Wash (duration: `wash_duration`)
+    - Elute (duration: `gradient_duration`, with gradient)
+    - Optional final wash (duration: `final_wash_duration`)
+    """
+
+    def __init__(
+        self,
+        column: ChromatographicColumnBase,
+        c_load: list[float],
+        c_salt_low: list[float],
+        c_salt_high: list[float],
+        flow_rate: float,
+        load_duration: float,
+        wash_duration: float,
+        gradient_duration: float,
+        final_wash_duration: float = 0.0,
+        set_initial_conditions: bool = True,
+    ) -> None:
+        """
+        Initialize LWE process.
+
+        Parameters
+        ----------
+        column : ChromatographicColumnBase
+            Chromatographic column object.
+        c_load : list[float]
+            Feed concentration.
+        c_salt_low : list[float]
+            Low salt buffer concentration.
+        c_salt_high : list[float]
+            High salt buffer concentration.
+        flow_rate : float
+            Flow rate.
+        load_duration : float
+            Loading duration.
+        wash_duration : float
+            Wash duration.
+        gradient_duration : float
+            Gradient duration.
+        final_wash_duration : float, optional
+            Optional final wash step with high salt buffer. Defaults to 0.0.
+        set_initial_conditions : bool, optional
+            Whether to set initial column conditions. Defaults to True.
+        """
+        flow_sheet = self._build_flow_sheet(
+            column=column,
+            c_load=c_load,
+            c_salt_low=c_salt_low,
+            c_salt_high=c_salt_high,
+            set_initial_conditions=set_initial_conditions,
+        )
+        super().__init__(flow_sheet, 'LWE')
+
+        self.cycle_time = (
+            load_duration
+            + wash_duration
+            + gradient_duration
+            + final_wash_duration
+        )
+        gradient_slope = flow_rate / gradient_duration
+
+        # Durations
+        self.add_duration('load_duration', load_duration)
+        self.add_duration('wash_duration', wash_duration)
+        self.add_duration('gradient_duration', gradient_duration)
+        if final_wash_duration > 0:
+            self.add_duration('final_wash_duration', final_wash_duration)
+
+        # Events
+        # Load
+        self.add_event('load_on', 'flow_sheet.load.flow_rate', flow_rate, 0)
+        # Wash
+        self.add_event('load_off', 'flow_sheet.load.flow_rate', 0.0)
+        self.add_event_dependency('load_off', ['load_on', 'load_duration'], [1, 1])
+        self.add_event('wash_on', 'flow_sheet.salt_low.flow_rate', flow_rate)
+        self.add_event_dependency('wash_on', ['load_off'])
+        # Elute
+        self.add_event(
+            'gradient_salt_low_start',
+            'flow_sheet.salt_low.flow_rate',
+            [flow_rate, -gradient_slope],
+            0,
+        )
+        self.add_event_dependency(
+            'gradient_salt_low_start',
+            ['wash_on', 'wash_duration'],
+            [1, 1],
+        )
+        self.add_event(
+            'gradient_salt_high_start',
+            'flow_sheet.salt_high.flow_rate',
+            [0, gradient_slope],
+            0,
+        )
+        self.add_event_dependency('gradient_salt_high_start', ['gradient_salt_low_start'])
+        # Final Wash
+        self.add_event('gradient_salt_low_end', 'flow_sheet.salt_low.flow_rate', 0.0)
+        self.add_event_dependency(
+            'gradient_salt_low_end',
+            ['gradient_salt_low_start', 'gradient_duration'],
+            [1, 1],
+        )
+        if final_wash_duration > 0:
+            self.add_event(
+                'final_wash_on',
+                'flow_sheet.salt_high.flow_rate',
+                flow_rate,
+            )
+            self.add_event_dependency('final_wash_on', ['gradient_salt_low_end'])
+            self.add_event('final_wash_off', 'flow_sheet.salt_high.flow_rate', 0.0)
+            self.add_event_dependency(
+                'final_wash_off',
+                ['final_wash_on', 'final_wash_duration'],
+                [1, 1],
+            )
+
+    def _build_flow_sheet(
+        self,
+        column: ChromatographicColumnBase,
+        c_load: list[float],
+        c_salt_low: list[float],
+        c_salt_high: list[float],
+        set_initial_conditions: bool = True,
+    ) -> FlowSheet:
+        """Build and return the flow sheet for LWE process."""
+        component_system = column.component_system
+
+        # Unit Operations
+        load = Inlet(component_system, name='load')
+        load.c = c_load
+        salt_low = Inlet(component_system, name='salt_low')
+        salt_low.c = c_salt_low
+        salt_high = Inlet(component_system, name='salt_high')
+        salt_high.c = c_salt_high
+        if set_initial_conditions:
+            column.c = c_salt_low
+            if "cp" in column.parameters:
+                column.cp = c_salt_low
+        outlet = Outlet(component_system, name='outlet')
+
+        # Flow Sheet
+        flow_sheet = FlowSheet(component_system)
+
+        flow_sheet.add_unit(load, feed_inlet=True)
+        flow_sheet.add_unit(salt_low, eluent_inlet=True)
+        flow_sheet.add_unit(salt_high, eluent_inlet=True)
+        flow_sheet.add_unit(column)
+        flow_sheet.add_unit(outlet, product_outlet=True)
+
+        flow_sheet.add_connection(load, column)
+        flow_sheet.add_connection(salt_low, column)
+        flow_sheet.add_connection(salt_high, column)
+        flow_sheet.add_connection(column, outlet)
+
+        return flow_sheet

--- a/CADETProcess/modelBuilder/mrssrBuilder.py
+++ b/CADETProcess/modelBuilder/mrssrBuilder.py
@@ -1,0 +1,155 @@
+from CADETProcess.processModel import (
+    ChromatographicColumnBase,
+    Cstr,
+    FlowSheet,
+    Inlet,
+    Outlet,
+    Process,
+)
+
+
+class MRSSR(Process):
+    """
+    Mixed-recycle steady-state recycling (MRSSR) process.
+
+    The flowsheet includes:
+    - feed: Inlet
+    - eluent: Inlet
+    - tank: Cstr (mixing tank)
+    - column: ChromatographicColumnBase
+    - outlet: Outlet
+
+    The process is configured with the following events:
+    - Feed injection (duration: `feed_duration`), coupled to elution flow rate.
+    - Recycling (starts at `recycle_on`, ends at `recycle_off`).
+    """
+
+    def __init__(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        flow_rate: float,
+        feed_duration: float,
+        recycle_on: float,
+        recycle_off: float,
+        cycle_time: float,
+        V_tank: float,
+        c_eluent: list[float] | float = 0.0,
+        c_tank_init: list[float] | float | None = None,
+    ) -> None:
+        """
+        Initialize MRSSR process.
+
+        Parameters
+        ----------
+        column : ChromatographicColumnBase
+            Chromatographic column object.
+        c_feed : list[float]
+            Feed concentration.
+        flow_rate : float
+            Flow rate.
+        feed_duration : float
+            Feed injection duration.
+        recycle_on : float
+            Time at which to start recycling.
+        recycle_off : float
+            Time at which to end recycling.
+        cycle_time : float
+            Total cycle time.
+        V_tank : float
+            Volume of the mixing tank.
+        c_eluent : list[float] | float, optional
+            Eluent concentration. Defaults to 0.0.
+        c_tank_init : list[float] | float | None, optional
+            Initial tank concentration. If None, feed concentration is used.
+            Defaults to None.
+
+        """
+        flow_sheet = self._build_flow_sheet(
+            column=column,
+            c_feed=c_feed,
+            c_eluent=c_eluent,
+            V_tank=V_tank,
+            c_tank_init=c_tank_init,
+        )
+
+        super().__init__(flow_sheet, "MRSSR")
+
+        self.cycle_time = cycle_time
+
+        # Durations
+        self.add_duration("feed_duration", feed_duration)
+
+        # Events
+        self.add_event("inject_on", "flow_sheet.tank.flow_rate", flow_rate, 0)
+        self.add_event("inject_off", "flow_sheet.tank.flow_rate", 0.0)
+        self.add_event("eluent_on", "flow_sheet.eluent.flow_rate", flow_rate)
+        self.add_event("eluent_off", "flow_sheet.eluent.flow_rate", 0.0)
+        self.add_event("feed_on", "flow_sheet.feed.flow_rate", flow_rate)
+        self.add_event("feed_off", "flow_sheet.feed.flow_rate", 0.0)
+        self.add_event(
+            "recycle_on",
+            f"flow_sheet.output_states.{column.name}",
+            {"tank": 1},
+            recycle_on,
+        )
+        self.add_event(
+            "recycle_off",
+            f"flow_sheet.output_states.{column.name}",
+            {"outlet": 1},
+            recycle_off,
+        )
+
+        # Dependencies
+        self.add_event_dependency("eluent_off", ["inject_on"])
+        self.add_event_dependency("eluent_on", ["inject_off"])
+        self.add_event_dependency("feed_on", ["inject_off"])
+        self.add_event_dependency("feed_off", ["feed_on", "feed_duration"], [1, 1])
+        self.add_event_dependency(
+            "inject_off",
+            ["inject_on", "feed_duration", "recycle_off", "recycle_on"],
+            [1, 1, 1, -1]
+        )
+
+    def _build_flow_sheet(
+        self,
+        column: ChromatographicColumnBase,
+        c_feed: list[float],
+        c_eluent: list[float] | float = 0.0,
+        V_tank: float = 1e-6,
+        c_tank_init: list[float] | float | None = None,
+    ) -> FlowSheet:
+        """Build and return the flow sheet for MRSSR process."""
+        component_system = column.component_system
+
+        # Unit Operations
+        feed = Inlet(component_system, name="feed")
+        feed.c = c_feed
+
+        eluent = Inlet(component_system, name="eluent")
+        eluent.c = c_eluent
+
+        tank = Cstr(component_system, name="tank")
+        tank.V = V_tank
+        if c_tank_init is None:
+            c_tank_init = c_feed
+        tank.c = c_tank_init
+
+        outlet = Outlet(component_system, name="outlet")
+
+        # Flow Sheet
+        flow_sheet = FlowSheet(component_system)
+
+        flow_sheet.add_unit(feed, feed_inlet=True)
+        flow_sheet.add_unit(eluent, eluent_inlet=True)
+        flow_sheet.add_unit(tank)
+        flow_sheet.add_unit(column)
+        flow_sheet.add_unit(outlet, product_outlet=True)
+
+        flow_sheet.add_connection(feed, tank)
+        flow_sheet.add_connection(tank, column)
+        flow_sheet.add_connection(eluent, column)
+        flow_sheet.add_connection(column, tank)
+        flow_sheet.add_connection(column, outlet)
+
+        return flow_sheet

--- a/CADETProcess/reference.py
+++ b/CADETProcess/reference.py
@@ -113,8 +113,6 @@ class ReferenceIO(ReferenceBase, SolutionIO):
 
         if flow_rate is None:
             flow_rate = 1
-        if isinstance(flow_rate, (int, float)):
-            flow_rate = flow_rate * np.ones(time.shape)
 
         super().__init__(name, component_system, time, solution, flow_rate)
 

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -264,6 +264,9 @@ class SolutionIO(SolutionBase):
         flow_rate : TimeLine | npt.ArrayLike
             The flow rate data, which can be a TimeLine object or an array-like structure.
         """
+        if np.isscalar(flow_rate):
+            flow_rate = flow_rate * np.ones(time.shape)
+
         if not isinstance(flow_rate, TimeLine):
             flow_rate = TimeLine.from_profile(time, flow_rate)
         self.flow_rate = flow_rate


### PR DESCRIPTION
As mentioned yesterday, I’ve added model builder utilities for several common processes:
- Batch Elution
- Flip-Flop
- Closed-Loop Recycling
- Steady-State Recycling
- Load-Wash-Elute

Additional ideas for future inclusion:
- Breakthrough
- Pulse Injection

## Open questions
1. **Scope of Inclusion:**
   These processes often have variants (e.g., adding periphery), making it impractical to cover every possible option. Should we include them in the main CADET-Process package, or would curated examples be more appropriate? Should we aim for maximum generality before integrating them into the core?

2. **Design Pattern:**
   Currently, a "Builder" pattern is used, but its value is limited here. Unlike the `CarouselBuilder`, we only instantiate the builder and then call `build_process()`. An alternative is to subclass `Process` directly, which would also enable type-checking for the resulting process.

3. **Testing Utility:**
   Some of these processes have analytical reference solutions, which could be valuable for testing and validation.

Looking forward to your thoughts, @hannahlanzrath @AntoniaBerger.