### PR TITLE
Add method to compute trust-region radius

### DIFF
--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -11,6 +11,7 @@ from CADETProcess.optimization import (
     OptimizationProblem,
     OptimizationResults,
     OptimizerBase,
+    compute_initial_radius,
 )
 from CADETProcess.performance import Mass, Performance, Purity
 from CADETProcess.simulationResults import SimulationResults
@@ -284,6 +285,7 @@ class FractionationOptimizer:
         bad_metrics: float | list[float] = 0,
         minimize: bool = True,
         allow_empty_fractions: bool = True,
+        scale_trust_radius: bool = False,
         ignore_failed: bool = False,
         return_optimization_results: bool = False,
         save_results: bool = False,
@@ -321,6 +323,9 @@ class FractionationOptimizer:
             The default it True.
         allow_empty_fractions: bool, optional
             If True, allow empty fractions. The default is True.
+        scale_trust_radius: bool, optional
+            If True, scale initial trust radius depending on linear constraints
+            and initial values. The default is False.
         ignore_failed : bool, optional
             Ignore failed optimization and use initial values.
             The default is False.
@@ -400,6 +405,18 @@ class FractionationOptimizer:
             minimize=minimize,
             bad_metrics=bad_metrics,
         )
+
+        if scale_trust_radius:
+            x0_transformed = opt.transform(x0)
+            tr_radius = compute_initial_radius(
+                x0_transformed,
+                opt.A_transformed,
+                opt.n_linear_constraints * [-np.inf],
+                opt.b_transformed,
+                min_radius=0.01,
+            )
+            if isinstance(self.optimizer, COBYLA):
+                self.optimizer.rhobeg = tr_radius
 
         # Lock to enable caching
         simulation_results.process.lock = True

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -26,7 +26,10 @@ from CADETProcess.optimization import (
     Population,
 )
 
-__all__ = ["OptimizerBase"]
+__all__ = [
+    "OptimizerBase",
+    "compute_initial_radius"
+]
 
 
 class OptimizerBase(Structure):
@@ -750,3 +753,65 @@ class OptimizerBase(Structure):
     def __str__(self) -> str:
         """str: String representation."""
         return self.__class__.__name__
+
+
+def compute_initial_radius(
+    x0: npt.ArrayLike,
+    A: npt.ArrayLike,
+    lb_lincon: npt.ArrayLike,
+    ub_lincon: npt.ArrayLike,
+    min_radius: float = 1.0,
+    safety: float = 0.5,
+    slack_cap: float = 1.0,
+) -> float:
+    """
+    Compute initial trust-region radius with linear constraints.
+
+    Parameters
+    ----------
+    x0 : array_like
+        Initial point (must be strictly feasible).
+    A : array_like
+        Linear constraint matrix with shape (m, n).
+    lb_lincon, ub_lincon : array_like
+        Lower and upper bounds for A @ x.
+    min_radius : float, optional
+        Minimum value for trust-region radius.
+    safety : float, optional
+        Interior safety factor (< 1).
+    slack_cap : float, optional
+        Upper cap on slack influence.
+
+    Returns
+    -------
+    float
+        Initial trust-region radius.
+    """
+    tr_radius = float(min_radius)
+
+    A = np.asarray(A)
+    if A.size == 0:
+        return tr_radius
+
+    A_abs_max = np.max(np.abs(A))
+    if A_abs_max == 0.0:
+        # Constraints are degenerate; ignore them
+        return tr_radius
+
+    x0 = np.asarray(x0)
+    lb_lincon = np.asarray(lb_lincon)
+    ub_lincon = np.asarray(ub_lincon)
+
+    Ax0 = A @ x0
+
+    # Enforce strict feasibility
+    if np.any(Ax0 <= lb_lincon) or np.any(Ax0 >= ub_lincon):
+        raise ValueError("x0 must be strictly feasible for linear constraints")
+
+    slack = np.minimum(Ax0 - lb_lincon, ub_lincon - Ax0)
+
+    # Convert constraint-space slack into x-space radius
+    scale = 1.0 / A_abs_max
+    tr_scaled = safety * min(np.min(slack), slack_cap) * scale
+
+    return min(tr_radius, tr_scaled)


### PR DESCRIPTION
To avoid issues with `COBYLA` sometimes violating linear constraints, this PR introduces a method to automatically scale the initial trust region radius (`rhobeg`) depending on the initial values and any given linear constraints. While this issue was reported to [prima](https://github.com/libprima/prima/issues/269) (who maintain scipy's `COBYLA` implementation), but it seems to be an inherent property of the algorithm to *not* guarantee that all evaluations are with feasible individuals. More checks could be implemented, but for now, this seems to solve some of the urgent issues.

Also note, that this is not done by default, neither for the `COBYLA` optimizer, nor for the fractionation optimization (but a flag exists here which we might set to `True` eventually).
