### PR TITLE
Chore/support hopsy 1.7

### DIFF
--- a/CADETProcess/optimization/optimizationProblem.py
+++ b/CADETProcess/optimization/optimizationProblem.py
@@ -17,6 +17,7 @@ import hopsy
 import numpy as np
 import numpy.typing as npt
 from addict import Dict
+from packaging.version import Version
 
 from CADETProcess import CADETProcessError, log, settings
 from CADETProcess.dataStructure import (
@@ -3122,7 +3123,9 @@ class OptimizationProblem(Structure):
             include_dependent_variables=False, simplify=False, use_custom_model=True
         )
 
-        chebyshev = hopsy.compute_chebyshev_center(problem, original_space=True)[:, 0]
+        chebyshev = hopsy.compute_chebyshev_center(problem, original_space=True)
+        if Version(hopsy.__version__.strip('"')) < Version("1.7.0b"):
+            chebyshev = chebyshev[:, 0]
 
         if include_dependent_variables:
             chebyshev = self.get_dependent_values(chebyshev)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "numpy>=1.21",
     "matplotlib>=3.4",
     "numba>=0.55.1",
+    "packaging>=26.0",
     "pathos>=0.2.8",
     "psutil>=5.9.8",
     "pymoo>=0.6",


### PR DESCRIPTION
This PR supports the upcoming hopsy v1.7 version which contained a breaking change regarding the return value/shape of the `compute_chebyshev_center` method.