### PR TITLE
Add `ProcessMeta` dataclass to store process meta information

### DIFF
--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -12,7 +12,7 @@ from CADETProcess.dataStructure import String
 from CADETProcess.dynamicEvents import Event, EventHandler
 from CADETProcess.fractionation.fractions import Fraction, FractionPool
 from CADETProcess.performance import Performance
-from CADETProcess.processModel import ComponentSystem, Process
+from CADETProcess.processModel import ComponentSystem, Process, ProcessMeta
 from CADETProcess.simulationResults import SimulationResults
 from CADETProcess.solution import SolutionIO, slice_solution
 
@@ -131,8 +131,6 @@ class Fractionator(EventHandler):
         self._fractionation_states = Dict({chrom: [] for chrom in self.chromatograms})
         self._chromatogram_events = Dict({chrom: [] for chrom in self.chromatograms})
 
-        self._cycle_time = self.process.cycle_time
-
         self.reset()
 
     @property
@@ -201,6 +199,11 @@ class Fractionator(EventHandler):
         return self.simulation_results.process
 
     @property
+    def process_meta(self) -> ProcessMeta:
+        """ProcessMeta: Process meta information."""
+        return self.simulation_results.process_meta
+
+    @property
     def n_comp(self) -> int:
         """int: Number of components to be fractionized."""
         return self.chromatograms[0].n_comp
@@ -210,18 +213,12 @@ class Fractionator(EventHandler):
         """
         The cycle time of the Fractionator.
 
-        Note that in some situations, it might be desired to set a custom cycle time
-        for calculating the performance indicators. For this purpose, overwrite the
-        cycle time in the Process object after adding it to the Fractionator.
-
-        Warning: This is not a robust feature! Side effects can ocurr in the Process!
-
         See Also
         --------
         productivity
 
         """
-        return self._cycle_time
+        return self.time[-1]
 
     @property
     def time(self) -> np.ndarray:
@@ -547,7 +544,7 @@ class Fractionator(EventHandler):
     @property
     def productivity(self) -> np.ndarray:
         """ndarray: Specific productivity in corresponding fraction pool."""
-        return self.mass / (self.process.cycle_time * self.process.V_solid)
+        return self.mass / (self.process_meta.cycle_time * self.process_meta.V_solid)
 
     @property
     def eluent_consumption(self) -> np.ndarray:
@@ -560,7 +557,7 @@ class Fractionator(EventHandler):
         consumption. It is preferred here in order to avoid numeric issues
         if the collected mass is 0.
         """
-        return self.mass / self.process.V_eluent
+        return self.mass / self.process_meta.V_eluent
 
     @property
     def performance(self) -> Performance:

--- a/CADETProcess/processModel/process.py
+++ b/CADETProcess/processModel/process.py
@@ -15,7 +15,7 @@ from .componentSystem import ComponentSystem
 from .flowSheet import FlowSheet
 from .unitOperation import Inlet, Outlet
 
-__all__ = ["Process"]
+__all__ = ["Process", "ProcessMeta"]
 
 
 class Process(EventHandler):
@@ -146,6 +146,16 @@ class Process(EventHandler):
         """float: Volume of all solid phase material used in flow sheet."""
         return sum([unit.volume_solid for unit in self.flow_sheet.units_with_binding])
 
+    @property
+    def process_meta(self) -> "ProcessMeta":
+        """ProcessMeta: Process meta information."""
+        return ProcessMeta(
+            cycle_time=self.cycle_time,
+            V_eluent=self.V_eluent,
+            V_solid=self.V_solid,
+            m_feed=self.m_feed,
+        )
+
     @cached_property_if_locked
     def flow_rate_timelines(self) -> dict:
         """Return TimeLine of flow_rate for all unit_operations."""
@@ -179,7 +189,6 @@ class Process(EventHandler):
                 unit_flow_rates = flow_rate_timelines[unit]
 
                 # If inlet, also use outlet for total_in
-
                 if isinstance(self.flow_sheet[unit], Inlet):
                     for port in flow_rate_dict["total_out"]:
                         section = Section(
@@ -906,3 +915,13 @@ class ParameterSensitivity:
     section_indices: list = None
     abstols: list = None
     factors: list = None
+
+
+@dataclass
+class ProcessMeta:
+    """Class for storing process meta information."""
+
+    cycle_time: float
+    V_eluent: float
+    V_solid: float
+    m_feed: list[float]

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -31,7 +31,12 @@ from CADETProcess.dataStructure import (
     UnsignedFloat,
     UnsignedInteger,
 )
-from CADETProcess.processModel import ComponentSystem, Process, UnitBaseClass
+from CADETProcess.processModel import (
+    ComponentSystem,
+    Process,
+    ProcessMeta,
+    UnitBaseClass,
+)
 from CADETProcess.solution import SolutionBase
 
 __all__ = ["SimulationResults"]
@@ -117,6 +122,13 @@ class SimulationResults(Structure):
         self._time_complete = None
         self._solution = None
         self._sensitivity = None
+
+        self._process_meta = process.process_meta
+
+    @property
+    def process_meta(self) -> ProcessMeta:
+        """ProcessMeta: Process meta information."""
+        return self._process_meta
 
     def update(self, new_results: SimulationResults) -> None:
         """Update the simulation results with results from a new cycle."""

--- a/CADETProcess/simulationResults.py
+++ b/CADETProcess/simulationResults.py
@@ -191,6 +191,11 @@ class SimulationResults(Structure):
                 for cycle in cycles[1:]:
                     new_flow_rate = cycle.flow_rate.offset(flow_rate_complete.end)
                     for section in new_flow_rate.sections:
+                        # Find the closest time to avoid numerical issues
+                        start_index = np.argmin(np.abs(time_complete - section.start))
+                        section.start = time_complete[start_index]
+                        end_index = np.argmin(np.abs(time_complete - section.end))
+                        section.end = time_complete[end_index]
                         flow_rate_complete.add_section(section)
                 merged.flow_rate = flow_rate_complete
 


### PR DESCRIPTION
`ProcessMeta` allows this information to be safely preserved when tweaking fractionation. For example, when a post-processing method determines cycle time from a chromatogram, the eluent and cycle time need to be adjusted to accurately compute KPIs. 
