### PR TITLE
Add shared fixtures to conftest.py

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,109 @@
+import numpy as np
+import pytest
+from CADETProcess.processModel import (
+    MCT,
+    ComponentSystem,
+    Cstr,
+    GeneralRateModel,
+    Inlet,
+    LumpedRateModelWithoutPores,
+    LumpedRateModelWithPores,
+    TubularReactor,
+)
+
+length = 0.6
+diameter = 0.024
+bed_porosity = 0.3
+particle_porosity = 0.6
+particle_radius = 1e-4
+total_porosity = bed_porosity + (1 - bed_porosity) * particle_porosity
+axial_dispersion = 4.7e-7
+film_diffusion = [0, 1e-6]
+pore_diffusion = [0, 1e-11]
+
+nchannel = 3
+channel_cross_section_areas = [0.1, 0.1, 0.1]
+exchange_matrix = np.array([
+    [[0.0], [0.01], [0.0]],
+    [[0.02], [0.0], [0.03]],
+    [[0.0], [0.0], [0.0]],
+])
+
+cross_section_area = np.pi / 4 * diameter**2
+init_liquid_volume = cross_section_area * length * total_porosity
+const_solid_volume = cross_section_area * length * (1 - total_porosity)
+
+
+@pytest.fixture
+def component_system():
+    return ComponentSystem(2)
+
+
+@pytest.fixture
+def inlet(component_system):
+    return Inlet(component_system, name="test_inlet")
+
+
+@pytest.fixture
+def cstr(component_system):
+    unit = Cstr(component_system, name="test_cstr")
+    unit.const_solid_volume = const_solid_volume
+    unit.init_liquid_volume = init_liquid_volume
+    unit.flow_rate = 1
+    return unit
+
+
+@pytest.fixture
+def tubular_reactor(component_system):
+    unit = TubularReactor(component_system, name="test_tubular_reactor")
+    unit.length = length
+    unit.diameter = diameter
+    unit.axial_dispersion = axial_dispersion
+    return unit
+
+
+@pytest.fixture
+def lrm(component_system):
+    unit = LumpedRateModelWithoutPores(component_system, name="test_lrm")
+    unit.length = length
+    unit.diameter = diameter
+    unit.axial_dispersion = axial_dispersion
+    unit.total_porosity = total_porosity
+    return unit
+
+
+@pytest.fixture
+def lrmp(component_system):
+    unit = LumpedRateModelWithPores(component_system, name="test_lrmp")
+    unit.length = length
+    unit.diameter = diameter
+    unit.axial_dispersion = axial_dispersion
+    unit.bed_porosity = bed_porosity
+    unit.particle_radius = particle_radius
+    unit.particle_porosity = particle_porosity
+    unit.film_diffusion = film_diffusion
+    return unit
+
+
+@pytest.fixture
+def mct():
+    unit = MCT(ComponentSystem(1), nchannel=nchannel, name="test_mct")
+    unit.length = length
+    unit.channel_cross_section_areas = channel_cross_section_areas
+    unit.axial_dispersion = axial_dispersion
+    unit.exchange_matrix = exchange_matrix
+    return unit
+
+
+@pytest.fixture
+def grm(component_system):
+    unit = GeneralRateModel(component_system, name="test_grm")
+    unit.length = length
+    unit.diameter = diameter
+    unit.axial_dispersion = axial_dispersion
+    unit.bed_porosity = bed_porosity
+    unit.particle_radius = particle_radius
+    unit.particle_porosity = particle_porosity
+    unit.film_diffusion = film_diffusion
+    unit.pore_diffusion = pore_diffusion
+    return unit

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,18 @@
+import pytest
+
+from tests.integration.create_LWE import create_lwe
+
+
+@pytest.fixture
+def lwe_process():
+    return create_lwe()
+
+
+@pytest.fixture(params=[
+    "GeneralRateModel",
+    "LumpedRateModelWithoutPores",
+    "LumpedRateModelWithPores",
+    "Cstr",
+])
+def lwe_process_all_units(request):
+    return create_lwe(unit_type=request.param)

--- a/tests/processModel/test_unit_operation.py
+++ b/tests/processModel/test_unit_operation.py
@@ -1,15 +1,5 @@
 import numpy as np
 import pytest
-from CADETProcess.processModel import (
-    MCT,
-    ComponentSystem,
-    Cstr,
-    GeneralRateModel,
-    Inlet,
-    LumpedRateModelWithoutPores,
-    LumpedRateModelWithPores,
-    TubularReactor,
-)
 
 length = 0.6
 diameter = 0.024
@@ -39,81 +29,6 @@ exchange_matrix = np.array([
     [[0.0], [0.0], [0.0]]
 ])
 flow_direction = 1
-
-
-@pytest.fixture
-def component_system():
-    return ComponentSystem(2)
-
-
-@pytest.fixture
-def inlet(component_system):
-    return Inlet(component_system, name="test_inlet")
-
-
-@pytest.fixture
-def cstr(component_system):
-    cstr = Cstr(component_system, name="test_cstr")
-    cstr.const_solid_volume = const_solid_volume
-    cstr.init_liquid_volume = init_liquid_volume
-    cstr.flow_rate = 1
-    return cstr
-
-
-@pytest.fixture
-def tubular_reactor(component_system):
-    tubular_reactor = TubularReactor(component_system, name="test_tubular_reactor")
-    tubular_reactor.length = length
-    tubular_reactor.diameter = diameter
-    tubular_reactor.axial_dispersion = axial_dispersion
-    return tubular_reactor
-
-
-@pytest.fixture
-def lrm(component_system):
-    lrm = LumpedRateModelWithoutPores(component_system, name="test_lrm")
-    lrm.length = length
-    lrm.diameter = diameter
-    lrm.axial_dispersion = axial_dispersion
-    lrm.total_porosity = total_porosity
-    return lrm
-
-
-@pytest.fixture
-def lrmp(component_system):
-    lrmp = LumpedRateModelWithPores(component_system, name="test_lrmp")
-    lrmp.length = length
-    lrmp.diameter = diameter
-    lrmp.axial_dispersion = axial_dispersion
-    lrmp.bed_porosity = bed_porosity
-    lrmp.particle_radius = particle_radius
-    lrmp.particle_porosity = particle_porosity
-    lrmp.film_diffusion = [film_diffusion_0, film_diffusion_1]
-    return lrmp
-
-
-@pytest.fixture
-def grm(components=2):
-    grm = GeneralRateModel(ComponentSystem(components), name="test_grm")
-    grm.length = length
-    grm.diameter = diameter
-    grm.axial_dispersion = axial_dispersion
-    grm.bed_porosity = bed_porosity
-    grm.particle_radius = particle_radius
-    grm.particle_porosity = particle_porosity
-    grm.film_diffusion = [film_diffusion_0, film_diffusion_1]
-    grm.pore_diffusion = [pore_diffusion_0, pore_diffusion_1]
-    return grm
-
-
-@pytest.fixture
-def mct(components=1):
-    mct = MCT(ComponentSystem(components), nchannel=3, name="test_mct")
-    mct.length = length
-    mct.channel_cross_section_areas = channel_cross_section_areas
-    mct.axial_dispersion = axial_dispersion
-    mct.exchange_matrix = exchange_matrix
-    return mct
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Lifts repeated unit operation construction out of individual setUp() methods into a root conftest.py so all test modules can use them without rebuilding. Adds an integration/conftest.py with lwe_process fixtures for parametrised simulation tests.