### PR TITLE
Add k_eq to selected binding_models

### DIFF
--- a/CADETProcess/processModel/binding.py
+++ b/CADETProcess/processModel/binding.py
@@ -197,6 +197,16 @@ class Linear(BindingBaseClass):
         "desorption_rate",
     ]
 
+    @property
+    def k_eq(self) -> list[float]:
+        """list[float]: Equilibrium constant."""
+        return np.divide(self.adsorption_rate, self.desorption_rate).tolist()
+
+    @property
+    def henry_coefficient(self) -> list[float]:
+        """list[float]: Henry coefficient."""
+        return self.k_eq
+
 
 class Langmuir(BindingBaseClass):
     """
@@ -221,6 +231,16 @@ class Langmuir(BindingBaseClass):
         "desorption_rate",
         "capacity",
     ]
+
+    @property
+    def k_eq(self) -> list[float]:
+        """list[float]: Equilibrium constant."""
+        return np.divide(self.adsorption_rate, self.desorption_rate).tolist()
+
+    @property
+    def henry_coefficient(self) -> list[float]:
+        """list[float]: Henry coefficient."""
+        return np.multiply(self.k_eq, self.capacity).tolist()
 
 
 class LangmuirLDF(BindingBaseClass):


### PR DESCRIPTION
Note, this is currently just a property without setter.

We could also consider making this a default property for all binding models but we would first need to check whether all binding models really have a meaningful equilibrium constant.

Moreover, we could consider adding more properties such as Henry coefficients.