### PR TITLE
Refactor ComponentSystem: drop Structure inheritance, rename molecular_weight

### DIFF
--- a/CADETProcess/processModel/componentSystem.py
+++ b/CADETProcess/processModel/componentSystem.py
@@ -1,65 +1,79 @@
+from __future__ import annotations
+
+import warnings
 from collections import defaultdict
-from functools import wraps
-from typing import Any, Iterator
+from dataclasses import dataclass
+from typing import Any, Iterator, Optional
 
 from addict import Dict
 
 from CADETProcess import CADETProcessError
-from CADETProcess.dataStructure import Integer, String, Structure, UnsignedFloat
+from CADETProcess.dataStructure import deprecated_alias
 
 __all__ = ["ComponentSystem", "Component", "Species"]
 
 
-class Species(Structure):
+@dataclass
+class Species:
     """
-    Species class.
-
-    Represent a species in a chemical system.
+    A specific chemical form of a component.
 
     Attributes
     ----------
     name : str
-        The name of the species.
-    charge : int, optional
-        The charge of the species. Default is 0.
-    molecular_weight : float
-        The molecular weight of the species.
-    density : float
-        Density of the species.
+        Name of the species.
+    charge : int
+        Charge of the species. Default is 0.
+    molar_mass : float, optional
+        Molar mass in kg/mol.
+    density : float, optional
+        Pure-component density in kg/m³.
     """
 
-    name: String = String()
-    charge: Integer = Integer(default=0)
-    molecular_weight: UnsignedFloat = UnsignedFloat()
-    density: UnsignedFloat = UnsignedFloat()
+    name: str
+    charge: int = 0
+    molar_mass: Optional[float] = None
+    density: Optional[float] = None
 
-    def __str__(self) -> str:
-        """str: String representation of the component."""
+    @property
+    def molecular_weight(self) -> Optional[float]:
+        """Deprecated. Use molar_mass."""
+        warnings.warn(
+            "`molecular_weight` is deprecated; use `molar_mass` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.molar_mass
+
+    @molecular_weight.setter
+    def molecular_weight(self, value: Optional[float]) -> None:
+        warnings.warn(
+            "`molecular_weight` is deprecated; use `molar_mass` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.molar_mass = value
+
+    def __str__(self) -> str:  # noqa: D105
         return self.name
 
 
-class Component(Structure):
+class Component:
     """
-    Information about single component.
+    A conserved chemical entity that may exist as multiple species.
 
-    A component can contain subspecies (e.g. differently charged variants).
-
-    Attributes
+    Parameters
     ----------
-    name : str | None
+    name : str, optional
         Name of the component.
-    species : list[Species]
-        List of Subspecies.
-    n_species : int
-        Number of Subspecies.
-    label : list[str]
-        Name of component (including species).
-    charge : int | list[int | None]
-        Charge of component (including species).
-    molecular_weight : float | list[float | None]
-        Molecular weight of component (including species).
-    density : float | list[float | None]
-        Density of component (including species).
+    species : str | list[str], optional
+        Name(s) of the subspecies. If None the component name is used.
+    charge : int | list[int | None], optional
+        Charge(s) of the subspecies.
+    molar_mass : float | list[float | None], optional
+        Molar mass(es) of the subspecies in kg/mol.
+    density : float | list[float | None], optional
+        Density(ies) of the subspecies in kg/m³.
 
     See Also
     --------
@@ -67,149 +81,147 @@ class Component(Structure):
     ComponentSystem
     """
 
-    name: String = String()
-
+    @deprecated_alias(molecular_weight="molar_mass")
     def __init__(
         self,
         name: str | None = None,
         species: str | list[str | None] = None,
         charge: int | list[int | None] = None,
-        molecular_weight: float | list[float | None] = None,
+        molar_mass: float | list[float | None] = None,
         density: float | list[float | None] = None,
     ) -> None:
-        """
-        Initialize Component.
-
-        Parameters
-        ----------
-        name : str | None
-            Name of the component.
-        species : str | list[str | None]
-            Name(s) of the subspecies to initialize. If None, the component's name is used.
-        charge : int | list [int | None]
-            Charges of the subspecies. Defaults to None for each species.
-        molecular_weight : float | list[float | None]
-            Molecular weights of the subspecies. Defaults to None for each species.
-        density : float | list[float | None]
-            Density of component (including species). Defaults to None for each species.
-        """
-        self.name: str | None = name
+        self.name = name
         self._species: list[Species] = []
 
         if species is None:
-            self.add_species(name, charge, molecular_weight, density)
+            self._add_species(name, charge, molar_mass, density)
         elif isinstance(species, str):
-            self.add_species(species, charge, molecular_weight, density)
+            self._add_species(species, charge, molar_mass, density)
         elif isinstance(species, list):
             if charge is None:
                 charge = len(species) * [None]
-            if molecular_weight is None:
-                molecular_weight = len(species) * [None]
+            if molar_mass is None:
+                molar_mass = len(species) * [None]
             if density is None:
                 density = len(species) * [None]
             for i, spec in enumerate(species):
-                self.add_species(spec, charge[i], molecular_weight[i], density[i])
+                self._add_species(spec, charge[i], molar_mass[i], density[i])
         else:
             raise CADETProcessError("Could not determine number of species")
 
-    @property
-    def species(self) -> list[Species]:
-        """list[Species]: The subspecies of the component."""
-        return self._species
+    def _add_species(
+        self,
+        name: str | None,
+        charge: int | None,
+        molar_mass: float | None,
+        density: float | None,
+    ) -> Species:
+        kwargs: dict[str, Any] = {}
+        if charge is not None:
+            kwargs["charge"] = charge
+        if molar_mass is not None:
+            kwargs["molar_mass"] = molar_mass
+        if density is not None:
+            kwargs["density"] = density
+        species = Species(name, **kwargs)
+        self._species.append(species)
+        return species
 
-    @wraps(Species.__init__)
     def add_species(
         self,
         species: str | Species,
-        *args: Any,
-        **kwargs: Any,
+        charge: int | None = None,
+        molar_mass: float | None = None,
+        density: float | None = None,
     ) -> Species:
         """
         Add a subspecies to the component.
 
         Parameters
         ----------
-        species: string | Species
-            Species to add
-        *args
-            Variable length argument list.
-        **kwargs
-            Arbitrary keyword arguments.
+        species : str | Species
+            Species or name of the species to add.
+        charge : int, optional
+            Charge of the species.
+        molar_mass : float, optional
+            Molar mass in kg/mol.
+        density : float, optional
+            Pure-component density in kg/m³.
 
         Returns
         -------
         Species
-            The subspecies that was added.
+            The added species.
         """
-        if not isinstance(species, Species):
-            species = Species(species, *args, **kwargs)
-        self._species.append(species)
-        return species
+        if isinstance(species, Species):
+            self._species.append(species)
+            return species
+        return self._add_species(species, charge, molar_mass, density)
+
+    @property
+    def species(self) -> list[Species]:
+        """list[Species]: The subspecies of the component."""
+        return self._species
 
     @property
     def n_species(self) -> int:
-        """int: The number of subspecies in the component."""
-        return len(self.species)
+        """int: Number of subspecies."""
+        return len(self._species)
 
     @property
     def label(self) -> list[str]:
-        """list[str]: The names of the subspecies."""
-        return [spec.name for spec in self.species]
+        """list[str]: Names of the subspecies."""
+        return [s.name for s in self._species]
 
     @property
     def charge(self) -> list[int | None]:
-        """list[int | None]: The charges of the subspecies."""
-        return [spec.charge for spec in self.species]
+        """list[int | None]: Charges of the subspecies."""
+        return [s.charge for s in self._species]
+
+    @property
+    def molar_mass(self) -> list[float | None]:
+        """list[float | None]: Molar masses of the subspecies in kg/mol."""
+        return [s.molar_mass for s in self._species]
 
     @property
     def molecular_weight(self) -> list[float | None]:
-        """list[float | None]: The molecular weights of the subspecies."""
-        return [spec.molecular_weight for spec in self.species]
+        """Deprecated. Use molar_mass."""
+        warnings.warn(
+            "`molecular_weight` is deprecated; use `molar_mass` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.molar_mass
 
     @property
     def density(self) -> list[float | None]:
-        """list[float | None]: The density of the subspecies."""
-        return [spec.density for spec in self.species]
+        """list[float | None]: Densities of the subspecies in kg/m³."""
+        return [s.density for s in self._species]
 
-    def __str__(self) -> str:
-        """str: String representation of the component."""
-        return self.name
+    def __str__(self) -> str:  # noqa: D105
+        return self.name if self.name is not None else ""
 
-    def __iter__(self) -> Iterator[Species]:
-        """Iterate over the subspecies of the component."""
-        yield from self.species
+    def __iter__(self) -> Iterator[Species]:  # noqa: D105
+        yield from self._species
 
 
-class ComponentSystem(Structure):
+class ComponentSystem:
     """
-    Information about components in system.
+    An ordered collection of components defining the chemical system.
 
-    A component can contain subspecies (e.g. differently charged variants).
-
-    Attributes
+    Parameters
     ----------
-    name : String
-        Name of the component system.
-    components : list[Component]
-        List of individual components.
-    n_species : int
-        Number of Subspecies.
-    n_comp : int
-        Number of all component species.
-    n_components : int
-        Number of components.
-    indices : dict[str, list[int]]
-        Component indices.
-    names : list[str]
-        Names of all components.
-    species : list[str]
-        Names of all component species.
-    charges : list[int | None]
-        Charges of all components species.
-    molecular_weights : list[float | None]
-        Molecular weights of all component species.
-    densities : list[float | None]
-        Densities of all component species.
+    components : int | list[str | Component], optional
+        Number of anonymous components, or an explicit list of names or
+        Component instances.
+    name : str, optional
+        Name of the system.
+    charges : list[int | None], optional
+        Charges per component.
+    molar_masses : list[float | None], optional
+        Molar masses per component in kg/mol.
+    densities : list[float | None], optional
+        Densities per component in kg/m³.
 
     See Also
     --------
@@ -217,39 +229,16 @@ class ComponentSystem(Structure):
     Component
     """
 
-    name: String = String()
-
+    @deprecated_alias(molecular_weights="molar_masses")
     def __init__(
         self,
         components: int | list[str | Component | None] = None,
         name: str | None = None,
         charges: list[int | None] = None,
-        molecular_weights: list[float | None] = None,
+        molar_masses: list[float | None] = None,
         densities: list[float | None] = None,
     ) -> None:
-        """
-        Initialize the ComponentSystem object.
-
-        Parameters
-        ----------
-        components : int | list[str | Component | None]
-            The number of components or the list of components to be added.
-            If None, no components are added.
-        name : str | None
-            The name of the ComponentSystem.
-        charges : list[int | None]
-            The charges of each component.
-        molecular_weights : list[float | None]
-            The molecular weights of each component.
-        densities : list[float | None]
-            The densities of each component.
-
-        Raises
-        ------
-        CADETProcessError
-            If the `components` argument is neither an int nor a list.
-        """
-        self.name: str | None = name
+        self.name = name
         self._components: list[Component] = []
 
         if components is None:
@@ -265,8 +254,8 @@ class ComponentSystem(Structure):
 
         if charges is None:
             charges = n_comp * [None]
-        if molecular_weights is None:
-            molecular_weights = n_comp * [None]
+        if molar_masses is None:
+            molar_masses = n_comp * [None]
         if densities is None:
             densities = n_comp * [None]
 
@@ -274,36 +263,35 @@ class ComponentSystem(Structure):
             self.add_component(
                 comp,
                 charge=charges[i],
-                molecular_weight=molecular_weights[i],
+                molar_mass=molar_masses[i],
                 density=densities[i],
             )
 
     @property
     def components(self) -> list[Component]:
-        """list[Component]: List of components in the system."""
+        """list[Component]: Components in the system."""
         return self._components
 
     @property
     def components_dict(self) -> dict[str, Component]:
         """dict[str, Component]: Components indexed by name."""
-        return {name: comp for name, comp in zip(self.names, self.components)}
+        return {name: comp for name, comp in zip(self.names, self._components)}
 
     @property
     def n_components(self) -> int:
         """int: Number of components."""
-        return len(self.components)
+        return len(self._components)
 
     @property
     def n_comp(self) -> int:
-        """int: Number of species."""
+        """int: Total number of species."""
         return self.n_species
 
     @property
     def n_species(self) -> int:
-        """int: Number of species."""
-        return sum([comp.n_species for comp in self.components])
+        """int: Total number of species."""
+        return sum(comp.n_species for comp in self._components)
 
-    @wraps(Component.__init__)
     def add_component(
         self,
         component: str | Component,
@@ -316,11 +304,9 @@ class ComponentSystem(Structure):
         Parameters
         ----------
         component : str | Component
-            The component instance or name of the component to be added.
-        *args : Any
-            The positional arguments to be passed to the component class's constructor.
-        **kwargs : Any
-            The keyword arguments to be passed to the component class's constructor.
+            Component instance or name of the component to add.
+        *args, **kwargs
+            Passed to Component constructor when component is a string.
         """
         if not isinstance(component, Component):
             component = Component(component, *args, **kwargs)
@@ -339,12 +325,7 @@ class ComponentSystem(Structure):
         Parameters
         ----------
         component : str | Component
-            The name of the component or the component instance to be removed.
-
-        Raises
-        ------
-        CADETProcessError
-            If the component is unknown or not present in the system.
+            Name or instance of the component to remove.
         """
         if isinstance(component, str):
             try:
@@ -352,102 +333,85 @@ class ComponentSystem(Structure):
             except KeyError:
                 raise CADETProcessError("Unknown Component.")
 
-        if component not in self.components:
+        if component not in self._components:
             raise CADETProcessError("Unknown Component.")
 
         self._components.remove(component)
 
     @property
     def indices(self) -> dict[str, list[int]]:
-        """dict[str, list[int]]: List of species indices for each component name."""
+        """dict[str, list[int]]: Species indices per component name."""
         indices = defaultdict(list)
-
         index = 0
-        for comp in self.components:
-            for spec in comp.species:
+        for comp in self._components:
+            for _ in comp.species:
                 indices[comp.name].append(index)
                 index += 1
-
         return Dict(indices)
 
     @property
     def species_indices(self) -> dict[str, int]:
-        """dict[str, int]: Indices for each species."""
+        """dict[str, int]: Index per species name."""
         indices = Dict()
-
         index = 0
-        for comp in self.components:
+        for comp in self._components:
             for spec in comp.species:
                 indices[spec.name] = index
                 index += 1
-
         return indices
 
     @property
     def names(self) -> list[str]:
-        """list[str]: List of component names."""
-        names = [
+        """list[str]: Component names."""
+        return [
             comp.name if comp.name is not None else str(i)
-            for i, comp in enumerate(self.components)
+            for i, comp in enumerate(self._components)
         ]
-
-        return names
 
     @property
     def species(self) -> list[str]:
-        """list[str]: List of species names."""
-        species = []
+        """list[str]: Species names in order."""
+        result = []
         index = 0
-        for comp in self.components:
+        for comp in self._components:
             for label in comp.label:
-                if label is None:
-                    species.append(str(index))
-                else:
-                    species.append(label)
-
+                result.append(label if label is not None else str(index))
                 index += 1
-
-        return species
+        return result
 
     @property
     def charges(self) -> list[int | None]:
-        """list[int | None]: List of species charges."""
-        charges = []
-        for comp in self.components:
-            charges += comp.charge
+        """list[int | None]: Charges per species."""
+        return [charge for comp in self._components for charge in comp.charge]
 
-        return charges
+    @property
+    def molar_masses(self) -> list[float | None]:
+        """list[float | None]: Molar masses per species in kg/mol."""
+        return [mm for comp in self._components for mm in comp.molar_mass]
 
     @property
     def molecular_weights(self) -> list[float | None]:
-        """list[float | None]: List of species molecular weights."""
-        molecular_weights = []
-        for comp in self.components:
-            molecular_weights += comp.molecular_weight
-
-        return molecular_weights
+        """Deprecated. Use molar_masses."""
+        warnings.warn(
+            "`molecular_weights` is deprecated; use `molar_masses` instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return self.molar_masses
 
     @property
     def densities(self) -> list[float | None]:
-        """list[float | None]: List of species densities."""
-        densities = []
-        for comp in self.components:
-            densities += comp.density
+        """list[float | None]: Densities per species in kg/m³."""
+        return [density for comp in self._components for density in comp.density]
 
-        return densities
+    def __repr__(self) -> str:  # noqa: D105
+        return f"{self.__class__.__name__}({self.names!r})"
 
-    def __repr__(self) -> str:
-        """str: Return the string representation of the object."""
-        return f"{self.__class__.__name__}({self.names})"
-
-    def __len__(self) -> int:
-        """int: Return the number of components in the system."""
+    def __len__(self) -> int:  # noqa: D105
         return self.n_comp
 
-    def __iter__(self) -> Iterator[Component]:
-        """Iterate over components in the system."""
-        yield from self.components
+    def __iter__(self) -> Iterator[Component]:  # noqa: D105
+        yield from self._components
 
-    def __getitem__(self, item: int) -> Component:
-        """Component: Retrieve a component by its index."""
+    def __getitem__(self, item: int) -> Component:  # noqa: D105
         return self._components[item]

--- a/tests/processModel/test_components.py
+++ b/tests/processModel/test_components.py
@@ -34,7 +34,7 @@ class TestComponents(unittest.TestCase):
 
         self.component_system_5 = ComponentSystem()
         self.component_system_5.add_component(
-            "A", species=["A+", "A-"], molecular_weight=[1, 0]
+            "A", species=["A+", "A-"], molar_mass=[1, 0]
         )
 
         self.component_system_6 = ComponentSystem()
@@ -117,10 +117,16 @@ class TestComponents(unittest.TestCase):
         charges = self.component_system_3.charges
         np.testing.assert_equal(charges_expected, charges)
 
-    def test_molecular_weights(self):
-        molecular_weights_expected = [1, 0]
-        molecular_weights = self.component_system_5.molecular_weights
-        np.testing.assert_equal(molecular_weights_expected, molecular_weights)
+    def test_molar_masses(self):
+        molar_masses_expected = [1, 0]
+        molar_masses = self.component_system_5.molar_masses
+        np.testing.assert_equal(molar_masses_expected, molar_masses)
+
+    def test_molecular_weights_deprecated(self):
+        with self.assertWarns(DeprecationWarning):
+            ComponentSystem(["A"], molecular_weights=[1.0])
+        with self.assertWarns(DeprecationWarning):
+            _ = self.component_system_5.molecular_weights
 
     def test_densities(self):
         densities_expected = [1, 0]


### PR DESCRIPTION
Species, Component, and ComponentSystem inherited from Structure, but the adapter never called `.parameters` on them; the descriptor machinery was dead weight. Species is now a dataclass; the other two are plain classes. `molecular_weight` / `molecular_weights` are renamed to `molar_mass` / `molar_masses` (SI, kg/mol) with deprecated aliases.