### PR TITLE
Change MacOS runner in CI to latest

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -23,7 +23,7 @@ jobs:
         include:
           - os: windows-latest
             python-version: "3.12"
-          - os: macos-13
+          - os: macos-latest
             python-version: "3.12"
 
     env:

--- a/tests/test_difference.py
+++ b/tests/test_difference.py
@@ -285,7 +285,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak
         difference = Shape(
@@ -296,7 +296,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 10]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak, normalize_metrics
         difference = Shape(
@@ -307,7 +307,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 4.6211716e-01]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak, include derivative
         difference = Shape(
@@ -318,7 +318,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 10, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak, include derivative, normalize metrics
         difference = Shape(
@@ -329,7 +329,7 @@ class TestShape(unittest.TestCase):
         )
         metrics_expected = [0, 4.6211716e-01, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Multi-component, currently not implemented
         with self.assertRaises(CADETProcessError):
@@ -372,7 +372,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak
         difference = ShapeFront(
@@ -383,7 +383,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 10]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak, normalize_metrics
         difference = ShapeFront(
@@ -394,7 +394,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 4.6211716e-01]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak, include derivative
         difference = ShapeFront(
@@ -405,7 +405,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0, 10, 0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Compare with other Gauss Peak, include derivative, normalize metrics
         difference = ShapeFront(
@@ -416,7 +416,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0.0, 4.6211716e-01, 0.0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         # Use maximum slope
         difference = ShapeFront(
@@ -428,7 +428,7 @@ class TestShapeFront(unittest.TestCase):
         )
         metrics_expected = [0.0, 0.0]
         metrics = difference.evaluate(self.reference)
-        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=6)
+        np.testing.assert_almost_equal(metrics, metrics_expected, decimal=5)
 
         difference = ShapeFront(
             self.reference_switched,


### PR DESCRIPTION
This PR aims to get the pipeline up back running and changing the runner to latest.

Depends on:
- #337 
- #336 

Additionally, in `test_difference.py` I adjusted the floating point tolerance, since MacOS seems to have a different accuracy there and was failing with values around 2e-6.