### PR TITLE
Model builder improvements

### DIFF
--- a/CADETProcess/modelBuilder/batchElutionBuilder.py
+++ b/CADETProcess/modelBuilder/batchElutionBuilder.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 from typing import Optional
 
@@ -59,7 +58,6 @@ class BatchElution(Process):
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
 
-        column = copy.deepcopy(column)
         if not column.name == "column":
             warnings.warn("Renaming column to `column` for consistency")
             column.name = "column"

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -1,5 +1,5 @@
+import copy
 import warnings
-from copy import deepcopy
 from functools import wraps
 from typing import Any, NoReturn, Optional, Union
 
@@ -332,8 +332,7 @@ class CarouselBuilder(Structure):
                 flow_sheet.add_unit(unit.inlet_unit)
                 flow_sheet.add_unit(unit.outlet_unit)
                 for i_col in range(unit.n_columns):
-                    col = deepcopy(self.column)
-                    col.component_system = self.component_system
+                    col = copy.copy(self.column)
                     col.name = f"column_{col_index}"
                     if unit.initial_state is not None:
                         col.initial_state = unit.initial_state[i_col]

--- a/CADETProcess/modelBuilder/carouselBuilder.py
+++ b/CADETProcess/modelBuilder/carouselBuilder.py
@@ -19,6 +19,7 @@ from CADETProcess.dataStructure import (
 )
 from CADETProcess.processModel import (
     BindingBaseClass,
+    ChromatographicColumnBase,
     ComponentSystem,
     Cstr,
     FlowSheet,
@@ -42,6 +43,16 @@ __all__ = [
     "LinearSMBBuilder",
     "LangmuirSMBBuilder",
 ]
+
+
+def _copy_column(
+    column: ChromatographicColumnBase, own_binding_model: bool
+) -> ChromatographicColumnBase:
+    col = copy.copy(column)
+    if own_binding_model:
+        col._binding_model = copy.deepcopy(column.binding_model)
+        col._binding_model.component_system = col.component_system
+    return col
 
 
 class ZoneBaseClass(UnitBaseClass):
@@ -293,9 +304,15 @@ class CarouselBuilder(Structure):
         """int: Number of columns in the Carousel System."""
         return sum([zone.n_columns for zone in self.zones])
 
-    def build_flow_sheet(self) -> FlowSheet:
+    def build_flow_sheet(self, own_binding_model: bool = False) -> FlowSheet:
         """
         Assemble the flow sheet.
+
+        Parameters
+        ----------
+        own_binding_model : bool, optional
+            If True, each column gets its own deep-copied binding model.
+            If False (default), all columns share the same binding model instance.
 
         Returns
         -------
@@ -307,14 +324,14 @@ class CarouselBuilder(Structure):
 
         flow_sheet = FlowSheet(self.component_system, self.name)
 
-        self._add_units(flow_sheet)
+        self._add_units(flow_sheet, own_binding_model)
         self._add_inter_zone_connections(flow_sheet)
         self._add_intra_zone_connections(flow_sheet)
         self._set_output_states(flow_sheet)
 
         return flow_sheet
 
-    def _add_units(self, flow_sheet: FlowSheet) -> None:
+    def _add_units(self, flow_sheet: FlowSheet, own_binding_model: bool = False) -> None:
         """Add units to flow_sheet."""
         col_index = 0
         for unit in self.flow_sheet.units:
@@ -332,7 +349,7 @@ class CarouselBuilder(Structure):
                 flow_sheet.add_unit(unit.inlet_unit)
                 flow_sheet.add_unit(unit.outlet_unit)
                 for i_col in range(unit.n_columns):
-                    col = copy.copy(self.column)
+                    col = _copy_column(self.column, own_binding_model)
                     col.name = f"column_{col_index}"
                     if unit.initial_state is not None:
                         col.initial_state = unit.initial_state[i_col]
@@ -382,16 +399,22 @@ class CarouselBuilder(Structure):
             else:
                 flow_sheet.set_output_state(unit, output_state)
 
-    def build_process(self) -> Process:
+    def build_process(self, own_binding_model: bool = False) -> Process:
         """
         Assemble the process object.
+
+        Parameters
+        ----------
+        own_binding_model : bool, optional
+            If True, each column gets its own deep-copied binding model.
+            If False (default), all columns share the same binding model instance.
 
         Returns
         -------
         Process
             The assembled process object.
         """
-        flow_sheet = self.build_flow_sheet()
+        flow_sheet = self.build_flow_sheet(own_binding_model)
         process = Process(flow_sheet, self.name)
 
         self._add_events(process)

--- a/CADETProcess/modelBuilder/clrBuilder.py
+++ b/CADETProcess/modelBuilder/clrBuilder.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 
 from CADETProcess.processModel import (
@@ -64,7 +63,6 @@ class CLR(Process):
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
 
-        column = copy.deepcopy(column)
         if not column.name == "column":
             warnings.warn("Renaming column to `column` for consistency")
             column.name = "column"

--- a/CADETProcess/modelBuilder/clrBuilder.py
+++ b/CADETProcess/modelBuilder/clrBuilder.py
@@ -23,7 +23,7 @@ class CLR(Process):
 
     The process is configured with the following events:
     - Feed injection (duration: `feed_duration`).
-    - Recycling (ends at `recycle_off`).
+    - Recycling (ends at `t_recycle_off`).
     - Elution after recycling.
     """
 
@@ -33,7 +33,7 @@ class CLR(Process):
         c_feed: list[float],
         flow_rate: float,
         feed_duration: float,
-        recycle_off: float,
+        t_recycle_off: float,
         cycle_time: float,
         c_eluent: list[float] | float = 0.0,
         pump_volume: float = 1e-9,
@@ -51,7 +51,7 @@ class CLR(Process):
             Flow rate.
         feed_duration : float
             Feed injection duration.
-        recycle_off : float
+        t_recycle_off : float
             Time at which recycling ends.
         cycle_time : float
             Total cycle time.
@@ -99,7 +99,7 @@ class CLR(Process):
             "recycle_off_output_state",
             f"flow_sheet.output_states.{column.name}",
             {"outlet": 1},
-            recycle_off,
+            t_recycle_off,
         )
         self.add_event("recycle_off_pump", "flow_sheet.pump.flow_rate", 0)
         self.add_event_dependency("recycle_off_pump", ["recycle_off_output_state"])

--- a/CADETProcess/modelBuilder/flipFlopBuilder.py
+++ b/CADETProcess/modelBuilder/flipFlopBuilder.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 
 from CADETProcess.processModel import (
@@ -60,7 +59,6 @@ class FlipFlop(Process):
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
 
-        column = copy.deepcopy(column)
         if not column.name == "column":
             warnings.warn("Renaming column to `column` for consistency")
             column.name = "column"

--- a/CADETProcess/modelBuilder/lweBuilder.py
+++ b/CADETProcess/modelBuilder/lweBuilder.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 
 from CADETProcess.processModel import (
@@ -70,7 +69,6 @@ class LWE(Process):
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
 
-        column = copy.deepcopy(column)
         if not column.name == "column":
             warnings.warn("Renaming column to `column` for consistency")
             column.name = "column"

--- a/CADETProcess/modelBuilder/mrssrBuilder.py
+++ b/CADETProcess/modelBuilder/mrssrBuilder.py
@@ -23,7 +23,7 @@ class MRSSR(Process):
 
     The process is configured with the following events:
     - Feed injection (duration: `feed_duration`), coupled to elution flow rate.
-    - Recycling (starts at `recycle_on`, ends at `recycle_off`).
+    - Recycling (starts at `t_recycle_on`, ends at `t_recycle_off`).
     """
 
     def __init__(
@@ -32,8 +32,8 @@ class MRSSR(Process):
         c_feed: list[float],
         flow_rate: float,
         feed_duration: float,
-        recycle_on: float,
-        recycle_off: float,
+        t_recycle_on: float,
+        t_recycle_off: float,
         cycle_time: float,
         V_tank: float,
         c_eluent: list[float] | float = 0.0,
@@ -52,9 +52,9 @@ class MRSSR(Process):
             Flow rate.
         feed_duration : float
             Feed injection duration.
-        recycle_on : float
+        t_recycle_on : float
             Time at which to start recycling.
-        recycle_off : float
+        t_recycle_off : float
             Time at which to end recycling.
         cycle_time : float
             Total cycle time.
@@ -100,13 +100,13 @@ class MRSSR(Process):
             "recycle_on",
             f"flow_sheet.output_states.{column.name}",
             {"tank": 1},
-            recycle_on,
+            t_recycle_on,
         )
         self.add_event(
             "recycle_off",
             f"flow_sheet.output_states.{column.name}",
             {"outlet": 1},
-            recycle_off,
+            t_recycle_off,
         )
 
         # Dependencies

--- a/CADETProcess/modelBuilder/mrssrBuilder.py
+++ b/CADETProcess/modelBuilder/mrssrBuilder.py
@@ -1,4 +1,3 @@
-import copy
 import warnings
 
 from CADETProcess.processModel import (
@@ -71,7 +70,6 @@ class MRSSR(Process):
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
 
-        column = copy.deepcopy(column)
         if not column.name == "column":
             warnings.warn("Renaming column to `column` for consistency")
             column.name = "column"

--- a/CADETProcess/modelBuilder/serialColumnsBuilder.py
+++ b/CADETProcess/modelBuilder/serialColumnsBuilder.py
@@ -1,5 +1,4 @@
 import copy
-import warnings
 from typing import Optional
 
 from CADETProcess.processModel import (
@@ -81,11 +80,6 @@ class SerialColumns(Process):
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
 
-        column = copy.deepcopy(column)
-        if not column.name == "column":
-            warnings.warn("Renaming column to `column` for consistency")
-            column.name = "column"
-
         flow_sheet = self._build_flow_sheet(
             column,
             split_ratio,
@@ -150,14 +144,12 @@ class SerialColumns(Process):
         eluent_2 = Inlet(component_system, name="eluent_2")
         eluent_2.c = c_eluent
 
-        column_1 = copy.deepcopy(column)
+        column_1 = copy.copy(column)
         column_1.name = "column_1"
-        column_1.component_system = component_system
         column_1.length = split_ratio * column.length
 
-        column_2 = copy.deepcopy(column)
+        column_2 = copy.copy(column)
         column_2.name = "column_2"
-        column_2.component_system = component_system
         column_2.length = (1 - split_ratio) * column.length
 
         outlet_1 = Outlet(component_system, name="outlet_1")

--- a/CADETProcess/modelBuilder/serialColumnsBuilder.py
+++ b/CADETProcess/modelBuilder/serialColumnsBuilder.py
@@ -10,6 +10,16 @@ from CADETProcess.processModel import (
 )
 
 
+def _copy_column(
+    column: ChromatographicColumnBase, own_binding_model: bool
+) -> ChromatographicColumnBase:
+    col = copy.copy(column)
+    if own_binding_model:
+        col._binding_model = copy.deepcopy(column.binding_model)
+        col._binding_model.component_system = col.component_system
+    return col
+
+
 class SerialColumns(Process):
     """
     Serial columns process.
@@ -49,6 +59,7 @@ class SerialColumns(Process):
         t_serial_off: float,
         cycle_time: float,
         c_eluent: Optional[list[float] | float] = 0.0,
+        own_binding_model: bool = False,
     ) -> None:
         """
         Initialize batch elution process.
@@ -76,6 +87,9 @@ class SerialColumns(Process):
             Cycle time.
         c_eluent : list[float] | float, optional
             Eluent concentration. The default is 0.0.
+        own_binding_model : bool, optional
+            If True, each column gets its own deep-copied binding model.
+            If False (default), all columns share the same binding model instance.
         """
         if not isinstance(column, ChromatographicColumnBase):
             raise TypeError("Expected ChromatographicColumnBase.")
@@ -85,6 +99,7 @@ class SerialColumns(Process):
             split_ratio,
             c_feed,
             c_eluent,
+            own_binding_model,
         )
 
         super().__init__(flow_sheet, "Serial Columns")
@@ -130,6 +145,7 @@ class SerialColumns(Process):
         split_ratio: float,
         c_feed: list[float],
         c_eluent: list[float] | float | None = 0.0,
+        own_binding_model: bool = False,
     ) -> FlowSheet:
         """Build and return the flow sheet for batch elution process."""
         component_system = column.component_system
@@ -144,11 +160,11 @@ class SerialColumns(Process):
         eluent_2 = Inlet(component_system, name="eluent_2")
         eluent_2.c = c_eluent
 
-        column_1 = copy.copy(column)
+        column_1 = _copy_column(column, own_binding_model)
         column_1.name = "column_1"
         column_1.length = split_ratio * column.length
 
-        column_2 = copy.copy(column)
+        column_2 = _copy_column(column, own_binding_model)
         column_2.name = "column_2"
         column_2.length = (1 - split_ratio) * column.length
 


### PR DESCRIPTION
## Summary
- Do not copy columns in model builders as to not lose reference to the object.
- Consistent naming of event times across ModelBuilders