### PR TITLE
Fix updating flow rate TimeLine of SolutionIO

### DIFF
--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -543,6 +543,63 @@ class TimeLine:
 
         return tl
 
+    def slice(
+        self,
+        start: float | None = None,
+        end: float | None = None,
+    ) -> TimeLine:
+        """
+        Slice the timeline from a profile.
+
+        Parameters
+        ----------
+        start : Optional[float]
+            Start time of the slice. If None, the first time point is used. The
+            default is None.
+        end: Optional[float]
+            End time of the slice. If None, the last time point is used. The
+            default is None.
+
+        Returns
+        -------
+        TimeLine
+            A new TimeLine instance between start and end.
+        """
+        if start is None:
+            start = self.section_times[0]
+        if start < self.section_times[0]:
+            raise ValueError("Start time must be larger than first time point.")
+        if end is None:
+            end = self.section_times[-1]
+        if end > self.section_times[-1]:
+            raise ValueError("End time must be smaller than last time point.")
+
+        time_line = TimeLine()
+
+        for section in self.sections:
+            # Section ends before start of slice
+            if section.end < start:
+                continue
+            # Section starts after end of slice
+            if section.start > end:
+                break
+
+            # Section is fully within slice
+            if section.start >= start and section.end <= end:
+                new_section = section
+            # Section is sliced
+            else:
+                new_section = Section(
+                    max(section.start, start),
+                    min(section.end, end),
+                    section.coefficients(max(section.start, start)),
+                    section.is_polynomial,
+                )
+
+            time_line.add_section(new_section)
+
+        return time_line
+
 
 class MultiTimeLine:
     """

--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import copy
 import itertools
 import warnings
 from typing import Optional
@@ -547,6 +548,7 @@ class TimeLine:
         self,
         start: float | None = None,
         end: float | None = None,
+        offset: float | None = None,
     ) -> TimeLine:
         """
         Slice the timeline from a profile.
@@ -559,6 +561,8 @@ class TimeLine:
         end: Optional[float]
             End time of the slice. If None, the last time point is used. The
             default is None.
+        offset: Optional[float]
+            Optional time offset. The default is None.
 
         Returns
         -------
@@ -599,6 +603,31 @@ class TimeLine:
             time_line.add_section(new_section)
 
         return time_line
+
+    def offset(
+        self,
+        offset: float,
+    ) -> TimeLine:
+        """
+        Shift the timeline by an offset.
+
+        Parameters
+        ----------
+        offset: flaot
+            The offset.
+
+        Returns
+        -------
+        TimeLine
+            A new TimeLine instance with offset sections.
+        """
+        offset_time_line = copy.deepcopy(self)
+
+        for section in offset_time_line.sections:
+            section.start += offset
+            section.end += offset
+
+        return offset_time_line
 
 
 class MultiTimeLine:

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -111,17 +111,20 @@ class Process(EventHandler):
                 feed_section = Section(0, self.cycle_time, feed.c, is_polynomial=True)
                 feed_signal_time_line.add_section(feed_section)
 
-            m_i = [
-                integrate.quad(
-                    lambda t: feed_flow_rate_time_line.value(t) * feed_signal_time_line.value(t)[comp],  # noqa: E501
-                    0,
-                    self.cycle_time,
-                    points=self.event_times,
-                )[0]
-                for comp in range(self.n_comp)
-            ]
+            m_i = np.zeros((self.n_comp, ))
+            for t0, t1 in zip(self.section_times[:-1], self.section_times[1:]):
+                # Precompute values on a fine grid for this segment
+                # move the right boundary infinitesimally to the left
+                t1m = np.nextafter(t1, t0)
 
-            feed_all += np.array(m_i)
+                t_eval = np.linspace(t0, t1m, 1001)
+
+                flow_vals = feed_flow_rate_time_line.value(t_eval)
+                c_vals = feed_signal_time_line.value(t_eval)
+
+                m_i += integrate.simpson(flow_vals * c_vals, t_eval, axis=0)
+
+            feed_all += m_i
 
         return feed_all
 

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -151,48 +151,68 @@ class SimulationResults(Structure):
         if self._solution is not None:
             return self._solution
 
-        time_complete = self.time_complete
+        def _merge_cycles(
+            cycles: list[SolutionBase],
+            time_complete: np.ndarray,
+        ) -> SolutionBase:
+            """
+            Merge cycle solutions into a complete solution.
+
+            Parameters
+            ----------
+            cycles : list
+                List of cycle objects.
+            time_complete : np.ndarray
+                Complete time array.
+
+            Returns
+            -------
+            object
+                A new object with merged solution and time.
+            """
+            merged = copy.deepcopy(cycles[0])
+            merged.time = time_complete
+
+            solution_complete = cycles[0].solution
+            if solution_complete.ndim > 1:
+                for cycle in cycles[1:]:
+                    solution_complete = np.vstack(
+                        (solution_complete, cycle.solution[1:])
+                    )
+            else:
+                for cycle in cycles[1:]:
+                    solution_complete = np.hstack(
+                        (solution_complete, cycle.solution[1:])
+                    )
+            merged.solution = solution_complete
+
+            if hasattr(cycles[0], "flow_rate"):
+                flow_rate_complete = copy.deepcopy(cycles[0].flow_rate)
+                for cycle in cycles[1:]:
+                    new_flow_rate = cycle.flow_rate.offset(flow_rate_complete.end)
+                    for section in new_flow_rate.sections:
+                        flow_rate_complete.add_section(section)
+                merged.flow_rate = flow_rate_complete
+
+            merged.update_solution()
+
+            return merged
 
         solution = Dict()
+        time_complete = self.time_complete
         for unit, solutions in self.solution_cycles.items():
             for sol, ports_cycles in solutions.items():
-                if isinstance(ports_cycles, Dict):
-                    ports = ports_cycles
-                    for port, cycles in ports.items():
-                        solution[unit][sol][port] = copy.deepcopy(cycles[0])
-                        solution_complete = cycles[0].solution
-                        if solution_complete.ndim > 1:
-                            for i in range(1, self.n_cycles):
-                                solution_complete = np.vstack((
-                                    solution_complete, cycles[i].solution[1:]
-                                ))
-                        else:
-                            for i in range(1, self.n_cycles):
-                                solution_complete = np.hstack((
-                                    solution_complete, cycles[i].solution[1:]
-                                ))
-
-                        solution[unit][sol][port].time = time_complete
-                        solution[unit][sol][port].solution = solution_complete
-                        solution[unit][sol][port].update_solution()
+                if isinstance(ports_cycles, dict):
+                    for port, cycles in ports_cycles.items():
+                        solution[unit][sol][port] = _merge_cycles(
+                            cycles,
+                            time_complete,
+                        )
                 else:
-                    cycles = ports_cycles
-                    solution[unit][sol] = copy.deepcopy(cycles[0])
-                    solution_complete = cycles[0].solution
-                    if solution_complete.ndim > 1:
-                        for i in range(1, self.n_cycles):
-                            solution_complete = np.vstack((
-                                solution_complete, cycles[i].solution[1:]
-                            ))
-                    else:
-                        for i in range(1, self.n_cycles):
-                            solution_complete = np.hstack((
-                                solution_complete, cycles[i].solution[1:]
-                            ))
-
-                    solution[unit][sol].time = time_complete
-                    solution[unit][sol].solution = solution_complete
-                    solution[unit][sol].update_solution()
+                    solution[unit][sol] = _merge_cycles(
+                        ports_cycles,
+                        time_complete,
+                    )
 
         self._solution = solution
 

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -276,6 +276,7 @@ class SolutionIO(SolutionBase):
         self._solution_interpolated = None
         self._dm_dt_interpolated = None
         self.update_transform()
+        self.flow_rate = self.flow_rate.slice(self.time[0], self.time[-1])
 
     @property
     def derivative(self) -> "SolutionIO":

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -271,6 +271,15 @@ class SolutionIO(SolutionBase):
 
         super().__init__(name, component_system, time, solution)
 
+    def offset(self, offset: float) -> "SolutionIO":
+        """Shift solution by an offset."""
+        offset_solution = copy.deepcopy(self)
+        offset_solution.time += offset
+        offset_solution.flow_rate = self.flow_rate.offset(offset)
+        offset_solution.update_solution()
+
+        return offset_solution
+
     def update_solution(self) -> None:
         """Update solution method."""
         self._solution_interpolated = None

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -544,26 +544,24 @@ class SolutionIO(SolutionBase):
         if end is None:
             end = self.cycle_time
 
-        # Note, we do not use self.dm_dt_interpolated to better account for
-        # discontinuities in the flow rate profile, by passing the section times to
-        # `quad_vec`. Maybe this can be improved in the future.
-        def dm_dt(t: float, flow_rate: np.ndarray, solution: np.ndarray) -> np.ndarray:
-            dm_dt = flow_rate.value(t) * solution(t)
-            return dm_dt
-
-        points = None
-        if len(self.flow_rate.section_times) > 2:
-            points = self.flow_rate.section_times[1:-1]
-
-        mass = integrate.quad_vec(
-            dm_dt,
+        all_times = np.sort(np.unique([
             start,
+            *[t for t in self.flow_rate.section_times if start <= t <= end],
             end,
-            epsabs=1e-6,
-            epsrel=1e-8,
-            args=(self.flow_rate, self.solution_interpolated),
-            points=points,
-        )[0]
+        ]))
+
+        mass = np.zeros((self.n_comp, ))
+        for t0, t1 in zip(all_times[:-1], all_times[1:]):
+            # Precompute values on a fine grid for this segment
+            # move the right boundary infinitesimally to the left
+            t1m = np.nextafter(t1, t0)
+
+            t_eval = np.linspace(t0, t1m, 1001)
+
+            flow_vals = self.flow_rate.value(t_eval)
+            sol_vals = self.solution_interpolated(t_eval)
+
+            mass += integrate.simpson(flow_vals * sol_vals, t_eval, axis=0)
 
         return mass
 


### PR DESCRIPTION
This PR fixes an issue where the flow rate `TimeLine` was not updated properly when slicing a solution object. Moreover, I found out that it was also never properly updated for the complete solution of all cycles (e.g. when using the stationarity evaluator).

Depends on #349 