### PR TITLE
Fix indices for aggregator optimization variables

### DIFF
--- a/CADETProcess/optimization/__init__.py
+++ b/CADETProcess/optimization/__init__.py
@@ -99,7 +99,7 @@ from .individual import *
 from .population import *
 from .cache import *
 from .results import *
-from .optimizationProblem import *
+from .optimizationProblem import OptimizationProblem, OptimizationVariable
 from .parallelizationBackend import *
 from .optimizer import *
 from .scipyAdapter import COBYLA, COBYQA, TrustConstr, NelderMead, SLSQP

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -20,12 +20,14 @@ from addict import Dict
 
 from CADETProcess import CADETProcessError, log, settings
 from CADETProcess.dataStructure import (
+    Aggregator,
     Bool,
     Callable,
     Float,
     Integer,
     NumpyProxyArray,
     ParameterBase,
+    ProxyList,
     RangedInteger,
     Sized,
     SizedNdArray,
@@ -3671,7 +3673,7 @@ class OptimizationVariable:
         except AttributeError:
             return None
 
-        if not isinstance(descriptor, ParameterBase):
+        if not isinstance(descriptor, (ParameterBase, Aggregator)):
             return None
 
         return descriptor
@@ -3735,7 +3737,7 @@ class OptimizationVariable:
         if isinstance(parameter_descriptor, (Float, Integer, Bool)):
             return False
 
-        if isinstance(parameter_descriptor, Sized):
+        if isinstance(parameter_descriptor, (Sized, Aggregator)):
             return True
 
         current_value = self._current_value(evaluation_object)
@@ -4027,7 +4029,7 @@ class OptimizationVariable:
 
                 parameter_type = self._parameter_type(eval_obj)
                 if (
-                    parameter_type is not NumpyProxyArray
+                    parameter_type not in [NumpyProxyArray, ProxyList]
                     and not isinstance(new_value, parameter_type)
                 ):
                     new_value = parameter_type(new_value.tolist())


### PR DESCRIPTION
This PR fixes an issue reported [on the Forum](https://forum.cadet-web.de/t/fitting-reaction-parameters-to-a-set-of-experimental-data/1296/8).

Note, this is kind of a quick-and-dirty quick-fix since aggregators will no longer be required once we update our reactions module.