### PR TITLE
Cache and re-raise exceptions when evaluting optimization problem

### DIFF
--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -887,16 +887,23 @@ class OptimizationProblem(Structure):
             if not force:
                 remaining = []
                 for step in reversed(requires):
+                    key = (str(eval_obj), step.id, x_key)
                     try:
-                        key = (str(eval_obj), step.id, x_key)
                         result = self.cache.get(key)
+                        if isinstance(result, Exception):
+                            # Re-raise cached exception to stop further processing
+                            self.logger.debug(
+                                f"Retrieved exception for {str(step)} from cache."
+                            )
+                            # Reconstruct custom exception to avoid type issue when restoring
+                            if "CADETProcessError" in result.__class__.__name__:
+                                result = CADETProcessError(str(result))
+                            raise result
                         self.logger.debug(f"Got {str(step)} results from cache.")
                         current_request = result
                         break
                     except KeyError:
-                        pass
-
-                    remaining.insert(0, step)
+                        remaining.insert(0, step)
             else:
                 remaining = requires
 
@@ -905,16 +912,20 @@ class OptimizationProblem(Structure):
             )
 
             for step in remaining:
-                if isinstance(step, Callback):
-                    step.evaluate(current_request, eval_obj)
-                    result = np.empty((0))
-                else:
-                    result = step.evaluate(current_request)
-
                 key = (str(eval_obj), step.id, x_key)
-                if not isinstance(step, Callback):
-                    self.cache.set(key, result, tag=x_key)
-                current_request = result
+                try:
+                    if isinstance(step, Callback):
+                        step.evaluate(current_request, eval_obj)
+                        result = np.empty((0))
+                    else:
+                        result = step.evaluate(current_request)
+                    if not isinstance(step, Callback):
+                        self.cache.set(key, result, tag=x_key)
+                    current_request = result
+                except Exception as e:
+                    # Cache the exception and re-raise to stop further processing
+                    self.cache.set(key, e, tag=x_key)
+                    raise
 
             if len(result) != func.n_metrics:
                 raise CADETProcessError(

--- a/tests/test_optimization_problem.py
+++ b/tests/test_optimization_problem.py
@@ -832,7 +832,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         x0_seed_1 = self.optimization_problem.create_initial_values(1, seed=1)
         np.testing.assert_almost_equal(x0_seed_1, x0_seed_1_expected)
 
-        x0_seed_1_random = self.optimization_problem.create_initial_values(1, seed)
+        x0_seed_1_random = self.optimization_problem.create_initial_values(1, seed=seed)
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_1_random, x0_seed_1_expected)
@@ -855,7 +855,7 @@ class Test_OptimizationProblemLinCon(unittest.TestCase):
         x0_seed_10 = self.optimization_problem.create_initial_values(10, seed=1)
         np.testing.assert_almost_equal(x0_seed_10, x0_seed_10_expected)
 
-        x0_seed_10_random = self.optimization_problem.create_initial_values(10, seed)
+        x0_seed_10_random = self.optimization_problem.create_initial_values(10, seed=seed, )
 
         with self.assertRaises(AssertionError):
             np.testing.assert_almost_equal(x0_seed_10_random, x0_seed_10_expected)
@@ -947,7 +947,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         )
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(
-            1, include_dependent_variables=False
+            1, seed=seed, include_dependent_variables=False
         )
 
         with self.assertRaises(AssertionError):
@@ -1005,7 +1005,7 @@ class Test_OptimizationProblemDepVar(unittest.TestCase):
         )
 
         x0_seed_1_random = self.optimization_problem.create_initial_values(
-            1, include_dependent_variables=True
+            1, seed=seed, include_dependent_variables=True
         )[0]
 
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
If an optimization problem method raises an exception (e.g., due to numerical issues), we expect the same failure when called again with identical values. Previously, no caching was implemented for failed calls, resulting in redundant evaluations. Now, when `force` is `False`, we cache and return the exception immediately, avoiding unnecessary retries.