### PR TITLE
Fix test_initial_value in Test Optimization_Problem

### DIFF
--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -1,3 +1,4 @@
+import random
 import shutil
 import time
 import unittest
@@ -21,6 +22,8 @@ from tests.optimization_problem_fixtures import (
     LinearConstraintsSooTestProblem2,
     LinearEqualityConstraintsSooTestProblem,
 )
+
+seed = random.randint(1, 255)
 
 
 class EvaluationObject(Structure):
@@ -829,7 +832,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         x0_seed_1 = self.optimization_problem.create_initial_values(1, seed=1)
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
-        x0_seed_1_random = self.optimization_problem.create_initial_values(1)
+        x0_seed_1_random = self.optimization_problem.create_initial_values(1, seed)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_1_random, x0_seed_1_expected)
@@ -852,7 +855,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         x0_seed_10 = self.optimization_problem.create_initial_values(10, seed=1)
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
-        x0_seed_10_random = self.optimization_problem.create_initial_values(10)
+        x0_seed_10_random = self.optimization_problem.create_initial_values(10, seed)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_10_random, x0_seed_10_expected)
@@ -971,7 +974,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, include_dependent_variables=False
+            10, seed=seed, include_dependent_variables=False
         )
 
         with self.assertRaises(AssertionError):
@@ -1029,7 +1032,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
         x0_seed_10_random = self.optimization_problem.create_initial_values(
-            10, include_dependent_variables=True
+            10, seed=seed, include_dependent_variables=True
         )
 
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
When you feel like the CI randomly fails, and the CI actually randomly fails.

### Issue Summary

The intermittent failure (`AssertionError: AssertionError not raised`) comes from a test that assumes an *unseeded random* call must differ from a seeded call:

```python
with self.assertRaises(AssertionError):
    np.testing.assert_almost_equal(create_initial_values(..., seed=None), expected_seed_1)
```

In `create_initial_values`, `seed=None` is turned into a random seed via:

```python
seed = random.randint(0, 255)
```

So an *unseeded random* call is actually just a call with a randomly chosen seed in the range 0 to 255. With probability 1/256, that seed is `1`. In that case, `create_initial_values(...)` produces exactly the same output as `create_initial_values(..., seed=1)`. Then `assert_almost_equal` does not raise and the test fails. Reruns usually pass because a different seed is picked.

This happens in 4 tests across 5 OS jobs, so there are 20 chances per pipeline run. That gives roughly a ~8% chance for a random pipeline failure.

---

### How to Reproduce


If `seed=1` is explicitly used for the *unseeded random* call, the test fails deterministically, which matches what we see in CI.

---

### How to Resolve

We should clarify what this test is actually supposed to check.

* The test before that Assertion already verifies that a fixed seed (`seed=1`) is reproducible.
* The remaining assertions seem to try to check that using a *different* seed gives different initial values.

**Current proposed fix**
Given that intent, explicitly using `seed=2` for the second “random” call would make the test deterministic and avoid CI flakiness.

If the intent is instead to test that *any* random seed produces different values, the seed range would have to be restricted so it can never be `1`.

In general, relying on randomness in CI tests is not a great idea as far as I know though.

Alternatively, we could just remove these assertions entirely.