### PR TITLE
Fix: remove extra returns from docstring in get_callback

### DIFF
--- a/CADETProcess/optimization/scipyAdapter.py
+++ b/CADETProcess/optimization/scipyAdapter.py
@@ -314,11 +314,6 @@ class SciPyInterface(OptimizerBase):
         However, there is ambiguity in what that point actually is (see also:
         https://github.com/scipy/scipy/issues/21061).
 
-        Returns
-        -------
-        Callable
-            The callback function.
-
         """
         if isinstance(self, (COBYLA, SLSQP)):
             def callback(x: npt.ArrayLike, state: dict = None) -> bool:


### PR DESCRIPTION
This PR removes the extra/doubled "Returns" from the docstring of the get_callback method, which locally caused errors in the documentation build.

I am unsure why this didn't error in the RTD build.