### PR TITLE
Update Python versions in CI

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ["3.10", "3.11", "3.12"]
+        python-version: ["3.12", "3.13", "3.14"]
         include:
           - os: windows-latest
-            python-version: "3.12"
+            python-version: "3.14"
           - os: macos-latest
-            python-version: "3.12"
+            python-version: "3.14"
 
     env:
       CONDA_FILE: environment.yml

--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -17,6 +17,7 @@ import hopsy
 import numpy as np
 import numpy.typing as npt
 from addict import Dict
+from packaging.version import Version
 
 from CADETProcess import CADETProcessError, log, settings
 from CADETProcess.dataStructure import (
@@ -3122,7 +3123,9 @@ class OptimizationProblem(Structure):
             include_dependent_variables=False, simplify=False, use_custom_model=True
         )
 
-        chebyshev = hopsy.compute_chebyshev_center(problem, original_space=True)[:, 0]
+        chebyshev = hopsy.compute_chebyshev_center(problem, original_space=True)
+        if Version(hopsy.__version__.strip('"')) < Version("1.7.0b"):
+            chebyshev = chebyshev[:, 0]
 
         if include_dependent_variables:
             chebyshev = self.get_dependent_values(chebyshev)

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,7 @@ name: cadet-process
 channels:
   - conda-forge
 dependencies:
-  - python>=3.10.*
-  - cadet>=5.0.3
   - libsqlite<3.49
+  - python>=3.12.*
+  - cadet>=5.1.0
   - pip

--- a/environment.yml
+++ b/environment.yml
@@ -2,7 +2,6 @@ name: cadet-process
 channels:
   - conda-forge
 dependencies:
-  - libsqlite<3.49
   - python>=3.12.*
   - cadet>=5.1.0
   - pip

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy>=1.21",
     "matplotlib>=3.4",
     "numba>=0.55.1",
+    "packaging>=26.0",
     "pathos>=0.2.8",
     "psutil>=5.9.8",
     "pymoo>=0.6",


### PR DESCRIPTION
This PR upgrades Python versions in our CI test runners. Note, this is currently blocked by [hopsy](https://jugit.fz-juelich.de/IBG-1/ModSim/hopsy/-/issues/188) not providing binaries for the latest MacOS.

Note, this is fixed and support for the latest hopsy version was added in #358. Now we just need to wait until a new hopsy version is actually released, which should happen any day now.
For reference: https://jugit.fz-juelich.de/IBG-1/ModSim/hopsy/-/issues/190