### PR TITLE
Decouple Fractionator from SimulationResults

### DIFF
--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -300,6 +300,7 @@ class FractionationOptimizer:
         ignore_failed: bool = False,
         return_optimization_results: bool = False,
         save_results: bool = False,
+        c_min: Optional[float] = None,
     ) -> Fractionator | tuple[Fractionator, OptimizationResults]:
         """
         Optimize the fractionation times with respect to purity constraints.
@@ -346,6 +347,11 @@ class FractionationOptimizer:
             The default is False.
         save_results : bool, optional
             If True, save optimization results. The default is False.
+        c_min : float, optional
+            Minimum total concentration below which purity is set to NaN.
+            Overrides the per-chromatogram ``c_min`` attribute for all chromatograms
+            passed to this call. If None, each chromatogram's existing value is used
+            (default 1e-6).
 
         Returns
         -------
@@ -395,6 +401,10 @@ class FractionationOptimizer:
 
         if len(chromatograms) == 0:
             raise CADETProcessError("No chromatograms provided.")
+
+        if c_min is not None:
+            for chrom in chromatograms:
+                chrom.c_min = c_min
 
         # Convert inputs to lists of length n_comp
         n_comp = (

--- a/CADETProcess/fractionation/fractionationOptimizer.py
+++ b/CADETProcess/fractionation/fractionationOptimizer.py
@@ -14,7 +14,9 @@ from CADETProcess.optimization import (
     compute_initial_radius,
 )
 from CADETProcess.performance import Mass, Performance, Purity
+from CADETProcess.processModel.process import ProcessMeta
 from CADETProcess.simulationResults import SimulationResults
+from CADETProcess.solution import SolutionIO
 
 __all__ = ["FractionationOptimizer"]
 
@@ -100,7 +102,8 @@ class FractionationOptimizer:
 
     def _setup_fractionator(
         self,
-        simulation_results: SimulationResults,
+        chromatograms: list[SolutionIO],
+        process_meta: ProcessMeta,
         purity_required: list[float],
         components: Optional[list] = None,
         use_total_concentration_components: bool = True,
@@ -111,8 +114,10 @@ class FractionationOptimizer:
 
         Parameters
         ----------
-        simulation_results: object
-            Simulation results to be used for setting up the Fractionator object.
+        chromatograms : list of SolutionIO
+            Chromatograms to be fractionated.
+        process_meta : ProcessMeta
+            Process meta information (cycle time, volumes, feed masses).
         purity_required : list of floats
             Minimum purity required for the components in the fractionation.
         components: list, optional
@@ -128,7 +133,8 @@ class FractionationOptimizer:
             The Fractionator object that has been set up using the provided arguments.
         """
         frac = Fractionator(
-            simulation_results,
+            chromatograms,
+            process_meta,
             components=components,
             use_total_concentration_components=use_total_concentration_components,
         )
@@ -279,8 +285,9 @@ class FractionationOptimizer:
 
     def optimize_fractionation(
         self,
-        simulation_results: SimulationResults,
+        simulation_results: SimulationResults | SolutionIO | list[SolutionIO],
         purity_required: float | list[float],
+        process_meta: Optional[ProcessMeta] = None,
         components: Optional[list[str]] = None,
         use_total_concentration_components: bool = True,
         ranking: str | list[float] | int = "equal",
@@ -364,16 +371,35 @@ class FractionationOptimizer:
         CADETProcess.optimization.OptimizationProblem
         CADETProcess.optimization.OptimizerBase
         """
-        if not isinstance(simulation_results, SimulationResults):
-            raise TypeError("Expected SimulationResults.")
+        # Resolve chromatograms and process_meta from whatever was passed.
+        _process = None
+        if isinstance(simulation_results, SimulationResults):
+            if len(simulation_results.chromatograms) == 0:
+                raise CADETProcessError("Simulation results do not contain chromatogram.")
+            chromatograms = simulation_results.chromatograms
+            process_meta = simulation_results.process.process_meta
+            _process = simulation_results.process  # for lock management
+        elif isinstance(simulation_results, SolutionIO):
+            chromatograms = [simulation_results]
+        elif isinstance(simulation_results, list):
+            chromatograms = simulation_results
+        else:
+            raise TypeError(
+                "Expected SimulationResults, SolutionIO, or list of SolutionIO."
+            )
 
-        if len(simulation_results.chromatograms) == 0:
-            raise CADETProcessError("Simulation results do not contain chromatogram.")
+        if process_meta is None:
+            raise TypeError(
+                "process_meta is required when not passing SimulationResults."
+            )
+
+        if len(chromatograms) == 0:
+            raise CADETProcessError("No chromatograms provided.")
 
         # Convert inputs to lists of length n_comp
         n_comp = (
             len(components) if components
-            else simulation_results.component_system.n_comp
+            else chromatograms[0].component_system.n_comp
         )
         if isinstance(purity_required, float):
             purity_required = n_comp * [purity_required]
@@ -391,11 +417,13 @@ class FractionationOptimizer:
                 ranking[i] = 0.0
 
         # Store previous lock state, unlock to ensure consistent values
-        lock_state = simulation_results.process.lock
-        simulation_results.process.lock = False
+        lock_state = _process.lock if _process is not None else None
+        if _process is not None:
+            _process.lock = False
 
         frac = self._setup_fractionator(
-            simulation_results,
+            chromatograms,
+            process_meta,
             purity_required,
             components=components,
             use_total_concentration_components=use_total_concentration_components,
@@ -427,7 +455,8 @@ class FractionationOptimizer:
                 self.optimizer.tol = min(0.5 * self.optimizer.rhobeg, self.optimizer.tol)
 
         # Lock to enable caching
-        simulation_results.process.lock = True
+        if _process is not None:
+            _process.lock = True
 
         try:
             results = self.optimizer.optimize(
@@ -451,7 +480,8 @@ class FractionationOptimizer:
                 raise CADETProcessError(message)
         finally:
             # Restore previous lock state
-            simulation_results.process.lock = lock_state
+            if _process is not None:
+                _process.lock = lock_state
 
         if return_optimization_results:
             return results

--- a/CADETProcess/fractionation/fractionator.py
+++ b/CADETProcess/fractionation/fractionator.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 from collections import defaultdict
 from functools import wraps
 from typing import Any, Callable, Optional
@@ -12,8 +13,7 @@ from CADETProcess.dataStructure import String
 from CADETProcess.dynamicEvents import Event, EventHandler
 from CADETProcess.fractionation.fractions import Fraction, FractionPool
 from CADETProcess.performance import Performance
-from CADETProcess.processModel import ComponentSystem, Process, ProcessMeta
-from CADETProcess.simulationResults import SimulationResults
+from CADETProcess.processModel import ComponentSystem, ProcessMeta
 from CADETProcess.solution import SolutionIO, slice_solution
 
 __all__ = ["Fractionator"]
@@ -47,7 +47,8 @@ class Fractionator(EventHandler):
 
     def __init__(
         self,
-        simulation_results: SimulationResults,
+        chromatograms: SolutionIO | list[SolutionIO],
+        process_meta: Optional[ProcessMeta] = None,
         components: Optional[list[str]] = None,
         use_total_concentration_components: bool = True,
         *args: Any,
@@ -58,68 +59,64 @@ class Fractionator(EventHandler):
 
         Parameters
         ----------
-        simulation_results : SimulationResults
-            Simulation results containing chromatograms.
+        chromatograms : SolutionIO or list of SolutionIO
+            Chromatograms to be fractionated.
+        process_meta : ProcessMeta
+            Process meta information (cycle time, volumes, feed masses).
         components : list, optional
-            List of components to be fractionated. Default is None.
+            List of components to consider. Default is None (all components).
         use_total_concentration_components : bool, optional
-            Use total concentration components. Default is True.
+            Sum species into component concentrations. Default is True.
         *args
             Variable length argument list.
         **kwargs
             Arbitrary keyword arguments.
         """
+        # Deprecation shim: accept SimulationResults for backward compatibility.
+        from CADETProcess.simulationResults import SimulationResults
+        if isinstance(chromatograms, SimulationResults):
+            warnings.warn(
+                "Passing SimulationResults to Fractionator is deprecated. "
+                "Pass chromatograms and process_meta directly.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            sim = chromatograms
+            process_meta = sim.process.process_meta
+            chromatograms = sim.chromatograms
+
+        if process_meta is None:
+            raise TypeError(
+                "process_meta is required when not passing SimulationResults."
+            )
+
+        if isinstance(chromatograms, SolutionIO):
+            chromatograms = [chromatograms]
+
+        if len(chromatograms) == 0:
+            raise CADETProcessError("No chromatograms provided.")
+
         self.components: Optional[list[str]] = components
         self.use_total_concentration_components: bool = use_total_concentration_components
-        self.simulation_results = simulation_results
+        self._process_meta: ProcessMeta = process_meta
 
-        super().__init__(*args, **kwargs)
-
-    @property
-    def simulation_results(self) -> SimulationResults:
-        """SimulationResults: The simulation results containing the chromatograms."""
-        return self._simulation_results
-
-    @simulation_results.setter
-    def simulation_results(self, simulation_results: SimulationResults) -> None:
-        """
-        Set the simulation results.
-
-        Parameters
-        ----------
-        simulation_results : SimulationResults
-            Simulation results containing chromatograms.
-
-        Raises
-        ------
-        TypeError
-            If simulation_results is not of type SimulationResults.
-        CADETProcessError
-            If the simulation results do not contain any chromatograms.
-        """
-        if not isinstance(simulation_results, SimulationResults):
-            raise TypeError("Expected SimulationResults")
-
-        if len(simulation_results.chromatograms) == 0:
-            raise CADETProcessError("Simulation results do not contain chromatogram")
-
-        self._simulation_results = simulation_results
+        full_component_system = chromatograms[0].component_system
 
         self._chromatograms = [
             slice_solution(
                 chrom,
-                components=self.components,
-                use_total_concentration_components=self.use_total_concentration_components,
+                components=components,
+                use_total_concentration_components=use_total_concentration_components,
             )
-            for chrom in simulation_results.chromatograms
+            for chrom in chromatograms
         ]
 
         m_feed = np.zeros((self.component_system.n_comp,))
         counter = 0
-        for comp, indices in simulation_results.component_system.indices.items():
+        for comp, indices in full_component_system.indices.items():
             if comp in self.component_system.names:
-                m_feed_comp = simulation_results.process.m_feed[indices]
-                if self.use_total_concentration_components:
+                m_feed_comp = np.asarray(process_meta.m_feed)[np.array(indices)]
+                if use_total_concentration_components:
                     m_feed[counter] = np.sum(m_feed_comp)
                     counter += 1
                 else:
@@ -134,6 +131,8 @@ class Fractionator(EventHandler):
         self._chromatogram_events = Dict({chrom: [] for chrom in self.chromatograms})
 
         self.reset()
+
+        super().__init__(*args, **kwargs)
 
     @property
     def component_system(self) -> ComponentSystem:
@@ -196,14 +195,9 @@ class Fractionator(EventHandler):
         return chrom_events
 
     @property
-    def process(self) -> Process:
-        """Process: The process from the simulation results."""
-        return self.simulation_results.process
-
-    @property
     def process_meta(self) -> ProcessMeta:
         """ProcessMeta: Process meta information."""
-        return self.simulation_results.process_meta
+        return self._process_meta
 
     @property
     def n_comp(self) -> int:

--- a/docs/source/release_notes/v0.13.0.md
+++ b/docs/source/release_notes/v0.13.0.md
@@ -1,0 +1,22 @@
+# v0.13.0
+
+## Highlights
+
+### Docs: reference section rebuilt ([#386](https://github.com/fau-advanced-separations/CADET-Process/pull/386))
+
+The autosummary template was generating one page per class member, producing ~3200 files and making the reference section unusable.
+Switching to `autoclass :members:` with `numpydoc_show_class_members = False` reduces the output to ~370 pages, with all member docs rendered inline on the class page.
+
+### Fractionation improvements ([#387](https://github.com/fau-advanced-separations/CADET-Process/pull/387))
+
+- `Fractionator` and `FractionationOptimizer` decoupled from `SimulationResults`: both now accept `(chromatograms, process_meta)` directly.
+  Passing `SimulationResults` still works with a `DeprecationWarning`.
+  `optimize_fractionation` also gains a `c_min` keyword to set the minimum total concentration below which purity is considered undefined, overriding each chromatogram's default per call (closes #56).
+
+
+## Other changes
+
+- Fractionation optimizer test suite added: synthetic chromatogram fixtures cover eight separation regimes plus infeasibility, recovery monotonicity, and multi-outlet fractionation; no CADET-Core required ([#279](https://github.com/fau-advanced-separations/CADET-Process/pull/279))
+- Test suite restructured to mirror package layout; shared fixtures moved to `conftest.py` ([#378](https://github.com/fau-advanced-separations/CADET-Process/pull/378), [#379](https://github.com/fau-advanced-separations/CADET-Process/pull/379))
+- Coverage baseline established at 73% (2026-05-16)
+- Docs CI check added (`.github/workflows/docs.yml`); runs on all PRs with `nb_execution_mode=off`

--- a/docs/source/user_guide/process_evaluation/fractionation.md
+++ b/docs/source/user_guide/process_evaluation/fractionation.md
@@ -122,11 +122,14 @@ mystnb:
 _ = simulation_results.solution.outlet.outlet.plot()
 ```
 
-After import, the {class}`~CADETProcess.fractionation.Fractionator` is instantiated with the simulation results.
+After import, the {class}`~CADETProcess.fractionation.Fractionator` is instantiated with the chromatograms and process metadata extracted from the simulation results.
 
 ```{code-cell} ipython3
 from CADETProcess.fractionation import Fractionator
-fractionator = Fractionator(simulation_results)
+fractionator = Fractionator(
+    simulation_results.chromatograms,
+    simulation_results.process.process_meta,
+)
 ```
 
 To add a fractionation event, the following arguments need to be provided:

--- a/tests/fractionation/conftest.py
+++ b/tests/fractionation/conftest.py
@@ -3,51 +3,22 @@ import pytest
 from CADETProcess.fractionation import FractionationOptimizer
 from CADETProcess.processModel import ComponentSystem
 from CADETProcess.processModel.process import ProcessMeta
-from CADETProcess.simulationResults import SimulationResults
 
 from tests.chromatogram_factory import gaussian_chromatogram, rectangle_chromatogram
 
 
-def _make_simulation_results(chromatograms, m_feed=None):
-    """Construct a SimulationResults from synthetic chromatograms.
-
-    Uses a minimal process stub so no CADET simulation is required.
-    """
+def _make_fractionation_results(chromatograms, m_feed=None):
+    """Pair chromatograms with a ProcessMeta for Fractionator construction."""
     cs = chromatograms[0].component_system
     if m_feed is None:
         m_feed = np.ones(cs.n_comp)
-
     process_meta = ProcessMeta(
         cycle_time=chromatograms[0].cycle_time,
         V_eluent=1.0,
         V_solid=1.0,
         m_feed=m_feed,
     )
-
-    class _ProcessStub:
-        def __init__(self):
-            self.component_system = cs
-            self.m_feed = m_feed
-            self.lock = False
-
-        @property
-        def process_meta(self):
-            return process_meta
-
-    solution_cycles = {"outlet": {"solution_outlet": [chromatograms[0]]}}
-
-    return SimulationResults(
-        solver_name="test",
-        solver_parameters={},
-        exit_flag=0,
-        exit_message="",
-        time_elapsed=0.0,
-        process=_ProcessStub(),
-        solution_cycles=solution_cycles,
-        sensitivity_cycles={},
-        system_state={},
-        chromatograms=chromatograms,
-    )
+    return chromatograms, process_meta
 
 
 @pytest.fixture
@@ -64,19 +35,19 @@ def simulation_results(request):
 @pytest.fixture
 def single_component_wide_peak():
     cs = ComponentSystem(1)
-    return _make_simulation_results([rectangle_chromatogram(cs, [[(3, 7)]])])
+    return _make_fractionation_results([rectangle_chromatogram(cs, [[(3, 7)]])])
 
 
 @pytest.fixture
 def single_component_two_peaks():
     cs = ComponentSystem(1)
-    return _make_simulation_results([rectangle_chromatogram(cs, [[(2, 4), (7, 9)]])])
+    return _make_fractionation_results([rectangle_chromatogram(cs, [[(2, 4), (7, 9)]])])
 
 
 @pytest.fixture
 def two_components_separated():
     cs = ComponentSystem(2)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [rectangle_chromatogram(cs, [[(2, 4)], [(7, 9)]])],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -85,7 +56,7 @@ def two_components_separated():
 @pytest.fixture
 def two_components_touching():
     cs = ComponentSystem(2)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [rectangle_chromatogram(cs, [[(2, 5)], [(5, 7)]])],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -94,7 +65,7 @@ def two_components_touching():
 @pytest.fixture
 def two_components_overlapping():
     cs = ComponentSystem(2)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [rectangle_chromatogram(cs, [[(2, 5.1)], [(5, 7)]])],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -103,7 +74,7 @@ def two_components_overlapping():
 @pytest.fixture
 def two_components_gaussian_separated():
     cs = ComponentSystem(2)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [gaussian_chromatogram(cs, [(3, 0.5), (7, 0.5)])],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -112,7 +83,7 @@ def two_components_gaussian_separated():
 @pytest.fixture
 def two_components_gaussian_close():
     cs = ComponentSystem(2)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [gaussian_chromatogram(cs, [(4, 1.0), (6, 1.0)])],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -122,7 +93,7 @@ def two_components_gaussian_close():
 def two_components_fully_overlapping():
     """Both components elute at identical times; purity ceiling is 0.5."""
     cs = ComponentSystem(2)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [rectangle_chromatogram(cs, [[(3, 7)], [(3, 7)]])],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -133,7 +104,7 @@ def two_components_separated_mass_matched():
     """Separated peaks with m_feed equal to peak integrals for recovery assertions."""
     cs = ComponentSystem(2)
     # peaks [2,4] and [7,9]: width 2, height 1.0, flow 1.0 → mass ≈ 2.0 each
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [rectangle_chromatogram(cs, [[(2, 4)], [(7, 9)]])],
         m_feed=np.array([2.0, 2.0]),
     )
@@ -144,7 +115,7 @@ def two_components_overlapping_mass_matched():
     """Overlapping peaks with m_feed matching integrals for recovery assertions."""
     cs = ComponentSystem(2)
     # comp0: [2, 5.1] width ≈ 3.1; comp1: [5, 7] width 2.0
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [rectangle_chromatogram(cs, [[(2, 5.1)], [(5, 7)]])],
         m_feed=np.array([3.1, 2.0]),
     )
@@ -156,7 +127,7 @@ def two_outlets_two_components():
     cs = ComponentSystem(2)
     chrom_a = rectangle_chromatogram(cs, [[(2, 4)], [(7, 9)]])
     chrom_b = rectangle_chromatogram(cs, [[(2, 4)], [(7, 9)]], name="outlet_b")
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [chrom_a, chrom_b],
         m_feed=np.array([1.0, 1.0]),
     )
@@ -165,7 +136,7 @@ def two_outlets_two_components():
 @pytest.fixture
 def three_components_gaussian_separated():
     cs = ComponentSystem(3)
-    return _make_simulation_results(
+    return _make_fractionation_results(
         [gaussian_chromatogram(cs, [(2.5, 0.4), (5, 0.4), (7.5, 0.4)])],
         m_feed=np.array([1.0, 1.0, 1.0]),
     )

--- a/tests/fractionation/test_fractionation_optimizer.py
+++ b/tests/fractionation/test_fractionation_optimizer.py
@@ -23,7 +23,10 @@ from CADETProcess import CADETProcessError
     "three_components_gaussian_separated",
 ], indirect=["simulation_results"])
 def test_purity_requirement_met(simulation_results, purity_required, optimizer):
-    frac = optimizer.optimize_fractionation(simulation_results, purity_required)
+    chromatograms, process_meta = simulation_results
+    frac = optimizer.optimize_fractionation(
+        chromatograms, purity_required, process_meta=process_meta
+    )
     purity = frac.performance.purity
     np.testing.assert_array_less(
         np.array(purity_required) - 1e-3,
@@ -33,14 +36,14 @@ def test_purity_requirement_met(simulation_results, purity_required, optimizer):
 
 
 def test_infeasible_raises(optimizer, two_components_fully_overlapping):
+    chromatograms, process_meta = two_components_fully_overlapping
     with pytest.raises(CADETProcessError):
-        optimizer.optimize_fractionation(two_components_fully_overlapping, [0.95, 0.95])
+        optimizer.optimize_fractionation(chromatograms, [0.95, 0.95], process_meta=process_meta)
 
 
 def test_recovery_bounded(optimizer, two_components_separated_mass_matched):
-    frac = optimizer.optimize_fractionation(
-        two_components_separated_mass_matched, [0.95, 0.95]
-    )
+    chromatograms, process_meta = two_components_separated_mass_matched
+    frac = optimizer.optimize_fractionation(chromatograms, [0.95, 0.95], process_meta=process_meta)
     recovery = frac.performance.recovery
     assert np.all(recovery >= 0), f"Negative recovery: {recovery}"
     assert np.all(recovery <= 1 + 1e-4), f"Recovery exceeds 1: {recovery}"
@@ -51,12 +54,10 @@ def test_recovery_reduced_by_overlap(
     two_components_separated_mass_matched,
     two_components_overlapping_mass_matched,
 ):
-    frac_sep = optimizer.optimize_fractionation(
-        two_components_separated_mass_matched, [0.95, 0.95]
-    )
-    frac_ov = optimizer.optimize_fractionation(
-        two_components_overlapping_mass_matched, [0.95, 0.95]
-    )
+    chroms_sep, pm_sep = two_components_separated_mass_matched
+    chroms_ov, pm_ov = two_components_overlapping_mass_matched
+    frac_sep = optimizer.optimize_fractionation(chroms_sep, [0.95, 0.95], process_meta=pm_sep)
+    frac_ov = optimizer.optimize_fractionation(chroms_ov, [0.95, 0.95], process_meta=pm_ov)
     recovery_sep = frac_sep.performance.recovery
     recovery_ov = frac_ov.performance.recovery
     assert np.all(recovery_sep >= recovery_ov - 1e-3), (
@@ -69,7 +70,10 @@ def test_recovery_reduced_by_overlap(
     ("two_components_gaussian_separated", [0.95, 0.95]),
 ], ids=["separated", "gaussian_separated"], indirect=["simulation_results"])
 def test_productivity_and_eluent_nonnegative(simulation_results, purity_required, optimizer):
-    frac = optimizer.optimize_fractionation(simulation_results, purity_required)
+    chromatograms, process_meta = simulation_results
+    frac = optimizer.optimize_fractionation(
+        chromatograms, purity_required, process_meta=process_meta
+    )
     perf = frac.performance
     assert np.all(perf.productivity >= 0), f"Negative productivity: {perf.productivity}"
     assert np.all(perf.eluent_consumption >= 0), (
@@ -78,7 +82,8 @@ def test_productivity_and_eluent_nonnegative(simulation_results, purity_required
 
 
 def test_multi_outlet_fractionation(optimizer, two_outlets_two_components):
-    frac = optimizer.optimize_fractionation(two_outlets_two_components, [0.95, 0.95])
+    chromatograms, process_meta = two_outlets_two_components
+    frac = optimizer.optimize_fractionation(chromatograms, [0.95, 0.95], process_meta=process_meta)
     purity = frac.performance.purity
     np.testing.assert_array_less(
         np.array([0.95, 0.95]) - 1e-3,


### PR DESCRIPTION
`Fractionator.__init__` previously required a `SimulationResults` object, forcing tests and notebooks to construct a full process just to fractionate a chromatogram. The primary signature is now `(chromatograms, process_meta)`, accepting a `SolutionIO`, a list, or a `ProcessMeta` dataclass directly. Passing `SimulationResults` still works but emits a `DeprecationWarning`.

`FractionationOptimizer.optimize_fractionation` gains the same flexibility, accepting `SimulationResults | SolutionIO | list[SolutionIO]` as its first argument, with `process_meta` required as a keyword when not inferred from `SimulationResults`.

A `c_min` keyword is also added to set the minimum total concentration below which purity is considered undefined, overriding each chromatogram's default per call (closes #56).