### PR TITLE
Fix deepcopy failure with scipy 1.18 interpolation objects

### DIFF
--- a/CADETProcess/dynamicEvents/section.py
+++ b/CADETProcess/dynamicEvents/section.py
@@ -326,6 +326,18 @@ class TimeLine:
         """list: scipy.interpolate.PPoly for each dimension."""
         return self._piecewise_poly
 
+    def __getstate__(self) -> dict:
+        """Return pickle state, excluding the derived piecewise polynomial cache."""
+        return {"_sections": self._sections}
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore from pickle state and rebuild the piecewise polynomial cache."""
+        self._sections = state["_sections"]
+        if self._sections:
+            self.update_piecewise_poly()
+        else:
+            self._piecewise_poly = []
+
     def value(self, time: float) -> np.ndarray:
         """
         np.ndarray: Value of parameter at given time.

--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -287,6 +287,17 @@ class SolutionIO(SolutionBase):
         self.update_transform()
         self.flow_rate = self.flow_rate.slice(self.time[0], self.time[-1])
 
+    def __getstate__(self) -> dict:
+        """Return pickle state, excluding interpolation caches."""
+        state = self.__dict__.copy()
+        state["_solution_interpolated"] = None
+        state["_dm_dt_interpolated"] = None
+        return state
+
+    def __setstate__(self, state: dict) -> None:
+        """Restore from pickle state; caches are recomputed lazily on next access."""
+        self.__dict__.update(state)
+
     @property
     def derivative(self) -> "SolutionIO":
         """SolutionIO: Derivative of this solution."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
     "pathos>=0.2.8",
     "psutil>=5.9.8",
     "pymoo>=0.6",
-    "scipy>=1.14",
+    "scipy>=1.14,<1.18",
 ]
 
 [dependency-groups]


### PR DESCRIPTION
scipy 1.18.0 added `_xp` and `_xp_internal` (Array API dispatch) as module-object instance attributes on `PPoly`, `PchipInterpolator`, and related classes. Module objects are not picklable, so `copy.deepcopy` now fails for any object that transitively holds a scipy interpolator — breaking `ReferenceIO` construction, `SolutionIO.derivative`, and fractionation tests. `TimeLine._piecewise_poly` and `SolutionIO._solution_interpolated`/`_dm_dt_interpolated` are derived or lazy caches that are excluded from pickle state via `__getstate__`/`__setstate__`; both are recomputed on next use. scipy is capped at `<1.18` so dependabot opens a PR when 1.18 support can be restored. A MRE and upstream issue report for scipy are pending.