### PR TITLE
Fix autosummary page explosion in docs build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@ __pycache__/
 docs/source/reference/generated/*
 docs/build/*
 docs/jupyter_execute/*
+docs/source/jupyter_execute/
 docs/source/reference/generated/*
 docs/source/examples/
 debug*

--- a/CADETProcess/plotting.py
+++ b/CADETProcess/plotting.py
@@ -16,9 +16,6 @@ General Utils
     get_fig_size
     setup_figure
     get_all_twin_handles_labels
-    show_or_reopen
-    style_and_save_figure
-
 Secondary Axis
 ==============
 

--- a/CADETProcess/simulator/__init__.py
+++ b/CADETProcess/simulator/__init__.py
@@ -53,4 +53,14 @@ After simulation, the ``Simulator`` returns a ``SimulationResults`` object.
 """
 
 from .simulator import SimulatorBase
-from .cadetAdapter import Cadet
+from .cadetAdapter import (
+    Cadet,
+    ModelSolverParameters,
+    UnitParameters,
+    AdsorptionParameters,
+    ReactionParameters,
+    SolverParameters,
+    SolverTimeIntegratorParameters,
+    ReturnParameters,
+    SensitivityParameters,
+)

--- a/docs/source/_templates/autosummary/class.rst
+++ b/docs/source/_templates/autosummary/class.rst
@@ -4,35 +4,6 @@
 .. currentmodule:: {{ module }}
 
 .. autoclass:: {{ objname }}
-   :no-members:
-   :no-inherited-members:
-   :no-special-members:
-
-  {% block methods %}
-   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-      .. autosummary::
-         :toctree:
-      {% for item in all_methods %}
-         {%- if not item.startswith('_') or item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-      {% for item in inherited_members %}
-         {%- if item in ['__call__', '__mul__', '__getitem__', '__len__'] %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-  {% endblock %}
-
-  {% block attributes %}
-  {% if attributes %}
-   .. HACK -- the point here is that we don't want this to appear in the output, but the autosummary should still generate the pages.
-      .. autosummary::
-         :toctree:
-      {% for item in all_attributes %}
-         {%- if not item.startswith('_') %}
-         {{ name }}.{{ item }}
-         {%- endif -%}
-      {%- endfor %}
-  {% endif %}
-  {% endblock %}
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -47,6 +47,7 @@ source_suffix = {
 ## Numpydoc
 extensions.append("numpydoc")
 numpydoc_class_members_toctree = False
+numpydoc_show_class_members = False
 
 ## Autodoc
 extensions.append("sphinx.ext.autodoc")


### PR DESCRIPTION
Per-member autosummary pages made the reference unbrowsable (3207 files) and were the primary docs build cost.