### PR TITLE
Catch import errors in MacOS arm CI runners

### DIFF
--- a/CADETProcess/sysinfo.py
+++ b/CADETProcess/sysinfo.py
@@ -1,20 +1,37 @@
 import platform
-
 import psutil
 
 uname = platform.uname()
-cpu_freq = psutil.cpu_freq()
-memory = psutil.virtual_memory()
-memory_total = psutil._common.bytes2human(memory.total)
 
 system_information = {
     "system": uname.system,
     "release": uname.release,
     "machine": uname.machine,
     "processor": uname.processor,
-    "n_cores": psutil.cpu_count(logical=True),
-    "n_cores_physical": psutil.cpu_count(logical=False),
-    "max_frequency": cpu_freq.max,
-    "min_frequency": cpu_freq.min,
-    "memory_total": memory_total,
+    "n_cores": None,
+    "n_cores_physical": None,
+    "max_frequency": None,
+    "min_frequency": None,
+    "memory_total": None,
 }
+
+if psutil is not None:
+    try:
+        system_information["n_cores"] = psutil.cpu_count(logical=True)
+        system_information["n_cores_physical"] = psutil.cpu_count(logical=False)
+    except Exception:
+        pass
+
+    try:
+        cpu_freq = psutil.cpu_freq()
+        if cpu_freq is not None:
+            system_information["max_frequency"] = cpu_freq.max
+            system_information["min_frequency"] = cpu_freq.min
+    except Exception:
+        pass
+
+    try:
+        memory = psutil.virtual_memory()
+        system_information["memory_total"] = f"{memory.total / 1024**3:.1f} GiB"
+    except Exception:
+        pass

--- a/CADETProcess/sysinfo.py
+++ b/CADETProcess/sysinfo.py
@@ -1,4 +1,5 @@
 import platform
+
 import psutil
 
 uname = platform.uname()

--- a/tests/test_fractions.py
+++ b/tests/test_fractions.py
@@ -1,8 +1,8 @@
 import unittest
 
+import numpy as np
 from CADETProcess import CADETProcessError
 from CADETProcess.fractionation import Fraction, FractionPool
-import numpy as np
 
 
 class Test_Fractions(unittest.TestCase):


### PR DESCRIPTION
This PR fixes and issue that arose only in MacOS CI runners with arm architecture, where not all ´psutil´ functions worked as expected and caused the whole pipeline to fail.

With this fix and 
- https://github.com/fau-advanced-separations/CADET-Process/pull/336

MacOS runner with Arm architecture can now successfully run CADET-Process tests again:

- https://github.com/cadet/CADET-Metapackage/actions/runs/21440172726 (Metapackage)
- https://github.com/fau-advanced-separations/CADET-Process/actions/runs/21440002446/job/61740302077?pr=338 (Process)

Related:
- #338 