### PR TITLE
Add fields

### DIFF
--- a/CADETProcess/fields.py
+++ b/CADETProcess/fields.py
@@ -1,0 +1,242 @@
+from __future__ import annotations
+
+from functools import wraps
+from typing import Any, Callable, Optional
+
+import matplotlib.pyplot as plt
+import numpy as np
+import numpy.typing as npt
+import xarray as xr
+
+
+class Field:
+    """Represent internal state or solution of a unit operation."""
+
+    def __init__(
+        self,
+        coordinates: Optional[dict[str, npt.ArrayLike | tuple[npt.ArrayLike, str]]] = None,
+        data: Optional[npt.ArrayLike] = None,
+        components: Optional[list[str]] = None,
+        name: Optional[str] = None,
+        unit: Optional[str] = None,
+    ) -> None:
+        """
+        Represent a scalar or vector field as a DataArray.
+
+        Parameters
+        ----------
+        coordinates : Optional[dict[str, npt.ArrayLike | tuple[npt.ArrayLike, str]]]
+            Coordinate labels and values, optionally with units as (values, unit).
+        data : Optional[npt.ArrayLike]
+            Values with shape `grid_shape` (and `len(components)` if vector field).
+            If None, filled with random numbers (for dev).
+        components : Optional[list[str]]
+            Names of components (for vector fields). If None, treated as scalar field.
+        name : Optional[str]
+            Name of the field (e.g., "temperature").
+        unit : Optional[str]
+            Unit of the field (data).
+        """
+        # Unpack coordinates and coord_units from tuples
+        coords = {}
+        coord_units = {}
+        if coordinates is None:
+            coordinates = {}
+        for dim, coord in coordinates.items():
+            if isinstance(coord, tuple):
+                coords[dim] = np.asarray(coord[0])
+                coord_units[dim] = coord[1]
+            else:
+                coords[dim] = np.asarray(coord)
+        self.coordinates = coords
+
+        # Build shape and dims
+        dims = list(coords.keys())
+        if components is not None:
+            dims.append("component")
+
+        # Handle 0D case
+        if not dims:
+            # Scalar field: data is 0D, dims is empty
+            grid_shape = ()
+        else:
+            # nD field: data is nD, dims is non-empty
+            grid_shape = tuple(len(v) for v in coords.values())
+
+        if components is not None:
+            grid_shape += (len(components),)
+        if data is None:
+            data = np.random.rand(*grid_shape)  # only for development
+        data = np.asarray(data)
+
+        if data.shape != grid_shape:
+            raise ValueError(
+                f"Data shape {data.shape} does not match expected shape {grid_shape}"
+            )
+
+        # Build DataArray coordinates
+        da_coords = coords.copy()
+        dims = list(coords.keys())
+        if components is not None:
+            da_coords["component"] = components
+            dims.append("component")
+
+        # Store DataArray
+        self._data = xr.DataArray(data, coords=da_coords, dims=dims, name=name)
+
+        # Set unit for data
+        if unit is not None:
+            self._data.attrs["units"] = unit
+
+        # Set units for coordinates
+        for dim, dim_unit in coord_units.items():
+            self._data[dim].attrs["units"] = dim_unit
+
+    @property
+    def name(self) -> str:
+        """Return the name of the Field."""
+        return self._data.name
+
+    @property
+    def data(self) -> xr.DataArray:
+        """Return the underlying xarray DataArray."""
+        return self._data
+
+    @property
+    def components(self) -> Optional[list[str]]:
+        """Return component names if present, else None."""
+        return (
+            self._data.coords["component"].values.tolist()
+            if "component" in self._data.dims
+            else None
+        )
+
+    def wraps_xr(method_name: str) -> Callable:
+        """Wrap xr.DataArray method."""
+        def xr_decorator(func: Callable) -> Callable:
+            @wraps(func)
+            def xr_wrapper(
+                self: "Field",
+                *args: Any,
+                **kwargs: Any,
+            ) -> "Field":
+                """Wrap xr.DataArray method."""
+                da = getattr(self._data, method_name)(*args, **kwargs)
+                coords = {k: da.coords[k].values for k in da.dims if k != "component"}
+                comps = (
+                    da.coords["component"].values.tolist()
+                    if "component" in da.dims
+                    else None
+                )
+                return Field(coords, data=da.values, components=comps)
+            return xr_wrapper
+        return xr_decorator
+
+    @wraps_xr("sel")
+    def sel(self, **kwargs: Any) -> "Field":
+        """Slice the field using xarray's sel."""
+        pass
+
+    @wraps_xr("isel")
+    def isel(self, drop: bool = False, **kwargs: Any) -> "Field":
+        """Slice the field using xarray's isel (by integer index)."""
+        pass
+
+    @wraps_xr("interp")
+    def interp(self, **kwargs: Any) -> "Field":
+        """Interpolate the field along given coordinates."""
+        pass
+
+    @wraps_xr("differentiate")
+    def differentiate(self, **kwargs: Any) -> "Field":
+        """Differentiate the array with second order accurate central differences."""
+        pass
+
+    @wraps_xr("integrate")
+    def integrate(self, **kwargs: Any) -> "Field":
+        """Integrate the array along the given coordinate using the trapezoidal rule."""
+        pass
+
+    def plot(
+        self,
+        sel: Optional[dict[str, float | list[str]]] = None,
+        ax: Optional[plt.Axes] = None,
+        **kwargs: Any,
+    ) -> plt.Axes | np.ndarray[plt.Axes]:
+        """
+        Plot the field using xarray's plotting backend.
+
+        Parameters
+        ----------
+        sel : dict[str, float or list[str]], optional
+            Coordinates (including "component") at which to slice before plotting.
+        ax : matplotlib.axes.Axes, optional
+            Axis to plot into (1D or 2D scalar only). If None, create new.
+            Note, this does currently not work for faceted plots.
+        **kwargs: Any
+            Passed to xarray plot method.
+
+        Returns
+        -------
+        plt.Axes | np.ndarray[plt.Axes]
+            The axes object(s) that were used for plotting
+        """
+        da = self._data
+        if sel is not None:
+            da = da.sel(sel, method="nearest")
+
+        plot_dims = [d for d in da.dims if d != "component"]
+        ndim = len(plot_dims)
+
+        if ndim > 2:
+            raise ValueError(
+                f"Field has {ndim} dims after slicing; plot only supports 1D or 2D."
+            )
+
+        # Create new figure for 1D or scalar 2D
+        if ax is None and (ndim == 1 or (ndim == 2 and "component" not in da.dims)):
+            fig, ax = plt.subplots()
+
+        # --- 1D case ---
+        if ndim == 1:
+            if "component" in da.dims:
+                out = da.plot.line(
+                    ax=ax,
+                    hue="component",
+                    **kwargs
+                )
+            else:
+                out = da.plot.line(
+                    ax=ax,
+                    **kwargs
+                )
+            return ax
+
+        # --- 2D case ---
+        if ndim == 2:
+            if "component" in da.dims:
+                out = da.plot(
+                    col="component",
+                    **kwargs
+                )
+                return out.axs
+            else:
+                out = da.plot(
+                    ax=ax,
+                    **kwargs
+                )
+                return ax
+
+    def __getitem__(self, key: str) -> "Field":
+        """Extract a single component as a new Field."""
+        if "component" not in self._data.dims:
+            raise ValueError("No components defined.")
+
+        da = self._data.sel(component=key, drop=True)
+        coords = {k: da.coords[k].values for k in da.dims if k != "component"}
+
+        return Field(coords, data=da.values)
+
+    def __repr__(self) -> str:
+        """str: String representation of the Field."""
+        return f"Field({repr(self._data)})"

--- a/CADETProcess/fields.py
+++ b/CADETProcess/fields.py
@@ -48,15 +48,12 @@ class Field:
                 coord_units[dim] = coord[1]
             else:
                 coords[dim] = np.asarray(coord)
+
         self.coordinates = coords
 
         # Build shape and dims
-        dims = list(coords.keys())
-        if components is not None:
-            dims.append("component")
-
         # Handle 0D case
-        if not dims:
+        if not coords:
             # Scalar field: data is 0D, dims is empty
             grid_shape = ()
         else:
@@ -76,13 +73,11 @@ class Field:
 
         # Build DataArray coordinates
         da_coords = coords.copy()
-        dims = list(coords.keys())
         if components is not None:
             da_coords["component"] = components
-            dims.append("component")
 
         # Store DataArray
-        self._data = xr.DataArray(data, coords=da_coords, dims=dims, name=name)
+        self._data = xr.DataArray(data, coords=da_coords, name=name)
 
         # Set unit for data
         if unit is not None:
@@ -111,6 +106,48 @@ class Field:
             else None
         )
 
+    @property
+    def has_components(self) -> bool:
+        """Return True if Field has components."""
+        return self.components is not None
+
+    def wraps_xr_selection(method_name: str) -> Callable:
+        """Specialized wrapper for sel/isel to handle 'component' separately."""
+        def selection_decorator(func: Callable) -> Callable:
+            @wraps(func)
+            def selection_wrapper(self: "Field", *args: Any, **kwargs: Any) -> "Field":
+                # Pop 'component' to handle it separately
+                component = kwargs.pop("component", None)
+
+                # Select component if specified
+                da = self._data
+                if component is not None:
+                    da = getattr(da, method_name)(component=component)
+
+                # Call the xarray method
+                da = getattr(da, method_name)(*args, **kwargs)
+
+                # Process result
+                coords = {k: da.coords[k].values for k in da.dims if k != "component"}
+                comps = (
+                    da.coords["component"].values.tolist()
+                    if "component" in da.dims
+                    else None
+                )
+                return Field(coords, data=da.values, components=comps)
+            return selection_wrapper
+        return selection_decorator
+
+    @wraps_xr_selection("sel")
+    def sel(self, **kwargs: Any) -> "Field":
+        """Slice the field using xarray's sel."""
+        pass
+
+    @wraps_xr_selection("isel")
+    def isel(self, **kwargs: Any) -> "Field":
+        """Slice the field using xarray's isel (by integer index)."""
+        pass
+
     def wraps_xr(method_name: str) -> Callable:
         """Wrap xr.DataArray method."""
         def xr_decorator(func: Callable) -> Callable:
@@ -131,16 +168,6 @@ class Field:
                 return Field(coords, data=da.values, components=comps)
             return xr_wrapper
         return xr_decorator
-
-    @wraps_xr("sel")
-    def sel(self, **kwargs: Any) -> "Field":
-        """Slice the field using xarray's sel."""
-        pass
-
-    @wraps_xr("isel")
-    def isel(self, drop: bool = False, **kwargs: Any) -> "Field":
-        """Slice the field using xarray's isel (by integer index)."""
-        pass
 
     @wraps_xr("interp")
     def interp(self, **kwargs: Any) -> "Field":
@@ -181,9 +208,12 @@ class Field:
         plt.Axes | np.ndarray[plt.Axes]
             The axes object(s) that were used for plotting
         """
-        da = self._data
+        field = self
+
         if sel is not None:
-            da = da.sel(sel, method="nearest")
+            field = self.sel(**sel, method="nearest")
+
+        da = field._data
 
         plot_dims = [d for d in da.dims if d != "component"]
         ndim = len(plot_dims)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,0 +1,107 @@
+import matplotlib.pyplot as plt
+import numpy as np
+import pytest
+from CADETProcess.fields import Field
+
+
+# %% Fixtures
+@pytest.fixture
+def coords():
+    """Provide standard 3D coordinate set."""
+    return {
+        "time": np.linspace(0, 100, 101),
+        "axial": np.linspace(0, 10, 11),
+        "radial": np.linspace(0, 1, 5),
+    }
+
+
+@pytest.fixture
+def components():
+    """Provide standard component names."""
+    return ["A", "B"]
+
+
+# %% Initialization
+@pytest.mark.parametrize(
+    "expected_dims,components",
+    [
+        (("time", "axial", "radial"), None),
+        (("time", "axial", "radial", "component"), ["A", "B"]),
+    ],
+)
+def test_field_shapes(coords, components, expected_dims):
+    """Test that field dimensions are correct for scalar and vector fields."""
+    f = Field(coords, components=components)
+    assert f.data.dims == expected_dims
+
+
+# %% Interpolation
+def test_interp_removes_selected_coords(coords):
+    """Test that interpolation removes selected coordinates."""
+    f = Field(coords)
+    f2 = f.interp(time=42.3, axial=5.1)
+    assert "time" not in f2.data.dims
+    assert "axial" not in f2.data.dims
+    assert "radial" in f2.data.dims
+
+
+def test_vector_field_interp(coords, components):
+    """Test that interpolation preserves component dimension for vector fields."""
+    f = Field(coords, components=components)
+    f2 = f.interp(time=42.3, axial=5.1)
+    assert "component" in f2.data.dims
+    assert f2.data.shape[-1] == len(components)
+
+
+# %% Selection
+def test_sel_component(coords):
+    """Test selection and indexing of components."""
+    f = Field({"time": np.linspace(0, 10, 11)}, components=["A", "B", "C"])
+    fa = f.sel(component="A")
+    assert "component" not in fa.data.dims
+    fab = f.sel(component=["A", "B"])
+    assert "component" in fab.data.dims
+    fb = f.isel(component=1)
+    assert "component" not in fb.data.dims
+
+
+# %% Plotting
+def test_plot_1d_scalar(coords):
+    """Test plotting a 1D scalar field."""
+    f = Field({"time": coords["time"]}, name="Scalar 1D", unit="mM")
+    obj = f.plot()
+    assert isinstance(obj, plt.Axes)
+
+
+def test_plot_1d_vector(coords, components):
+    """Test plotting a 1D vector field."""
+    f = Field({"time": coords["time"]}, components=components, name="Vector 1D")
+    obj = f.plot()
+    assert isinstance(obj, plt.Axes)
+
+
+def test_plot_2d_scalar(coords):
+    """Test plotting a 2D scalar field."""
+    f = Field({"time": coords["time"], "axial": coords["axial"]}, name="Scalar 2D")
+    obj = f.plot()
+    assert isinstance(obj, plt.Axes)
+
+
+def test_plot_2d_vector(coords, components):
+    """Test plotting a 2D vector field."""
+    f = Field({"time": coords["time"], "axial": coords["axial"]}, components=components)
+    obj = f.plot()
+    assert isinstance(obj, np.ndarray)
+
+
+def test_plot_raises_for_too_many_dims(coords, components):
+    """Test that plotting raises an error for fields with too many dimensions."""
+    f = Field(coords, components=components)
+    with pytest.raises(ValueError):
+        f.plot()
+
+
+# %% Run tests
+
+if __name__ == "__main__":
+    pytest.main([__file__])

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -57,10 +57,17 @@ def test_vector_field_interp(coords, components):
 def test_sel_component(coords):
     """Test selection and indexing of components."""
     f = Field({"time": np.linspace(0, 10, 11)}, components=["A", "B", "C"])
+
     fa = f.sel(component="A")
     assert "component" not in fa.data.dims
+
     fab = f.sel(component=["A", "B"])
     assert "component" in fab.data.dims
+
+    fabt = f.sel(component="A", time=0.1234, method="nearest")
+    assert "component" not in fabt.data.dims
+    assert "time" not in fabt.data.dims
+
     fb = f.isel(component=1)
     assert "component" not in fb.data.dims
 


### PR DESCRIPTION
This PR adds a new `fields` module which is intended to be used to represent internal state of unit operations, as well the solution of simulations. It's essentially a wrapper around [xarray](https://docs.xarray.dev/en/stable/)'s `DataArray` and exposes some of its methods.

The ultimate goal of this is to replace our current `Solution` / `Reference` classes which are somewhat limited when dealing with multidimensional data (e.g. for particle / 2D-GRM). Moreover, this will unify indexing / interpolation / plotting interfaces, we 

## Open questions
Some of the existing methods might need to be adapted (especially for `SolutionIO`):
- total concentration
- local purity
- normalization
- flow rate / dmdt
- creation of fractions

I suggest leaving the `Fields` clean and integrate this into dedicated `Solution` classes that might inherit from `Fields`.

## Todo
(might be moved to separate PRs)

- [ ] Use fields in solution / reference modules
- [ ] Use for (initial) state of unit operations


```
from CADETProcess.fields import Field

# %% Coordinates

time_coords = np.linspace(0, 100, 101)
axial_coords = np.linspace(0, 10, 11)
radial_coords = np.linspace(0, 1, 5)

components = ["A", "B"]

# 3D vector field
f3v = Field(
    coordinates={
        "time": (time_coords, "s"),
        "axial": (axial_coords, "m"),
        "radial": (radial_coords, "m"),
    },
    components=["A", "B"],
    name="3D Vector Field",
    unit="mM"
)

# Select individual components
f3v_a = f3v["A"]

# Select values at certain times
f3v_0 = f3v.sel(time=0)  # Note, dimensions are reduced
f3v_0 = f3v.sel(time=0.1233, method="nearest")  # Use nearest value if not available

# Interpolate / resample
f3v_0 = f3v.interp(time=np.linspace(0, 100, 1001))

# Plot
f3v_plot_t0 = f3v.plot({"time": 0})  # Faceted plot with 2D plot per component
f3v_plot_a0_r0 = f3v.plot({"axial": 0, "radial": 0})  # 1D Plot with component overlay

# Differentiation / Intergration
f3v_diff = f3v.differentiate("time")
f3v_diff_plot_a0_r0 = f3v_diff.plot({"axial": 0, "radial": 0})  # 1D Plot with component overlay

f3v_int = f3v.integrate("time")
f3v_int_plot_a0_r0 = f3v_int.plot({"axial": 0, "radial": 0})  # 1D Plot with component overlay
```