### PR TITLE
Fix StopIteration in purity plot when n_components exceeds color cycle length

### DIFF
--- a/CADETProcess/solution.py
+++ b/CADETProcess/solution.py
@@ -32,6 +32,7 @@ Method to slice a Solution:
 from __future__ import annotations
 
 import copy
+from itertools import cycle
 from typing import Any, Optional
 
 import matplotlib.pyplot as plt
@@ -778,7 +779,7 @@ class SolutionIO(SolutionBase):
         local_purity_components = solution.local_purity_components * 100
         local_purity_species = solution.local_purity_species * 100
 
-        colors = iter(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+        colors = cycle(plt.rcParams["axes.prop_cycle"].by_key()["color"])
         species_index = 0
         for i, comp in enumerate(solution.component_system.components):
             color = next(colors)
@@ -1913,7 +1914,7 @@ def _plot_solution_1D(
     # Plot data
     sol = solution.solution
     c_total_comp = solution.total_concentration_components
-    colors = iter(plt.rcParams["axes.prop_cycle"].by_key()["color"])
+    colors = cycle(plt.rcParams["axes.prop_cycle"].by_key()["color"])
     species_index = 0  # Initialize species index
 
     for i, comp in enumerate(solution.component_system.components):

--- a/docs/source/release_notes/v0.13.0.md
+++ b/docs/source/release_notes/v0.13.0.md
@@ -61,6 +61,7 @@ and the Comparator no longer needs to hold a reference registry.
 
 ## Other changes
 
+- Fix `StopIteration` in purity plots when the number of components exceeds the color cycle length (e.g. GIEX with a pH tracer) ([#401](https://github.com/fau-advanced-separations/CADET-Process/pull/401))
 - Fractionation optimizer test suite added: synthetic chromatogram fixtures cover eight separation regimes plus infeasibility, recovery monotonicity, and multi-outlet fractionation; no CADET-Core required ([#279](https://github.com/fau-advanced-separations/CADET-Process/pull/279))
 - Test suite restructured to mirror package layout; shared fixtures moved to `conftest.py` ([#378](https://github.com/fau-advanced-separations/CADET-Process/pull/378), [#379](https://github.com/fau-advanced-separations/CADET-Process/pull/379))
 - Coverage baseline established at 73% (2026-05-16)


### PR DESCRIPTION
`iter()` on the prop_cycle color list exhausts when the number of components exceeds the cycle length, which happens with GIEX where the pH tracer adds an extra component beyond the bound states. `itertools.cycle` wraps around instead of raising.

Closes #297.