### PR TITLE
Chore: 

### DIFF
--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -403,6 +403,7 @@ class FractionationOptimizer:
 
         # Lock to enable caching
         simulation_results.process.lock = True
+
         try:
             results = self.optimizer.optimize(
                 opt,
@@ -413,12 +414,16 @@ class FractionationOptimizer:
             )
             opt.set_variables(results.x[0])
             frac.reset()
-        except CADETProcessError as e:
+        except (ValueError, CADETProcessError) as e:
+            message = (
+                f"Optimization failed due to {type(e).__name__}: {str(e)} "
+                "Returning initial values."
+            )
             if ignore_failed:
-                warnings.warn("Optimization failed. Returning initial values")
+                warnings.warn(message)
                 frac.initial_values(purity_required)
             else:
-                raise CADETProcessError(str(e))
+                raise CADETProcessError(message)
         finally:
             # Restore previous lock state
             simulation_results.process.lock = lock_state

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -156,7 +156,7 @@ class FractionationOptimizer:
         frac: Fractionator,
         purity_required: list[float],
         allow_empty_fractions: bool = True,
-        ranking: Optional[int | list[float]] = 1,
+        ranking: str | list[float] | int = "equal",
         obj_fun: Optional[Callable] = None,
         minimize: bool = True,
         bad_metrics: Optional[float | list[float]] = None,
@@ -173,11 +173,10 @@ class FractionationOptimizer:
             Minimum purity required for the components in the fractionation.
         allow_empty_fractions: bool, optional
             If True, allow empty fractions. The default is True.
-        ranking : Optional[int | list[float]] = 1,
+        ranking : str | list[float] | int, optional, default="equal",
             Weighting factors for individual components.
-            If 1, the same value is assumed for all components.
-            If None, no ranking is used and the problem is solved as multi-objective.
-            The default is 1.
+            If "equal", the same value is assumed for all components.
+            If integer, only component of that index is used.
         obj_fun : callable, optional
             Alternative objective function.
             If no function is provided, the fraction mass is maximized.
@@ -281,7 +280,7 @@ class FractionationOptimizer:
         purity_required: float | list[float],
         components: Optional[list[str]] = None,
         use_total_concentration_components: bool = True,
-        ranking: Optional[int | list[float]] = 1,
+        ranking: str | list[float] | int = "equal",
         obj_fun: Optional[Callable] = None,
         n_objectives: int = 1,
         bad_metrics: float | list[float] = 0,
@@ -305,11 +304,11 @@ class FractionationOptimizer:
             List of components to consider in the fractionation process.
         use_total_concentration_components : bool, Default=True
             Flag wheter to use the total concentration components.
-        ranking : Optional[int | list[float]] = 1,
+        ranking : str | list[float] | int, optional, default="equal"
             Weighting factors for individual components.
-            If 1, the same value is assumed for all components.
-            If None, no ranking is used and the problem is solved as multi-objective.
-            The default is 1.
+            If integer, only component of that index is used.
+            If None, the same value is assumed for all components.
+            The default is None.
         obj_fun : function, optional
             Objective function used for OptimizationProblem.
             If COBYLA is used, must return single objective.

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -1,3 +1,4 @@
+import copy
 import warnings
 from typing import Callable, Optional
 
@@ -206,6 +207,7 @@ class FractionationOptimizer:
         n_fractions = np.array([pool.n_fractions for pool in frac.fraction_pools])
         empty_fractions = np.where(n_fractions[0:-1] == 0)[0]
         if len(empty_fractions) > 0 and allow_empty_fractions:
+            purity_required = copy.deepcopy(purity_required)
             for empty_fraction in empty_fractions:
                 purity_required[empty_fraction] = 0
 

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -155,8 +155,8 @@ class FractionationOptimizer:
         self,
         frac: Fractionator,
         purity_required: list[float],
+        ranking: list[float],
         allow_empty_fractions: bool = True,
-        ranking: str | list[float] | int = "equal",
         obj_fun: Optional[Callable] = None,
         minimize: bool = True,
         bad_metrics: Optional[float | list[float]] = None,
@@ -171,12 +171,10 @@ class FractionationOptimizer:
             The Fractionator object.
         purity_required : list[float]
             Minimum purity required for the components in the fractionation.
+        ranking : list[float]
+            Weighting factors for individual components.
         allow_empty_fractions: bool, optional
             If True, allow empty fractions. The default is True.
-        ranking : str | list[float] | int, optional, default="equal",
-            Weighting factors for individual components.
-            If "equal", the same value is assumed for all components.
-            If integer, only component of that index is used.
         obj_fun : callable, optional
             Alternative objective function.
             If no function is provided, the fraction mass is maximized.
@@ -363,9 +361,22 @@ class FractionationOptimizer:
         if len(simulation_results.chromatograms) == 0:
             raise CADETProcessError("Simulation results do not contain chromatogram.")
 
+        # Convert inputs to lists of length n_comp
+        n_comp = simulation_results.component_system.n_comp
         if isinstance(purity_required, float):
-            n_comp = simulation_results.component_system.n_comp
             purity_required = n_comp * [purity_required]
+        if ranking == "equal":
+            ranking = n_comp * [1.0]
+        if isinstance(ranking, int):
+            index = ranking
+            ranking = n_comp * [0.0]
+            ranking[index] = 1.0
+
+        # Synchronize zeros between purity_required and ranking
+        for i in range(n_comp):
+            if purity_required[i] == 0 or ranking[i] == 0:
+                purity_required[i] = 0.0
+                ranking[i] = 0.0
 
         # Store previous lock state, unlock to ensure consistent values
         lock_state = simulation_results.process.lock
@@ -382,8 +393,8 @@ class FractionationOptimizer:
         opt, x0 = self._setup_optimization_problem(
             frac,
             purity_required,
-            allow_empty_fractions=allow_empty_fractions,
             ranking=ranking,
+            allow_empty_fractions=allow_empty_fractions,
             obj_fun=obj_fun,
             n_objectives=n_objectives,
             minimize=minimize,

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -243,12 +243,13 @@ class Individual(Structure):
     @property
     def objectives_minimization_factors(self) -> np.ndarray:
         """np.ndarray: Array indicating objectives transformed to minimization."""
-        return self.f_minimized / self.f
+        return np.where(np.signbit(self.f_minimized) == np.signbit(self.f), 1, -1)
 
     @property
     def meta_scores_minimization_factors(self) -> np.ndarray | None:
         """np.ndarray: Array indicating meta sorces transformed to minimization."""
-        return self.m_minimized / self.m
+        if self.m is not None:
+            return np.where(np.signbit(self.m_minimized) == np.signbit(self.m), 1, -1)
 
     def dominates(self, other: "Individual") -> bool:
         """

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -265,38 +265,91 @@ class Individual(Structure):
         dominates : bool
             True if objectives of "self" are not strictly worse than the
             corresponding objectives of "other" and at least one objective is
-            strictly better. False otherwise
+            strictly better. False otherwise.
         """
+        dominates_f = self.dominates_f(other)
+
+        if self.m is not None:
+            dominates_m = self.dominates_m(other)
+        else:
+            dominates_m = True
+
+        return dominates_f and dominates_m
+
+    def _dominates(self, other: "Individual", attr: str) -> bool:
+        """
+        Determine if individual dominates other in terms of some value.
+
+        Parameters
+        ----------
+        other : Individual
+            Other individual
+
+        Returns
+        -------
+        dominates : bool
+            True if values of "self" are not strictly worse than the
+            corresponding values of "other" and at least one value is
+            strictly better. False otherwise.
+        """
+        # Evaluation checks
         if not self.is_evaluated:
             raise CADETProcessError("Individual needs to be evaluated first.")
         if not other.is_evaluated:
             raise CADETProcessError("Other individual needs to be evaluated first.")
 
+        # Feasibility check
         if self.is_feasible and not other.is_feasible:
             return True
         if not self.is_feasible and other.is_feasible:
             return False
-
         if not self.is_feasible and not other.is_feasible:
-            if np.any(self.cv < other.cv):
-                better_in_all = np.all(self.cv <= other.cv)
-                strictly_better_in_one = np.any(self.cv < other.cv)
-                return better_in_all and strictly_better_in_one
+            better_in_all = np.all(self.cv <= other.cv)
+            strictly_better_in_one = np.any(self.cv < other.cv)
+            return better_in_all and strictly_better_in_one
 
-        if self.m is not None:
-            self_values = self.m_minimized
-            other_values = other.m_minimized
-        else:
-            self_values = self.f_minimized
-            other_values = other.f_minimized
+        # Objective comparison
+        self_value = getattr(self, attr)
+        other_value = getattr(other, attr)
+        better_in_all = np.all(self_value <= other_value)
+        strictly_better_in_one = np.any(self_value < other_value)
+        return better_in_all and strictly_better_in_one
 
-        if np.any(self_values > other_values):
-            return False
+    def dominates_f(self, other: "Individual") -> bool:
+        """
+        Determine if individual dominates other in terms of objectives.
 
-        if np.any(self_values < other_values):
-            return True
+        Parameters
+        ----------
+        other : Individual
+            Other individual
 
-        return False
+        Returns
+        -------
+        dominates : bool
+            True if objectives of "self" are not strictly worse than the
+            corresponding objectives of "other" and at least one objective is
+            strictly better. False otherwise.
+        """
+        return self._dominates(other, "f_minimized")
+
+    def dominates_m(self, other: "Individual") -> bool:
+        """
+        Determine if individual dominates other in terms of meta scores.
+
+        Parameters
+        ----------
+        other : Individual
+            Other individual
+
+        Returns
+        -------
+        dominates : bool
+            True if meta scores of "self" are not strictly worse than the
+            corresponding objectives of "other" and at least one score is
+            strictly better. False otherwise.
+        """
+        return self._dominates(other, "m_minimized")
 
     def is_similar(self, other: "Individual", tol: float = 1e-1) -> bool:
         """

--- a/CADETProcess/optimization/individual.py
+++ b/CADETProcess/optimization/individual.py
@@ -1,4 +1,5 @@
 import hashlib
+import warnings
 from typing import Optional
 
 import numpy as np
@@ -55,7 +56,7 @@ class Individual(Structure):
         Linear equality constraint violations.
     f : np.ndarray
         Objective values.
-    f_min : np.ndarray
+    f_minimized : np.ndarray
         Minimized objective values.
     g : np.ndarray
         Nonlinear constraint values.
@@ -63,7 +64,7 @@ class Individual(Structure):
         Nonlinear constraints violation.
     m : np.ndarray
         Meta score values.
-    m_min : np.ndarray
+    m_minimized : np.ndarray
         Minimized meta score values.
     is_feasible : bool
         True, if individual fulfills all constraints.
@@ -79,12 +80,12 @@ class Individual(Structure):
     cv_lincon = Vector()
     cv_lineqcon = Vector()
     f = Vector()
-    f_min = Vector()
+    f_minimized = Vector()
     g = Vector()
     cv_nonlincon = Vector()
     cv_nonlincon_tol = Float()
     m = Vector()
-    m_min = Vector()
+    m_minimized = Vector()
     is_feasible = Bool()
 
     def __init__(
@@ -92,20 +93,22 @@ class Individual(Structure):
         x: npt.ArrayLike,
         f: Optional[npt.ArrayLike] = None,
         g: Optional[npt.ArrayLike] = None,
-        f_min: Optional[npt.ArrayLike] = None,
+        f_minimized: Optional[npt.ArrayLike] = None,
         x_transformed: Optional[npt.ArrayLike] = None,
         cv_bounds: Optional[npt.ArrayLike] = None,
         cv_lincon: Optional[npt.ArrayLike] = None,
         cv_lineqcon: Optional[npt.ArrayLike] = None,
         cv_nonlincon: Optional[npt.ArrayLike] = None,
         m: Optional[npt.ArrayLike] = None,
-        m_min: Optional[npt.ArrayLike] = None,
+        m_minimized: Optional[npt.ArrayLike] = None,
         independent_variable_names: list[str] = None,
         objective_labels: list[str] = None,
         nonlinear_constraint_labels: list[str] = None,
         meta_score_labels: list[str] = None,
         variable_names: list[str] = None,
         is_feasible: bool = True,
+        f_min: Optional[npt.ArrayLike] = None,
+        m_min: Optional[npt.ArrayLike] = None,
     ) -> None:
         """Initialize Individual Object."""
         self.x = x
@@ -119,9 +122,19 @@ class Individual(Structure):
         self.cv_lineqcon = cv_lineqcon
 
         self.f = f
-        if f_min is None:
-            f_min = f
-        self.f_min = f_min
+        if f_min is not None:
+            warnings.warn(
+                "The 'f_min' argument is deprecated and will be removed in a future version. "
+                "Use 'f_minimized' instead.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+            if f_minimized is not None:
+                raise ValueError("Cannot specify both 'f_min' and 'f_minimized'.")
+            f_minimized = f_min
+        if f_minimized is None:
+            f_minimized = f
+        self.f_minimized = f_minimized
 
         self.g = g
         if g is not None and cv_nonlincon is None:
@@ -129,9 +142,19 @@ class Individual(Structure):
         self.cv_nonlincon = cv_nonlincon
 
         self.m = m
-        if m_min is None:
-            m_min = m
-        self.m_min = m_min
+        if m_min is not None:
+            warnings.warn(
+                "The 'm_min' argument is deprecated and will be removed in a future version. "
+                "Use 'm_minimized' instead.",
+                DeprecationWarning,
+                stacklevel=2
+            )
+            if m_minimized is not None:
+                raise ValueError("Cannot specify both 'm_min' and 'm_minimized'.")
+            m_minimized = m_min
+        if m_minimized is None:
+            m_minimized = m
+        self.m_minimized = m_minimized
 
         if isinstance(variable_names, np.ndarray):
             variable_names = [s.decode() for s in variable_names]
@@ -220,12 +243,12 @@ class Individual(Structure):
     @property
     def objectives_minimization_factors(self) -> np.ndarray:
         """np.ndarray: Array indicating objectives transformed to minimization."""
-        return self.f_min / self.f
+        return self.f_minimized / self.f
 
     @property
-    def meta_scores_minimization_factors(self) -> np.ndarray:
+    def meta_scores_minimization_factors(self) -> np.ndarray | None:
         """np.ndarray: Array indicating meta sorces transformed to minimization."""
-        return self.m_min / self.m
+        return self.m_minimized / self.m
 
     def dominates(self, other: "Individual") -> bool:
         """
@@ -260,11 +283,11 @@ class Individual(Structure):
                 return better_in_all and strictly_better_in_one
 
         if self.m is not None:
-            self_values = self.m_min
-            other_values = other.m_min
+            self_values = self.m_minimized
+            other_values = other.m_minimized
         else:
-            self_values = self.f_min
-            other_values = other.f_min
+            self_values = self.f_minimized
+            other_values = other.f_minimized
 
         if np.any(self_values > other_values):
             return False
@@ -430,7 +453,7 @@ class Individual(Structure):
         data.cv_lineqcon = self.cv_lineqcon
 
         data.f = self.f
-        data.f_min = self.f_min
+        data.f_minimized = self.f_minimized
 
         if self.g is not None:
             data.g = self.g
@@ -438,7 +461,7 @@ class Individual(Structure):
 
         if self.m is not None:
             data.m = self.m
-            data.m_min = self.m_min
+            data.m_minimized = self.m_minimized
 
         data.variable_names = self.variable_names
         data.independent_variable_names = self.independent_variable_names

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -11,7 +11,7 @@ import uuid
 import warnings
 from functools import wraps
 from pathlib import Path
-from typing import Any, NoReturn, Optional
+from typing import Any, Literal, Optional
 
 import hopsy
 import numpy as np
@@ -216,9 +216,10 @@ class OptimizationProblem(Structure):
 
         return wrapper_ensures2d
 
-    def ensures_minimization(scores: npt.ArrayLike) -> tp.Callable:
+    def ensures_minimization(
+        scores: Literal["objectives", "meta_scores"]
+    ) -> tp.Callable:
         """Convert maximization problems to minimization problems."""
-
         def wrap(func: tp.Callable) -> tp.Callable:
             @wraps(func)
             def wrapper_ensures_minimization(
@@ -239,7 +240,9 @@ class OptimizationProblem(Structure):
         return wrap
 
     def transform_maximization(
-        self: Any, s: list[float], scores: str | list
+        self: Any,
+        s: list[float],
+        scores: Literal["objectives", "meta_scores"],
     ) -> list[float]:
         """Transform maximization problems to minimization problems."""
         factors = []
@@ -1730,7 +1733,7 @@ class OptimizationProblem(Structure):
         current_iteration: int = 0,
         parallelization_backend: ParallelizationBackendBase | None = None,
         force: bool = False,
-    ) -> NoReturn:
+    ) -> None:
         """
         Evaluate callback functions for each individual x in population X.
 

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -1849,6 +1849,7 @@ class OptimizationProblem(Structure):
         name: Optional[str] = None,
         n_meta_scores: int = 1,
         minimize: bool = True,
+        bad_metrics: Optional[float | list[float]] = None,
         evaluation_objects: Optional[object | int | list] = -1,
         requires: Optional[Evaluator | list] = None,
     ) -> None:
@@ -1866,6 +1867,8 @@ class OptimizationProblem(Structure):
             The default is 1.
         minimize : bool, optional
             If True, meta score is treated as minimization problem. The default is True.
+        bad_metrics : flot or list of floats, optional
+            Value which is returned when evaluation fails.
         evaluation_objects : {EvaluationObject, None, -1, list}
             EvaluationObjects which are evaluated by objective.
             If None, no EvaluationObject is used.
@@ -1898,6 +1901,9 @@ class OptimizationProblem(Structure):
         if name in self.meta_score_names:
             warnings.warn("Meta score with same name already exists.")
 
+        if bad_metrics is None and isinstance(meta_score, MetricBase):
+            bad_metrics = meta_score.bad_metrics
+
         if evaluation_objects is None:
             evaluation_objects = []
         elif evaluation_objects == -1:
@@ -1922,6 +1928,8 @@ class OptimizationProblem(Structure):
             meta_score,
             name,
             n_meta_scores=n_meta_scores,
+            minimize=minimize,
+            bad_metrics=bad_metrics,
             evaluation_objects=evaluation_objects,
             evaluators=evaluators,
         )

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -3213,11 +3213,11 @@ class OptimizationProblem(Structure):
         self,
         x: np.ndarray,
         f: np.ndarray | None = None,
-        f_min: np.ndarray | None = None,
+        f_minimized: np.ndarray | None = None,
         g: np.ndarray | None = None,
         cv_nonlincon: np.ndarray | None = None,
         m: np.ndarray | None = None,
-        m_min: np.ndarray | None = None,
+        m_minimized: np.ndarray | None = None,
     ) -> Individual:
         """
         Create new individual from data.
@@ -3228,7 +3228,7 @@ class OptimizationProblem(Structure):
             Variable values in untransformed space.
         f : np.ndarray
             Objective values.
-        f_min : np.ndarray
+        f_minimized : np.ndarray
             Minimized objective values.
         g : np.ndarray
             Nonlinear constraint values.
@@ -3236,7 +3236,7 @@ class OptimizationProblem(Structure):
             Nonlinear constraints violation.
         m : np.ndarray
             Meta score values.
-        m_min : np.ndarray
+        m_minimized : np.ndarray
             Minimized meta score values.
 
         Returns
@@ -3258,11 +3258,11 @@ class OptimizationProblem(Structure):
             cv_lincon=cv_lincon,
             cv_lineqcon=cv_lineqcon,
             f=f,
-            f_min=f_min,
+            f_minimized=f_minimized,
             g=g,
             cv_nonlincon=cv_nonlincon,
             m=m,
-            m_min=m_min,
+            m_minimized=m_minimized,
             independent_variable_names=self.independent_variable_names,
             objective_labels=self.objective_labels,
             nonlinear_constraint_labels=self.nonlinear_constraint_labels,
@@ -3278,11 +3278,11 @@ class OptimizationProblem(Structure):
         self,
         X: npt.ArrayLike,
         F: npt.ArrayLike = None,
-        F_min: npt.ArrayLike | None = None,
+        F_minimized: npt.ArrayLike | None = None,
         G: npt.ArrayLike | None = None,
         CV_nonlincon: npt.ArrayLike | None = None,
         M: npt.ArrayLike | None = None,
-        M_min: npt.ArrayLike | None = None,
+        M_minimized: npt.ArrayLike | None = None,
     ) -> Population:
         """
         Create new population from data.
@@ -3293,7 +3293,7 @@ class OptimizationProblem(Structure):
             Variable values in untransformed space.
         F : npt.ArrayLike
             Objective values.
-        F_min : npt.ArrayLike
+        F_minimized : npt.ArrayLike
             Minimized objective values.
         G : npt.ArrayLike
             Nonlinear constraint values.
@@ -3301,7 +3301,7 @@ class OptimizationProblem(Structure):
             Nonlinear constraints violation.
         M : npt.ArrayLike
             Meta score values.
-        M_min : npt.ArrayLike
+        M_minimized : npt.ArrayLike
             Minimized meta score values.
 
         Returns
@@ -3316,10 +3316,10 @@ class OptimizationProblem(Structure):
         else:
             F = np.array(F, ndmin=2)
 
-        if F_min is None:
-            F_min = F
+        if F_minimized is None:
+            F_minimized = F
         else:
-            F_min = np.array(F_min, ndmin=2)
+            F_minimized = np.array(F_minimized, ndmin=2)
 
         if G is None:
             G = len(X) * [None]
@@ -3336,23 +3336,23 @@ class OptimizationProblem(Structure):
         else:
             M = np.array(M, ndmin=2)
 
-        if M_min is None:
-            M_min = M
+        if M_minimized is None:
+            M_minimized = M
         else:
-            M_min = np.array(M_min, ndmin=2)
+            M_minimized = np.array(M_minimized, ndmin=2)
 
         pop = Population()
-        for x, f, f_min, g, cv_nonlincon, m, m_min in zip(
-            X, F, F_min, G, CV_nonlincon, M, M_min
+        for x, f, f_minimized, g, cv_nonlincon, m, m_minimized in zip(
+            X, F, F_minimized, G, CV_nonlincon, M, M_minimized
         ):
             ind = self.create_individual(
                 x,
                 f=f,
-                f_min=f_min,
+                f_minimized=f_minimized,
                 g=g,
                 cv_nonlincon=cv_nonlincon,
                 m=m,
-                m_min=m_min,
+                m_minimized=m_minimized,
             )
             pop.add_individual(ind)
 

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -519,6 +519,7 @@ class OptimizerBase(Structure):
             M_minimized = self.optimization_problem.evaluate_meta_scores(
                 X_transformed,
                 untransform=True,
+                get_dependent_values=True,
                 ensure_minimization=True,
                 parallelization_backend=self.parallelization_backend,
             )

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -504,29 +504,29 @@ class OptimizerBase(Structure):
         self,
         X_transformed: npt.ArrayLike,
         F: npt.ArrayLike,
-        F_min: npt.ArrayLike,
+        F_minimized: npt.ArrayLike,
         G: npt.ArrayLike,
         CV_nonlincon: npt.ArrayLike,
     ) -> Population:
         """Create new population from current generation for post procesing."""
         X_transformed = np.array(X_transformed, ndmin=2)
         F = np.array(F, ndmin=2)
-        F_min = np.array(F_min, ndmin=2)
+        F_minimized = np.array(F_minimized, ndmin=2)
         G = np.array(G, ndmin=2)
         CV_nonlincon = np.array(CV_nonlincon, ndmin=2)
 
         if self.optimization_problem.n_meta_scores > 0:
-            M_min = self.optimization_problem.evaluate_meta_scores(
+            M_minimized = self.optimization_problem.evaluate_meta_scores(
                 X_transformed,
                 untransform=True,
                 ensure_minimization=True,
                 parallelization_backend=self.parallelization_backend,
             )
             M = self.optimization_problem.transform_maximization(
-                M_min, scores="meta_scores"
+                M_minimized, scores="meta_scores"
             )
         else:
-            M_min = None
+            M_minimized = None
             M = None
 
         if self.optimization_problem.n_nonlinear_constraints == 0:
@@ -539,11 +539,11 @@ class OptimizerBase(Structure):
         population = self.optimization_problem.create_population(
             X,
             F=F,
-            F_min=F_min,
+            F_minimized=F_minimized,
             G=G,
             CV_nonlincon=CV_nonlincon,
             M=M,
-            M_min=M_min,
+            M_minimized=M_minimized,
         )
 
         for ind in population:

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -315,25 +315,25 @@ class Population:
     @property
     def g(self) -> np.ndarray | None:
         """np.ndarray: All evaluated nonlinear constraint function values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.array([ind.g for ind in self.individuals])
 
     @property
     def g_min(self) -> np.ndarray | None:
         """np.ndarray: Minimum nonlinear constraint values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.min(self.g, axis=0)
 
     @property
     def g_max(self) -> np.ndarray | None:
         """np.ndarray: Maximum nonlinear constraint values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.max(self.g, axis=0)
 
     @property
     def g_avg(self) -> np.ndarray | None:
         """np.ndarray: Average nonlinear constraint values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.mean(self.g, axis=0)
 
     @property
@@ -345,68 +345,68 @@ class Population:
     @property
     def cv_nonlincon(self) -> np.ndarray | None:
         """np.ndarray: All evaluated nonlinear constraint violation values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.array([ind.cv_nonlincon for ind in self.individuals])
 
     @property
     def cv_nonlincon_min(self) -> np.ndarray | None:
         """np.ndarray: Minimum nonlinear constraint violation values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.min(self.cv_nonlincon, axis=0)
 
     @property
     def cv_nonlincon_max(self) -> np.ndarray | None:
         """np.ndarray: Maximum nonlinearconstraint violation values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.max(self.cv_nonlincon, axis=0)
 
     @property
     def cv_nonlincon_avg(self) -> np.ndarray | None:
         """np.ndarray: Average nonlinear constraint violation values."""
-        if self.dimensions[2] > 0:
+        if self.n_g > 0:
             return np.mean(self.cv_nonlincon, axis=0)
 
     @property
     def m(self) -> np.ndarray | None:
         """np.ndarray: All evaluated meta scores."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             return np.array([ind.m for ind in self.individuals])
 
     @property
     def m_min(self) -> np.ndarray | None:
         """np.ndarray: Minimum meta scores."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             return np.min(self.m, axis=0)
 
     @property
     def m_max(self) -> np.ndarray | None:
         """np.ndarray: Maximum meta scores."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             return np.max(self.m, axis=0)
 
     @property
     def m_avg(self) -> np.ndarray | None:
         """np.ndarray: Average meta scores."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             return np.mean(self.m, axis=0)
 
     @property
     def m_minimized(self) -> np.ndarray | None:
         """np.ndarray: All evaluated meta scores, transformed to be minimized."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             return np.array([ind.m_minimized for ind in self.individuals])
 
     @property
     def m_best(self) -> np.ndarray | None:
         """np.ndarray: Best meta scores."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             m_best = np.min(self.m_minimized, axis=0)
             return np.multiply(self.meta_scores_minimization_factors, m_best)
 
     @property
     def m_best_indices(self) -> np.ndarray | None:
         """np.ndarray: Indices of the best meta scores."""
-        if self.dimensions[3] > 0:
+        if self.n_m > 0:
             return np.argmin(self.m_minimized, axis=0)
 
     @property

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -282,17 +282,6 @@ class Population:
         return np.array([ind.f for ind in self.individuals])
 
     @property
-    def f_minimized(self) -> np.ndarray:
-        """np.ndarray: All evaluated objective function values as if minimized."""
-        return np.array([ind.f_min for ind in self.individuals])
-
-    @property
-    def f_best(self) -> np.ndarray:
-        """np.ndarray: Best objective values."""
-        f_best = np.min(self.f_minimized, axis=0)
-        return np.multiply(self.objectives_minimization_factors, f_best)
-
-    @property
     def f_min(self) -> np.ndarray:
         """np.ndarray: Minimum objective values."""
         return np.min(self.f, axis=0)
@@ -308,16 +297,26 @@ class Population:
         return np.mean(self.f, axis=0)
 
     @property
+    def f_minimized(self) -> np.ndarray:
+        """np.ndarray: All evaluated objective function values as if minimized."""
+        return np.array([ind.f_min for ind in self.individuals])
+
+    @property
+    def f_best(self) -> np.ndarray:
+        """np.ndarray: Best objective values."""
+        f_best = np.min(self.f_minimized, axis=0)
+        return np.multiply(self.objectives_minimization_factors, f_best)
+
+    @property
+    def f_best_indices(self) -> np.ndarray:
+        """np.ndarray: Indices of the best objective values."""
+        return np.argmin(self.f_minimized, axis=0)
+
+    @property
     def g(self) -> np.ndarray:
         """np.ndarray: All evaluated nonlinear constraint function values."""
         if self.dimensions[2] > 0:
             return np.array([ind.g for ind in self.individuals])
-
-    @property
-    def g_best(self) -> np.ndarray:
-        """np.ndarray: Best nonlinear constraint values."""
-        indices = np.argmin(self.cv_nonlincon, axis=0)
-        return [self.g[ind, i] for i, ind in enumerate(indices)]
 
     @property
     def g_min(self) -> np.ndarray:
@@ -336,6 +335,12 @@ class Population:
         """np.ndarray: Average nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.mean(self.g, axis=0)
+
+    @property
+    def g_best(self) -> np.ndarray:
+        """np.ndarray: Best nonlinear constraint values."""
+        indices = np.argmin(self.cv_nonlincon, axis=0)
+        return [self.g[ind, i] for i, ind in enumerate(indices)]
 
     @property
     def cv_nonlincon(self) -> np.ndarray:

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -294,7 +294,8 @@ class Population:
     @property
     def f_avg(self) -> np.ndarray:
         """np.ndarray: Average objective values."""
-        return np.mean(self.f, axis=0)
+        masked_f = np.ma.masked_invalid(self.f)
+        return np.mean(masked_f, axis=0)
 
     @property
     def f_minimized(self) -> np.ndarray:
@@ -334,7 +335,8 @@ class Population:
     def g_avg(self) -> np.ndarray | None:
         """np.ndarray: Average nonlinear constraint values."""
         if self.n_g > 0:
-            return np.mean(self.g, axis=0)
+            masked_g = np.ma.masked_invalid(self.g)
+            return np.mean(masked_g, axis=0)
 
     @property
     def g_best(self) -> np.ndarray | None:
@@ -364,7 +366,8 @@ class Population:
     def cv_nonlincon_avg(self) -> np.ndarray | None:
         """np.ndarray: Average nonlinear constraint violation values."""
         if self.n_g > 0:
-            return np.mean(self.cv_nonlincon, axis=0)
+            masked_cv_nonlincon = np.ma.masked_invalid(self.cv_nonlincon)
+            return np.mean(masked_cv_nonlincon, axis=0)
 
     @property
     def m(self) -> np.ndarray | None:
@@ -388,7 +391,8 @@ class Population:
     def m_avg(self) -> np.ndarray | None:
         """np.ndarray: Average meta scores."""
         if self.n_m > 0:
-            return np.mean(self.m, axis=0)
+            masked_m = np.ma.masked_invalid(self.m)
+            return np.mean(masked_m, axis=0)
 
     @property
     def m_minimized(self) -> np.ndarray | None:

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -299,7 +299,7 @@ class Population:
     @property
     def f_minimized(self) -> np.ndarray:
         """np.ndarray: All evaluated objective function values as if minimized."""
-        return np.array([ind.f_min for ind in self.individuals])
+        return np.array([ind.f_minimized for ind in self.individuals])
 
     @property
     def f_best(self) -> np.ndarray:
@@ -313,95 +313,101 @@ class Population:
         return np.argmin(self.f_minimized, axis=0)
 
     @property
-    def g(self) -> np.ndarray:
+    def g(self) -> np.ndarray | None:
         """np.ndarray: All evaluated nonlinear constraint function values."""
         if self.dimensions[2] > 0:
             return np.array([ind.g for ind in self.individuals])
 
     @property
-    def g_min(self) -> np.ndarray:
+    def g_min(self) -> np.ndarray | None:
         """np.ndarray: Minimum nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.min(self.g, axis=0)
 
     @property
-    def g_max(self) -> np.ndarray:
+    def g_max(self) -> np.ndarray | None:
         """np.ndarray: Maximum nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.max(self.g, axis=0)
 
     @property
-    def g_avg(self) -> np.ndarray:
+    def g_avg(self) -> np.ndarray | None:
         """np.ndarray: Average nonlinear constraint values."""
         if self.dimensions[2] > 0:
             return np.mean(self.g, axis=0)
 
     @property
-    def g_best(self) -> np.ndarray:
+    def g_best(self) -> np.ndarray | None:
         """np.ndarray: Best nonlinear constraint values."""
         indices = np.argmin(self.cv_nonlincon, axis=0)
         return [self.g[ind, i] for i, ind in enumerate(indices)]
 
     @property
-    def cv_nonlincon(self) -> np.ndarray:
+    def cv_nonlincon(self) -> np.ndarray | None:
         """np.ndarray: All evaluated nonlinear constraint violation values."""
         if self.dimensions[2] > 0:
             return np.array([ind.cv_nonlincon for ind in self.individuals])
 
     @property
-    def cv_nonlincon_min(self) -> np.ndarray:
+    def cv_nonlincon_min(self) -> np.ndarray | None:
         """np.ndarray: Minimum nonlinear constraint violation values."""
         if self.dimensions[2] > 0:
             return np.min(self.cv_nonlincon, axis=0)
 
     @property
-    def cv_nonlincon_max(self) -> np.ndarray:
+    def cv_nonlincon_max(self) -> np.ndarray | None:
         """np.ndarray: Maximum nonlinearconstraint violation values."""
         if self.dimensions[2] > 0:
             return np.max(self.cv_nonlincon, axis=0)
 
     @property
-    def cv_nonlincon_avg(self) -> np.ndarray:
+    def cv_nonlincon_avg(self) -> np.ndarray | None:
         """np.ndarray: Average nonlinear constraint violation values."""
         if self.dimensions[2] > 0:
             return np.mean(self.cv_nonlincon, axis=0)
 
     @property
-    def m(self) -> np.ndarray:
+    def m(self) -> np.ndarray | None:
         """np.ndarray: All evaluated meta scores."""
         if self.dimensions[3] > 0:
             return np.array([ind.m for ind in self.individuals])
 
     @property
-    def m_minimized(self) -> np.ndarray:
-        """np.ndarray: All evaluated meta scores, transformed to be minimized."""
+    def m_min(self) -> np.ndarray | None:
+        """np.ndarray: Minimum meta scores."""
         if self.dimensions[3] > 0:
-            return np.array([ind.m_min for ind in self.individuals])
+            return np.min(self.m, axis=0)
 
     @property
-    def m_best(self) -> np.ndarray:
+    def m_max(self) -> np.ndarray | None:
+        """np.ndarray: Maximum meta scores."""
+        if self.dimensions[3] > 0:
+            return np.max(self.m, axis=0)
+
+    @property
+    def m_avg(self) -> np.ndarray | None:
+        """np.ndarray: Average meta scores."""
+        if self.dimensions[3] > 0:
+            return np.mean(self.m, axis=0)
+
+    @property
+    def m_minimized(self) -> np.ndarray | None:
+        """np.ndarray: All evaluated meta scores, transformed to be minimized."""
+        if self.dimensions[3] > 0:
+            return np.array([ind.m_minimized for ind in self.individuals])
+
+    @property
+    def m_best(self) -> np.ndarray | None:
         """np.ndarray: Best meta scores."""
         if self.dimensions[3] > 0:
             m_best = np.min(self.m_minimized, axis=0)
             return np.multiply(self.meta_scores_minimization_factors, m_best)
 
     @property
-    def m_min(self) -> np.ndarray:
-        """np.ndarray: Minimum meta scores."""
+    def m_best_indices(self) -> np.ndarray | None:
+        """np.ndarray: Indices of the best meta scores."""
         if self.dimensions[3] > 0:
-            return np.min(self.m, axis=0)
-
-    @property
-    def m_max(self) -> np.ndarray:
-        """np.ndarray: Maximum meta scores."""
-        if self.dimensions[3] > 0:
-            return np.max(self.m, axis=0)
-
-    @property
-    def m_avg(self) -> np.ndarray:
-        """np.ndarray: Average meta scores."""
-        if self.dimensions[3] > 0:
-            return np.mean(self.m, axis=0)
+            return np.argmin(self.m_minimized, axis=0)
 
     @property
     def is_feasilbe(self) -> bool:

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -277,6 +277,11 @@ class OptimizationResults(Structure):
         return self.meta_front.f
 
     @property
+    def f_best(self) -> np.ndarray:
+        """np.ndarray: Best objective function values of optimal points."""
+        return self.meta_front.f_best
+
+    @property
     def g(self) -> np.ndarray:
         """np.ndarray: Nonlinear constraint function values of optimal points."""
         return self.meta_front.g

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -315,27 +315,27 @@ class OptimizationResults(Structure):
     @property
     def f_best_history(self) -> np.ndarray:
         """np.ndarray: Best objective values per generation."""
-        return np.array([pop.f_best for pop in self.meta_fronts])
+        return np.array([pop.f_best for pop in self.populations])
 
     @property
     def f_min_history(self) -> np.ndarray:
         """np.ndarray: Minimum objective values per generation."""
-        return np.array([pop.f_min for pop in self.meta_fronts])
+        return np.array([pop.f_min for pop in self.populations])
 
     @property
     def f_max_history(self) -> np.ndarray:
         """np.ndarray: Maximum objective values per generation."""
-        return np.array([pop.f_max for pop in self.meta_fronts])
+        return np.array([pop.f_max for pop in self.populations])
 
     @property
     def f_avg_history(self) -> np.ndarray:
         """np.ndarray: Average objective values per generation."""
-        return np.array([pop.f_avg for pop in self.meta_fronts])
+        return np.array([pop.f_avg for pop in self.populations])
 
     @property
     def g_best_history(self) -> np.ndarray:
         """np.ndarray: Best nonlinear constraint per generation."""
-        return np.array([pop.g_best for pop in self.meta_fronts])
+        return np.array([pop.g_best for pop in self.populations])
 
     @property
     def g_min_history(self) -> np.ndarray:
@@ -343,7 +343,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.g_min for pop in self.meta_fronts])
+            return np.array([pop.g_min for pop in self.populations])
 
     @property
     def g_max_history(self) -> np.ndarray:
@@ -351,7 +351,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.g_max for pop in self.meta_fronts])
+            return np.array([pop.g_max for pop in self.populations])
 
     @property
     def g_avg_history(self) -> np.ndarray:
@@ -359,7 +359,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.g_avg for pop in self.meta_fronts])
+            return np.array([pop.g_avg for pop in self.populations])
 
     @property
     def cv_nonlincon_min_history(self) -> np.ndarray:
@@ -367,7 +367,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.cv_nonlincon_min for pop in self.meta_fronts])
+            return np.array([pop.cv_nonlincon_min for pop in self.populations])
 
     @property
     def cv_nonlincon_max_history(self) -> np.ndarray:
@@ -375,7 +375,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.cv_nonlincon_max for pop in self.meta_fronts])
+            return np.array([pop.cv_nonlincon_max for pop in self.populations])
 
     @property
     def cv_nonlincon_avg_history(self) -> np.ndarray:
@@ -383,12 +383,12 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_nonlinear_constraints == 0:
             return None
         else:
-            return np.array([pop.cv_nonlincon_avg for pop in self.meta_fronts])
+            return np.array([pop.cv_nonlincon_avg for pop in self.populations])
 
     @property
     def m_best_history(self) -> np.ndarray:
         """np.ndarray: Best meta scores per generation."""
-        return np.array([pop.m_best for pop in self.meta_fronts])
+        return np.array([pop.m_best for pop in self.populations])
 
     @property
     def m_min_history(self) -> np.ndarray:
@@ -396,7 +396,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
-            return np.array([pop.m_min for pop in self.meta_fronts])
+            return np.array([pop.m_min for pop in self.populations])
 
     @property
     def m_max_history(self) -> np.ndarray:
@@ -404,7 +404,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
-            return np.array([pop.m_max for pop in self.meta_fronts])
+            return np.array([pop.m_max for pop in self.populations])
 
     @property
     def m_avg_history(self) -> np.ndarray:
@@ -412,7 +412,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_meta_scores == 0:
             return None
         else:
-            return np.array([pop.m_avg for pop in self.meta_fronts])
+            return np.array([pop.m_avg for pop in self.populations])
 
     def plot_figures(self, show: bool = True) -> None:
         """

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -282,6 +282,11 @@ class OptimizationResults(Structure):
         return self.meta_front.f_best
 
     @property
+    def f_best_indices(self) -> np.ndarray:
+        """np.ndarray: Indices of the best objective values."""
+        return self.meta_front.f_best_indices
+
+    @property
     def g(self) -> np.ndarray:
         """np.ndarray: Nonlinear constraint function values of optimal points."""
         return self.meta_front.g

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -213,10 +213,10 @@ class OptimizationResults(Structure):
         pareto_front = ParetoFront(similarity_tol=self._similarity_tol)
 
         if pareto_new is not None:
-            pareto_front.update_population(pareto_new)
+            pareto_front.update(pareto_new)
         else:
             if len(self.pareto_fronts) > 0:
-                pareto_front.update_population(self.pareto_front)
+                pareto_front.update(self.pareto_front)
             pareto_front.update_population(self.population_last)
 
         if self._similarity_tol:

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -277,6 +277,11 @@ class OptimizationResults(Structure):
         return self.meta_front.f
 
     @property
+    def f_minimized(self) -> np.ndarray:
+        """np.ndarray: All evaluated objective function values as if minimized."""
+        return self.meta_front.f_minimized
+
+    @property
     def f_best(self) -> np.ndarray:
         """np.ndarray: Best objective function values of optimal points."""
         return self.meta_front.f_best

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -955,6 +955,8 @@ class OptimizationResults(Structure):
             self._meta_fronts = [
                 ParetoFront.from_dict(d) for d in data["meta_fronts"].values()
             ]
+        self.time_elapsed = data.get("time_elapsed")
+        self.cpu_time = data.get("cpu_time")
 
     def setup_csv(self) -> None:
         """Create csv files for optimization results."""

--- a/CADETProcess/performance.py
+++ b/CADETProcess/performance.py
@@ -197,7 +197,7 @@ class RankedPerformance:
     def __init__(
         self,
         performance: Performance,
-        ranking: Optional[float] = 1.0,
+        ranking: str | list[float] | int,
     ) -> None:
         """Initialize RankedPerformance."""
         if not isinstance(performance, Performance):
@@ -213,15 +213,19 @@ class RankedPerformance:
         return self._performance
 
     @property
-    def ranking(self) -> float:
+    def ranking(self) -> list[float]:
         """list[float]: Relative weighting factors for multi component evaluation."""
         return self._ranking
 
     @ranking.setter
-    def ranking(self, ranking: tuple[float | int] | np.ndarray) -> None:
-        if isinstance(ranking, (float, int)):
-            ranking = self.performance.n_comp * [ranking]
-        elif len(ranking) != self.performance.n_comp:
+    def ranking(self, ranking: str | list[float] | int = None) -> None:
+        if ranking == "equal":
+            ranking = self.performance.n_comp * [1.0]
+        if isinstance(ranking, int):
+            index = ranking
+            ranking = self.performance.n_comp * [0.0]
+            ranking[index] = 1
+        if len(ranking) != self.performance.n_comp:
             raise CADETProcessError("Number of components does not match.")
 
         self._ranking = ranking
@@ -264,7 +268,7 @@ class PerformanceIndicator(MetricBase):
     RankedPerformance
     """
 
-    def __init__(self, ranking: Optional[list[float]] = None) -> None:
+    def __init__(self, ranking: Optional[str | list[float] | int] = None) -> None:
         """
         Initialize PerformanceIndicator.
 
@@ -276,12 +280,12 @@ class PerformanceIndicator(MetricBase):
         self.ranking = ranking
 
     @property
-    def ranking(self) -> float:
+    def ranking(self) -> str | list[float] | int | None:
         """list[float]: Relative weighting factors for multi component evaluation."""
         return self._ranking
 
     @ranking.setter
-    def ranking(self, ranking: list[float]) -> None:
+    def ranking(self, ranking: Optional[str | list[float] | int]) -> None:
         self._ranking = ranking
 
     @property

--- a/tests/test_optimization_results.py
+++ b/tests/test_optimization_results.py
@@ -127,7 +127,7 @@ class TestOptimizationResults(unittest.TestCase):
             [
                 [-0.79736546],
                 [-0.94888115],
-                [-0.94888115],
+                [-0.46519315],
             ]
         )
         f_min_history = self.optimization_results.f_min_history

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -84,42 +84,65 @@ class RankedPerformanceTestCase(unittest.TestCase):
             mass_balance_difference,
         )
 
-        self.ranked_performance_equal = RankedPerformance(performance, ranking=1)
+        self.ranked_performance_equal = RankedPerformance(performance, ranking="equal")
+        self.ranked_performance_single = RankedPerformance(performance, ranking=0)
         self.ranked_performance_diff = RankedPerformance(performance, ranking=[0, 1, 2])
 
     def test_attributes(self):
+        # Equal ranking
         np.testing.assert_array_equal(self.ranked_performance_equal.mass, 20)
-        np.testing.assert_array_equal(
-            self.ranked_performance_diff.mass, 26.666666666666668
-        )
         np.testing.assert_array_equal(
             self.ranked_performance_equal.concentration, 0.39999999999999997
         )
-        np.testing.assert_array_equal(
-            self.ranked_performance_diff.concentration, 0.3333333333333333
-        )
         np.testing.assert_array_equal(self.ranked_performance_equal.purity, 0.9)
-        np.testing.assert_array_equal(
-            self.ranked_performance_diff.purity, 0.9166666666666666
-        )
         np.testing.assert_array_equal(
             self.ranked_performance_equal.recovery, 0.8166666666666668
         )
-        np.testing.assert_array_equal(self.ranked_performance_diff.recovery, 0.85)
         np.testing.assert_array_equal(
             self.ranked_performance_equal.productivity, 0.6499999999999999
-        )
-        np.testing.assert_array_equal(
-            self.ranked_performance_diff.productivity, 0.6333333333333333
         )
         np.testing.assert_array_equal(
             self.ranked_performance_equal.eluent_consumption, 1.5666666666666667
         )
         np.testing.assert_array_equal(
-            self.ranked_performance_diff.eluent_consumption, 1.4666666666666668
+            self.ranked_performance_equal.mass_balance_difference, 0.06666666666666668
+        )
+
+        # Single component
+        np.testing.assert_array_equal(self.ranked_performance_single.mass, 10.0)
+        np.testing.assert_array_equal(
+            self.ranked_performance_single.concentration, 0.5
         )
         np.testing.assert_array_equal(
-            self.ranked_performance_equal.mass_balance_difference, 0.06666666666666668
+            self.ranked_performance_single.purity, 0.9
+        )
+        np.testing.assert_array_equal(self.ranked_performance_single.recovery, 0.8)
+        np.testing.assert_array_equal(
+            self.ranked_performance_single.productivity, 0.7
+        )
+        np.testing.assert_array_equal(
+            self.ranked_performance_single.eluent_consumption, 1.5
+        )
+        np.testing.assert_array_equal(
+            self.ranked_performance_single.mass_balance_difference, 0.2
+        )
+
+        # Different rankings
+        np.testing.assert_array_equal(
+            self.ranked_performance_diff.mass, 26.666666666666668
+        )
+        np.testing.assert_array_equal(
+            self.ranked_performance_diff.concentration, 0.3333333333333333
+        )
+        np.testing.assert_array_equal(
+            self.ranked_performance_diff.purity, 0.9166666666666666
+        )
+        np.testing.assert_array_equal(self.ranked_performance_diff.recovery, 0.85)
+        np.testing.assert_array_equal(
+            self.ranked_performance_diff.productivity, 0.6333333333333333
+        )
+        np.testing.assert_array_equal(
+            self.ranked_performance_diff.eluent_consumption, 1.4666666666666668
         )
         np.testing.assert_array_equal(
             self.ranked_performance_diff.mass_balance_difference, -0.03333333333333333


### PR DESCRIPTION
This PR is a collection of some smaller updates. It
- adds properties to optimization results (f_best, f_best_indices, f_minimized)
- creates local copy of purity_required to avoid overwriting global config
- adds an option for considering single component in ranking
- synchronize purity and ranking arrays if entries are zero
- restore time information when restoring optimization results
- add bad metrics to meta scores
- get dependent values before evaluating meta scores
- refactor Pareto front domination methods
- avoid divide by zero error if objectives/scores are zero

---

Note, this also includes a **BREAKING CHANGE:**
Previously, a scalar `ranking` value was applied uniformly to all components, which was not meaningful for values other than 1. Now:
- If `ranking` is `None`, all components are set to 1.
- If `ranking` is an integer, only the component at that index is set to 1 (all others remain 0).

This change simplifies the API and removes ambiguous behavior.