### PR TITLE
Force headless matplotlib backend in CI to avoid Tkinter errors

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -67,6 +67,8 @@ jobs:
           conda run pip install -e ./[all] --group testing
 
       - name: Test
+        env:
+          MPLBACKEND: Agg
         run: |
           pytest tests -m "not slow" --durations=0
 


### PR DESCRIPTION
This PR configures the CI test job to run matplotlib in *headless* mode by setting `MPLBACKEND=Agg`.

In headless mode, plots are rendered off-screen without opening GUI windows. This avoids importing Tkinter and initializing the Tcl/Tk runtime, which is not fully available on Windows CI runners. As a result, tests that call plotting utilities (e.g. `plot_events()`) no longer fail due to missing GUI dependencies.

The change affects only the CI environment. Local test behavior and plotting remain unchanged.
