### PR TITLE
Check mass balance when evaluating stationarity

### DIFF
--- a/CADETProcess/comparison/comparator.py
+++ b/CADETProcess/comparison/comparator.py
@@ -283,7 +283,7 @@ class Comparator(Structure):
         if ax is None:
             fig, axs = plotting.setup_figure(
                 **setup_figure_kwargs,
-                ncols=self.n_difference_metrics,
+                nrows=self.n_difference_metrics,
                 squeeze=False,
             )
             axs = axs.reshape(-1)
@@ -292,12 +292,16 @@ class Comparator(Structure):
             fig = axs[0].get_figure()
 
         for ax, metric in zip(axs, self.metrics):
+            ax.set_title(metric.reference.name)
+
             solution = self.extract_solution(simulation_results, metric)
             solution_sliced = metric.slice_and_transform(solution)
 
             solution_sliced.plot(
                 ax=ax,
                 x_axis_in_minutes=x_axis_in_minutes,
+                show=False,
+                tight_layout=False,
             )
 
             ref_time = metric.reference.time
@@ -308,8 +312,6 @@ class Comparator(Structure):
                 ref_time,
                 metric.reference.solution,
                 linestyle="--",
-                color="k",
-                label="reference",
             )
             ax.legend(loc=1)
 

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -114,12 +114,14 @@ class SimulatorBase(Structure):
             cycle * process.cycle_time,
             self.time_resolution,
         )
-        section_times = self.get_section_times(process)
+
+        # Insert section times
+        section_times = process.section_times
         solution_times = np.append(solution_times, section_times)
-        solution_times = np.round(solution_times, self.sig_fig)
         solution_times = np.sort(solution_times)
         solution_times = np.unique(solution_times)
 
+        # Find indices of non-section times that are too close
         diff = np.where(np.diff(solution_times) < self.resolution_cutoff)[0]
         indices = []
         for d in diff:
@@ -158,34 +160,8 @@ class SimulatorBase(Structure):
 
         for i in range(1, self.n_cycles):
             solution_times = np.append(solution_times, (i) * time[-1] + time[1:])
-        solution_times = np.round(solution_times, self.sig_fig)
 
         return solution_times.tolist()
-
-    def get_section_times(self, process: Process) -> list[float]:
-        """
-        Get the section times for a single cycle of a process.
-
-        Parameters
-        ----------
-        process : Process
-            The process to simulate.
-
-        Returns
-        -------
-        list[float]
-            Section times for a single cycle of a process.
-
-        See Also
-        --------
-        get_solution_time
-        get_solution_time_complete
-        CADETProcess.processModel.Process.section_times
-        """
-        section_times = np.array(process.section_times)
-        section_times = np.round(section_times, self.sig_fig)
-
-        return section_times.tolist()
 
     def get_section_times_complete(self, process: Process) -> list[float]:
         """
@@ -208,7 +184,7 @@ class SimulatorBase(Structure):
         get_solution_time_complete
         CADETProcess.processModel.Process.section_times
         """
-        sections = np.array(self.get_section_times(process))
+        sections = np.array(process.section_times)
         cycle_time = sections[-1]
 
         section_times_complete = []
@@ -216,11 +192,9 @@ class SimulatorBase(Structure):
             section_cycle = cycle * cycle_time + sections[0:-1]
             section_times_complete += section_cycle.tolist()
 
-        section_times_complete.append(self.n_cycles * sections[-1])
+        section_times_complete.append(float(self.n_cycles * sections[-1]))
 
-        section_times_complete = np.round(section_times_complete, self.sig_fig)
-
-        return section_times_complete.tolist()
+        return section_times_complete
 
     def simulate(
         self,

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -8,7 +8,11 @@ from CADETProcess.dataStructure import Bool, Structure, UnsignedFloat, UnsignedI
 from CADETProcess.log import get_logger, log_exceptions, log_results, log_time
 from CADETProcess.processModel import Process
 from CADETProcess.simulationResults import SimulationResults
-from CADETProcess.stationarity import NRMSE, RelativeArea, StationarityEvaluator
+from CADETProcess.stationarity import (
+    NRMSE,
+    RelativeArea,
+    StationarityEvaluator,
+)
 
 __all__ = ["SimulatorBase"]
 

--- a/CADETProcess/simulator/simulator.py
+++ b/CADETProcess/simulator/simulator.py
@@ -132,7 +132,7 @@ class SimulatorBase(Structure):
 
         return solution_times
 
-    def get_solution_time_complete(self, process: Process) -> np.ndarray:
+    def get_solution_time_complete(self, process: Process) -> list[float]:
         """
         Get the time vector for multiple cycles of a process.
 
@@ -143,7 +143,7 @@ class SimulatorBase(Structure):
 
         Returns
         -------
-        np.ndarray
+        list[float]
             Time vector for multiple cycles of a process.
 
         See Also
@@ -162,7 +162,7 @@ class SimulatorBase(Structure):
 
         return solution_times.tolist()
 
-    def get_section_times(self, process: Process) -> list:
+    def get_section_times(self, process: Process) -> list[float]:
         """
         Get the section times for a single cycle of a process.
 
@@ -173,12 +173,12 @@ class SimulatorBase(Structure):
 
         Returns
         -------
-        list
+        list[float]
             Section times for a single cycle of a process.
 
         See Also
         --------
-        get_section_times_complete
+        get_solution_time
         get_solution_time_complete
         CADETProcess.processModel.Process.section_times
         """
@@ -187,7 +187,7 @@ class SimulatorBase(Structure):
 
         return section_times.tolist()
 
-    def get_section_times_complete(self, process: Process) -> list:
+    def get_section_times_complete(self, process: Process) -> list[float]:
         """
         Get the section times for multiple cycles of a process.
 

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -27,7 +27,7 @@ from CADETProcess.dataStructure import Structure, UnsignedFloat
 from CADETProcess.processModel import Inlet
 from CADETProcess.simulationResults import SimulationResults
 
-__all__ = ["RelativeArea", "NRMSE", "StationarityEvaluator"]
+__all__ = ["MassBalance", "NRMSE", "RelativeArea", "StationarityEvaluator"]
 
 
 class CriterionBase(Structure):
@@ -37,8 +37,8 @@ class CriterionBase(Structure):
         return self.__class__.__name__
 
 
-class RelativeArea(CriterionBase):
-    """Class to evaluate difference in relative area as stationarity critereon."""
+class MassBalance(CriterionBase):
+    """Class to evaluate mass balance as stationarity critereon."""
 
     pass
 
@@ -49,10 +49,16 @@ class NRMSE(CriterionBase):
     pass
 
 
+class RelativeArea(CriterionBase):
+    """Class to evaluate difference in relative area as stationarity critereon."""
+
+    pass
+
+
 class StationarityEvaluator(Comparator):
     """Class for checking two succeding chromatograms for stationarity."""
 
-    valid_criteria = ["RelativeArea", "NRMSE"]
+    valid_criteria = ["MassBalance", "NRMSE", "RelativeArea"]
 
     def __init__(
         self,
@@ -75,15 +81,12 @@ class StationarityEvaluator(Comparator):
         kwargs : dict
             Additional keyword arguments.
         """
-        # TODO: Check why cirteria are not stored.
         super().__init__(*args, **kwargs)
-
         self.logger = log.get_logger("StationarityEvaluator", level=log_level)
-
         self._criteria = []
 
     @property
-    def criteria(self) -> list:
+    def criteria(self) -> list[CriterionBase]:
         """list: List of criteria."""
         return self._criteria
 
@@ -125,20 +128,56 @@ class StationarityEvaluator(Comparator):
         if not isinstance(simulation_results, SimulationResults):
             raise TypeError("Expcected SimulationResults")
 
+        process = simulation_results.process
+        flow_sheet = process.flow_sheet
+
         stationarity = True
+
+        # System Mass Balance
+        for c in self.criteria:
+            if not isinstance(c, MassBalance):
+                continue
+
+            m_feed = process.m_feed
+            results_outlets = [
+                simulation_results.solution_cycles[unit.name].outlet[-1]
+                for unit in flow_sheet.outlets
+            ]
+            m_out = np.sum([
+                outlet_solution.create_fraction().mass
+                for outlet_solution in results_outlets
+            ], axis=0)
+            with np.errstate(divide="ignore", invalid="ignore"):
+                diff = abs(m_feed - m_out) / m_feed
+                diff = np.where(np.isfinite(diff), diff, 0.0)
+
+            if not np.all(diff <= c.threshold):
+                s = False
+                stationarity = s
+            else:
+                s = True
+
+            criteria[str(c)]["threshold"] = c.threshold
+            criteria[str(c)]["stationarity"] = s
+
+        # Per unit comparison
         for unit, solution in simulation_results.solution_cycles.items():
-            if isinstance(simulation_results.process.flow_sheet[unit], Inlet):
+            if isinstance(flow_sheet[unit], Inlet):
                 continue
             solution_previous = solution.outlet[-2]
             solution_this = solution.outlet[-1]
             self.add_reference(solution_previous, update=True, smooth=False)
 
             for c in self.criteria:
-                metric = self.add_difference_metric(
-                    str(c), unit, f"{unit}.outlet", smooth=False
-                )
-                criteria[unit][str(c)]["threshold"] = c.threshold
-                diff = metric.evaluate(solution_this)
+                if isinstance(c, MassBalance):
+                    continue
+                else:
+                    metric = self.add_difference_metric(
+                        str(c), unit, f"{unit}.outlet", smooth=False
+                    )
+                    criteria[unit][str(c)]["threshold"] = c.threshold
+                    diff = metric.evaluate(solution_this)
+
                 criteria[unit][str(c)]["metric"] = diff
                 if not np.all(diff <= c.threshold):
                     s = False

--- a/CADETProcess/stationarity.py
+++ b/CADETProcess/stationarity.py
@@ -26,6 +26,7 @@ from CADETProcess.comparison import Comparator
 from CADETProcess.dataStructure import Structure, UnsignedFloat
 from CADETProcess.processModel import Inlet
 from CADETProcess.simulationResults import SimulationResults
+from CADETProcess.solution import SolutionIO
 
 __all__ = ["MassBalance", "NRMSE", "RelativeArea", "StationarityEvaluator"]
 
@@ -161,30 +162,55 @@ class StationarityEvaluator(Comparator):
             criteria[str(c)]["stationarity"] = s
 
         # Per unit comparison
+        def _assert_unit_io(
+            solution_previous: SolutionIO,
+            solution_this: SolutionIO,
+            unit: str,
+            side: str,
+            criteria: dict,
+            c: object,
+        ) -> None:
+            """Assert stationarity for a given inlet/outlet of a unit."""
+            solution_previous.name = f"{unit}.{side}"
+            self.add_reference(
+                solution_previous,
+                update=True,
+                smooth=False,
+            )
+            metric = self.add_difference_metric(
+                str(c),
+                f"{unit}.{side}",
+                f"{unit}.{side}",
+                smooth=False,
+            )
+            diff = metric.evaluate(solution_this)
+            criteria[str(c)][unit][side]["metric"] = diff
+            stationarity = np.all(diff <= c.threshold)
+            criteria[str(c)][unit][side]["stationarity"] = stationarity
+
         for unit, solution in simulation_results.solution_cycles.items():
             if isinstance(flow_sheet[unit], Inlet):
                 continue
-            solution_previous = solution.outlet[-2]
-            solution_this = solution.outlet[-1]
-            self.add_reference(solution_previous, update=True, smooth=False)
 
             for c in self.criteria:
                 if isinstance(c, MassBalance):
                     continue
-                else:
-                    metric = self.add_difference_metric(
-                        str(c), unit, f"{unit}.outlet", smooth=False
-                    )
-                    criteria[unit][str(c)]["threshold"] = c.threshold
-                    diff = metric.evaluate(solution_this)
-
-                criteria[unit][str(c)]["metric"] = diff
-                if not np.all(diff <= c.threshold):
-                    s = False
-                    stationarity = s
-                else:
-                    s = True
-                criteria[unit][str(c)]["stationarity"] = s
+                _assert_unit_io(
+                    solution.inlet[-2],
+                    solution.inlet[-1],
+                    unit,
+                    "inlet",
+                    criteria,
+                    c,
+                )
+                _assert_unit_io(
+                    solution.outlet[-2],
+                    solution.outlet[-1],
+                    unit,
+                    "outlet",
+                    criteria,
+                    c,
+                )
 
         self.logger.debug(f"Stationrity criteria: {criteria}")
 


### PR DESCRIPTION
This PR adds a check of the system mass balance when evaluating stationarity by comparing the integral sum of all system outlets with the feed mass.

Note, this might be an issue when reactions are involved since they do not conserve the mass of a component, but we would have to account for the conserved moiety (which is too much). Maybe we should consider making this optional, but since this is just the default Comparator used for the evaluation of stationarity, users can still write their own, so I don't think it's too bad for now.

In addition to the mass balance, I also had to rewrite some parts of the user solution times/section times. Previously, this was done to prevent Sundials struggling with very small time steps. However, this can also lead to other issues, e.g. with post-processing when section times do not align with the actual values of optimization variables. 
Note, this is still not stable and needs more testing.