### PR TITLE
Move matplotlib backend restoration to finally block

### DIFF
--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -286,7 +286,10 @@ class Fractionator(EventHandler):
             end = np.max(chromatogram.time)
 
         fig, ax = chromatogram.plot(
-            ax=ax, x_axis_in_minutes=x_axis_in_minutes, *args, **kwargs
+            ax=ax,
+            x_axis_in_minutes=x_axis_in_minutes,
+            *args,
+            **kwargs,
         )
 
         y_max = 1.1 * np.max(chromatogram.solution)

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -691,7 +691,7 @@ class OptimizerBase(Structure):
             self.progress_frequency is not None
             and current_generation % self.progress_frequency == 0
         ):
-            self.results.plot_figures(show=False)
+            self.results.plot_figures()
 
         self._evaluate_callbacks(current_generation)
 
@@ -716,7 +716,7 @@ class OptimizerBase(Structure):
 
     def run_final_processing(self) -> None:
         """Run post processing at the end of the optimization."""
-        self.results.plot_figures(show=False)
+        self.results.plot_figures()
         if self.optimization_problem.n_callbacks > 0:
             self._evaluate_callbacks(0, "final")
         self.results.save_results("final")

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -269,32 +269,33 @@ class OptimizerBase(Structure):
             if not flag:
                 raise ValueError("x0 contains invalid entries.")
 
-        log.log_time("Optimization", self.logger.level)(self._run)
-        log.log_results("Optimization", self.logger.level)(self._run)
-        log.log_exceptions("Optimization", self.logger.level)(self._run)
+        try:
+            log.log_time("Optimization", self.logger.level)(self._run)
+            log.log_results("Optimization", self.logger.level)(self._run)
+            log.log_exceptions("Optimization", self.logger.level)(self._run)
 
-        backend = plt.get_backend()
-        plt.switch_backend("agg")
+            backend = plt.get_backend()
+            plt.switch_backend("agg")
 
-        start = time.time()
-        self._run(self.optimization_problem, x0, *args, **kwargs)
-        time_elapsed = time.time() - start
+            start = time.time()
+            self._run(self.optimization_problem, x0, *args, **kwargs)
+            time_elapsed = time.time() - start
 
-        self.results.time_elapsed = time_elapsed
-        self.results.cpu_time = self.n_cores * time_elapsed
+            self.results.time_elapsed = time_elapsed
+            self.results.cpu_time = self.n_cores * time_elapsed
 
-        self.run_final_processing()
+            self.run_final_processing()
 
-        if delete_cache:
-            optimization_problem.delete_cache(reinit=True)
-        self._current_cache_entries = []
+            if delete_cache:
+                optimization_problem.delete_cache(reinit=True)
+            self._current_cache_entries = []
 
-        plt.switch_backend(backend)
-
-        if not self.results.success:
-            raise CADETProcessError(
-                f"Optimizaton failed with message: {self.results.exit_message}"
-            )
+            if not self.results.success:
+                raise CADETProcessError(
+                    f"Optimizaton failed with message: {self.results.exit_message}"
+                )
+        finally:
+            plt.switch_backend(backend)
 
         return self.results
 

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -605,7 +605,6 @@ class Population:
                 *args,
                 ax=ax,
                 setup_figure_kwargs=setup_figure_kwargs,
-                show=False,
                 tight_layout=False,
                 **kwargs,
             )
@@ -616,7 +615,6 @@ class Population:
                 color=color_infeas,
                 *args,
                 ax=ax,
-                show=False,
                 tight_layout=False,
                 **({"update_layout": False, **kwargs})
             )
@@ -684,7 +682,6 @@ class Population:
             color=color_feas,
             *args,
             ax=ax,
-            show=False,
             tight_layout=False,
             setup_figure_kwargs=setup_figure_kwargs,
             **kwargs,
@@ -697,7 +694,6 @@ class Population:
                 color=x_infeas,
                 *args,
                 ax=ax,
-                show=False,
                 tight_layout=False,
                 **{"update_layout": False, **kwargs}
             )

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -414,7 +414,7 @@ class OptimizationResults(Structure):
         else:
             return np.array([pop.m_avg for pop in self.populations])
 
-    def plot_figures(self, show: bool = True) -> None:
+    def plot_figures(self) -> None:
         """
         Plot result figures.
 
@@ -433,34 +433,28 @@ class OptimizationResults(Structure):
 
             self.plot_convergence(
                 "objectives",
-                show=show,
                 file_name=f"{self.plot_directory / 'convergence_objectives.png'}",
             )
             if self.optimization_problem.n_nonlinear_constraints > 0:
                 self.plot_convergence(
                     "nonlinear_constraints",
-                    show=show,
                     file_name=f"{self.plot_directory / 'convergence_nonlinear_constraints.png'}",
                 )
             if self.optimization_problem.n_meta_scores > 0:
                 self.plot_convergence(
                     "meta_scores",
-                    show=show,
                     file_name=f"{self.plot_directory / 'convergence_meta_scores.png'}",
                 )
             self.plot_objectives(
-                show=show,
                 file_name=f"{self.plot_directory / 'objectives.png'}",
             )
             if self.optimization_problem.n_variables > 1 and len(self.x) > 1:
                 self.plot_pairwise(
-                    show=show,
                     file_name=f"{self.plot_directory / 'pairwise.png'}",
                 )
 
             if self.optimization_problem.n_objectives > 1:
                 self.plot_pareto(
-                    show=show,
                     file_name=f"{self.plot_directory / 'pareto.png'}",
                     plot_evolution=True,
                     plot_pareto=False,
@@ -512,7 +506,6 @@ class OptimizationResults(Structure):
                 color_infeas=cmap_infeas(val),
                 ax=ax,
                 setup_figure_kwargs=setup_figure_kwargs,
-                show=False,
                 tight_layout=False,
                 **kwargs,
             )
@@ -592,7 +585,6 @@ class OptimizationResults(Structure):
             color_feas="grey",
             plot_scatter=False,
             ax=ax,
-            show=False,
             tight_layout=False,
             **{"plot_infeasible": False, **kwargs},
         )
@@ -603,7 +595,6 @@ class OptimizationResults(Structure):
                 color_feas=cmap_feas(color_val),
                 color_infeas=cmap_infeas(color_val),
                 ax=ax,
-                show=False,
                 tight_layout=False,
                 **{"update_layout": False, **kwargs},
             )
@@ -664,7 +655,6 @@ class OptimizationResults(Structure):
             plot_scatter=False,
             ax=ax,
             setup_figure_kwargs=setup_figure_kwargs,
-            show=False,
             tight_layout=False,
             **{"plot_infeasible": False, **kwargs},
         )
@@ -675,7 +665,6 @@ class OptimizationResults(Structure):
                 color_feas=cmap_feas(color_val),
                 color_infeas=cmap_infeas(color_val),
                 ax=ax,
-                show=False,
                 tight_layout=False,
                 **{"update_layout": False, **kwargs},
             )

--- a/CADETProcess/plotting.py
+++ b/CADETProcess/plotting.py
@@ -55,6 +55,7 @@ Fill Regions
 """  # noqa
 
 import os
+import warnings
 from contextlib import contextmanager
 from dataclasses import dataclass
 from functools import wraps
@@ -406,19 +407,6 @@ def offset_secondary_yaxes(
 
 # %% Figure Utils
 
-def show_or_reopen(fig: plt.Figure) -> None:
-    """Show figure, reopening it in a GUI window if necessary."""
-    if fig.number not in plt.get_fignums():
-        dummy = plt.figure(figsize=fig.get_size_inches())
-        manager = dummy.canvas.manager
-        manager.canvas.figure = fig
-        fig.set_canvas(manager.canvas)
-        fig.show()
-        plt.close(dummy)
-    else:
-        fig.show()
-
-
 def figure_utils(func: Callable) -> Callable:
     """
     Unified decorator for styling, and saving figures.
@@ -435,7 +423,6 @@ def figure_utils(func: Callable) -> Callable:
         setup_figure_kwargs: Optional[dict] = None,
         file_name: Optional[os.PathLike] = None,
         dpi: int = 300,
-        show: bool = True,
         tight_layout: bool = True,
         **kwargs: Any,
     ) -> tuple[plt.Figure, plt.Axes | npt.NDArray[plt.Axes]]:
@@ -456,8 +443,6 @@ def figure_utils(func: Callable) -> Callable:
             not saved.
         dpi : int, default=300
             DPI for saving the figure.
-        show : bool, default=True
-            If False, close the figure.
         tight_layout : bool, default=True
             If True, set tight layout.
         **kwargs : Any
@@ -474,6 +459,10 @@ def figure_utils(func: Callable) -> Callable:
             **(setup_figure_kwargs or {}),
         }
 
+        show = kwargs.pop("show", None)
+        if show is not None:
+            warnings.warn("`show` argument is deprectated.")
+
         with mpl_style_context(setup_figure_kwargs["layout"]):
             fig, ax = func(
                 *args,
@@ -486,11 +475,6 @@ def figure_utils(func: Callable) -> Callable:
 
         if file_name is not None:
             fig.savefig(file_name, dpi=dpi)
-
-        if show:
-            fig.show()
-        else:
-            plt.close(fig)
 
         return fig, ax
     return figure_utils_wrapper

--- a/examples/batch_elution/optimization_single.py
+++ b/examples/batch_elution/optimization_single.py
@@ -66,7 +66,6 @@ optimization_problem.add_evaluator(
 def callback(fractionation, individual, evaluation_object, callbacks_dir):
     fractionation.plot_fraction_signal(
         file_name=f'{callbacks_dir}/{individual.id}_{evaluation_object}_fractionation.png',
-        show=False
     )
 
 


### PR DESCRIPTION
For performance, we temporarily switch to matplotlib’s `agg` backend during optimization and revert afterward. However, if the optimization fails, the backend is not restored. By wrapping the entire `_run` call in a `try` block and placing the restoration in the `finally` block, we ensure the backend is always reset automatically, even when the optimization raises an exception.