### PR TITLE
Wire callbacks through evaluation pipeline for cache reuse

### DIFF
--- a/CADETProcess/evaluation_pipeline/pipeline.py
+++ b/CADETProcess/evaluation_pipeline/pipeline.py
@@ -122,6 +122,7 @@ def _make_node(
     func: Callable,
     output_name: str,
     requires: list[str] | None,
+    cache: bool = True,
 ) -> PipeFunc:
     """Build a `PipeFunc` node with failure propagation and optional arg injection."""
     safe = _wrap_with_failure_propagation(func, stage=output_name)
@@ -129,7 +130,7 @@ def _make_node(
         node_func = _make_injection_wrapper(safe, requires)
     else:
         node_func = _make_context_wrapper(safe)
-    return PipeFunc(node_func, output_name=output_name, cache=True)
+    return PipeFunc(node_func, output_name=output_name, cache=cache)
 
 
 class EvaluationPipeline:
@@ -182,6 +183,7 @@ class EvaluationPipeline:
         func: Callable,
         output_name: str,
         requires: list[str] | None = None,
+        cache: bool = True,
     ) -> None:
         """Register a callable as a named node in the evaluation DAG.
 
@@ -200,6 +202,10 @@ class EvaluationPipeline:
             Ordered list of upstream output names to inject as positional arguments
             to `func`.  When given, `func` must accept ``len(requires)`` positional
             arguments.  When None, pipefunc wires `func` by its own argument names.
+        cache : bool
+            Whether to cache the output of this node.  Defaults to True.
+            Pass False for nodes with side effects (e.g. callbacks) where
+            repeated execution is intentional and results need not be stored.
 
         Raises
         ------
@@ -215,7 +221,7 @@ class EvaluationPipeline:
         if output_name in self._output_names:
             raise ValueError(f"output_name {output_name!r} is already registered")
 
-        node = _make_node(func, output_name, requires)
+        node = _make_node(func, output_name, requires, cache=cache)
         self._nodes.append(node)
         self._output_names.append(output_name)
         self._pipeline = None  # invalidate cached pipeline

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -14,7 +14,8 @@ import random
 import shutil
 import warnings
 from collections.abc import Callable
-from typing import Any, Optional
+from pathlib import Path
+from typing import Any, Literal, Optional
 
 import hopsy
 import numpy as np
@@ -1459,6 +1460,8 @@ class OptimizationProblem:
         """
         if not callable(callback):
             raise TypeError("Expected callable callback.")
+        if frequency < 1:
+            raise ValueError(f"frequency must be a positive integer, got {frequency!r}")
 
         if name is None:
             if inspect.isfunction(callback) or inspect.ismethod(callback):
@@ -1974,7 +1977,8 @@ class OptimizationProblem:
     def evaluate_callbacks(
         self,
         population: Any = None,
-        current_iteration: int = 0,
+        current_iteration: int | Literal["final"] = 0,
+        callbacks_dir: Any = None,
         parallelization_backend: Any = None,  # noqa: ARG002
     ) -> None:
         """Evaluate registered callbacks against a population.
@@ -1987,38 +1991,95 @@ class OptimizationProblem:
         current_iteration : int
             Current generation index; used to respect each callback's
             ``frequency`` setting.
+        callbacks_dir : path-like, optional
+            Base directory for callback output files.  Per-callback
+            subdirectories are created automatically when more than one
+            callback is registered.  A ``callbacks_dir`` set at registration
+            time via ``add_callback`` overrides this value for that callback.
         parallelization_backend :
             Unused; retained for API compatibility with the optimizer.
         """
         if population is None or not self._callbacks:
             return
-        eval_objs = self._space.evaluation_objects
+        _logger = logging.getLogger(__name__)
+        eval_objs = self._space.evaluation_objects or []
+        obj_index = {id(obj): i for i, obj in enumerate(eval_objs)}
         for cb in self._callbacks:
             if not (
                 current_iteration == "final"
                 or current_iteration % cb.frequency == 0
             ):
                 continue
+
+            # Resolve per-callback directory.
+            if cb.callbacks_dir is not None:
+                _cb_dir = Path(cb.callbacks_dir)
+            elif callbacks_dir is not None:
+                base = Path(callbacks_dir)
+                _cb_dir = base / str(cb) if len(self._callbacks) > 1 else base
+                _cb_dir.mkdir(exist_ok=True, parents=True)
+            else:
+                _cb_dir = None
+
+            if _cb_dir is not None and current_iteration != "final":
+                cb.cleanup(_cb_dir, current_iteration)
+
             metric_eval_objs = (
                 cb.evaluation_objects if cb.evaluation_objects else eval_objs or [None]
             )
-            callbacks_dir = getattr(cb, "_callbacks_dir", None)
-            sig = inspect.signature(cb.func).parameters
+            try:
+                sig = inspect.signature(cb.func).parameters
+            except (ValueError, TypeError):
+                sig = {}
             for individual in population:
                 self._space.set_values(individual.x)
+                # Use the pipeline to get evaluator chain outputs, benefiting
+                # from results already cached during objective/constraint
+                # evaluation for this individual.
+                ev_outputs: dict[str, Any] = {}
+                if cb.evaluator_chain and eval_objs:
+                    try:
+                        ev_outputs = self._pipeline.evaluate(
+                            individual.x, targets=cb.evaluator_chain
+                        )
+                    except Exception:
+                        _logger.debug(
+                            f"Pipeline evaluation for callback {cb.name!r} failed;"
+                            f" falling back to direct chain execution.",
+                            exc_info=True,
+                        )
+
                 for eval_obj in metric_eval_objs:
                     try:
                         if cb.evaluator_chain:
-                            # Evaluate the chain manually to avoid pipefunc's
-                            # serialization path, which fails for evaluation
-                            # objects that contain non-picklable closures.
-                            chain_result = (
-                                eval_obj if eval_obj is not None else individual.x
-                            )
-                            for ev_name in cb.evaluator_chain:
-                                chain_result = self._evaluator_func_by_name[ev_name](
-                                    chain_result
+                            last = cb.evaluator_chain[-1]
+                            if ev_outputs and last in ev_outputs:
+                                raw = ev_outputs[last]
+                                if isinstance(raw, list):
+                                    idx = obj_index.get(id(eval_obj))
+                                    if idx is not None and idx < len(raw):
+                                        chain_result = raw[idx]
+                                    else:
+                                        chain_result = (
+                                            eval_obj
+                                            if eval_obj is not None
+                                            else individual.x
+                                        )
+                                        for ev_name in cb.evaluator_chain:
+                                            chain_result = self._evaluator_func_by_name[
+                                                ev_name
+                                            ](chain_result)
+                                else:
+                                    chain_result = raw
+                            else:
+                                # Pipeline unavailable; fall back to direct execution.
+                                chain_result = (
+                                    eval_obj if eval_obj is not None else individual.x
                                 )
+                                for ev_name in cb.evaluator_chain:
+                                    chain_result = self._evaluator_func_by_name[
+                                        ev_name
+                                    ](chain_result)
                         else:
                             chain_result = (
                                 eval_obj if eval_obj is not None else individual.x
@@ -2029,12 +2090,13 @@ class OptimizationProblem:
                         if "evaluation_object" in sig:
                             kwargs["evaluation_object"] = eval_obj
                         if "callbacks_dir" in sig:
-                            kwargs["callbacks_dir"] = callbacks_dir
+                            kwargs["callbacks_dir"] = _cb_dir
                         cb.func(chain_result, *cb.args, **kwargs)
                     except Exception as exc:
-                        logging.getLogger(__name__).warning(
+                        _logger.warning(
                             f"Callback {cb.name!r} failed at iteration"
-                            f" {current_iteration}: {exc}"
+                            f" {current_iteration}: {exc}",
+                            exc_info=True,
                         )
 
     def evaluate_callbacks_population(self, *args: Any, **kwargs: Any) -> None:

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -709,7 +709,7 @@ class OptimizationProblem:
         self, x: npt.ArrayLike, tol: float | npt.ArrayLike = 0.0
     ) -> bool:
         """Return True if all independent values satisfy their bounds."""
-        return self._space.check_bounds(x, tol=tol)
+        return self._space.check_bounds(x, tol=tol, resolve_dependencies=True)
 
     # ── Linear constraints ─────────────────────────────────────────────────────
 

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -607,19 +607,10 @@ class OptimizerBase(Structure):
         else:
             callbacks_dir = self.callbacks_dir
 
-        for callback in self.optimization_problem.callbacks:
-            if self.optimization_problem.n_callbacks > 1:
-                _callbacks_dir = callbacks_dir / str(callback)
-                _callbacks_dir.mkdir(exist_ok=True, parents=True)
-            else:
-                _callbacks_dir = callbacks_dir
-
-            callback.cleanup(_callbacks_dir, current_generation)
-            callback._callbacks_dir = _callbacks_dir
-
         self.optimization_problem.evaluate_callbacks(
             self.results.meta_front,
             current_generation,
+            callbacks_dir=callbacks_dir,
             parallelization_backend=self.parallelization_backend,
         )
 

--- a/CADETProcess/parameter_space/space.py
+++ b/CADETProcess/parameter_space/space.py
@@ -5,19 +5,20 @@ Mappers are wired at ``add_parameter`` time and stored internally; callers inter
 only with the high-level API.  ``set_values`` resolves dependent parameters, validates
 each value, and writes via the wired mappers.
 
-Scope of feasibility checking
-------------------------------
-``check_bounds`` and the linear constraint matrices operate on **independent**
-parameters only — the variables the optimizer directly controls.  Bounds and linear
-constraints declared on *dependent* parameters cannot be enforced before the dependency
-transform is resolved.  They are caught lazily:
+Coordinate convention
+---------------------
+All ``ParameterSpace`` methods operate in **physical units** on the **full parameter
+vector** (independent + dependent, length ``n_parameters``).  Methods decorated with
+``@resolves_dependencies`` accept either the full vector (default) or an independent-
+only vector (length ``n_variables``) when called with ``resolve_dependencies=True``.
+Use ``get_dependent_values(x_independent)`` to expand an independent vector explicitly.
 
-- ``set_values`` calls each parameter's ``validate`` after resolving dependencies,
-  so any out-of-bounds dependent value raises at write time.
-- For sampling, follow the pattern used in ``OptimizationProblem.create_initial_values``:
-  draw independent samples within the independent feasible polytope, resolve with
-  ``_resolve_all_values``, then validate the full resolved vector before accepting the
-  sample.
+Three callers, three spaces:
+
+* **User** — physical units, named parameters.
+* **Optimizer** — normalized independent variables in ``[0, 1]``;  use
+  ``TransformedSpace`` for this coordinate system.
+* **Internal (sampling, population)** — physical units, full vector.
 
 Normalization
 -------------
@@ -66,36 +67,6 @@ from CADETProcess.parameter_space.parameters import (
 __all__ = ["ParameterSpace"]
 
 
-def denormalizes(func: Callable) -> Callable:
-    """Add a ``normalized`` keyword argument to a method.
-
-    When called with ``normalized=True``, the first positional argument *x* is
-    passed through ``self.denormalize`` before the method body runs.  The method
-    itself always operates in physical units.
-
-    The ``normalized`` parameter is injected into the wrapped function's
-    ``__signature__`` so that ``help()`` and IDE introspection show it.
-
-    Mirrors the ``@untransforms`` pattern in ``OptimizationProblem``.
-    """
-
-    @wraps(func)
-    def wrapper(self: Any, x: Any, *args: Any, normalized: bool = False, **kwargs: Any) -> Any:
-        if normalized:
-            x = self.denormalize(x)
-        return func(self, x, *args, **kwargs)
-
-    # Patch the signature so introspection shows `normalized`.
-    original = inspect.signature(func)
-    normalized_param = inspect.Parameter(
-        "normalized", inspect.Parameter.KEYWORD_ONLY, default=False, annotation=bool
-    )
-    new_params = list(original.parameters.values()) + [normalized_param]
-    wrapper.__signature__ = original.replace(parameters=new_params)
-
-    return wrapper
-
-
 class ParameterSpace:
     """Container for parameters, evaluation objects, constraints, and dependencies.
 
@@ -113,6 +84,77 @@ class ParameterSpace:
         )
         space.set_values([0.5])
     """
+
+    # ── Method decorators ─────────────────────────────────────────────────────
+
+    def denormalizes(func: Callable) -> Callable:  # type: ignore[misc]
+        """Adapter for methods that operate on physical coordinates.
+
+        The decorated method always receives *x* in physical units.  The
+        decorator adds a ``denormalize=True`` entry point that converts
+        normalized coordinates to physical before invoking the method, without
+        changing what the implementation sees or its contract.
+
+        Apply to methods that are part of the optimizer-facing interface but
+        implemented by ``ParameterSpace`` — i.e., methods that
+        ``TransformedSpace`` naturally delegates to with ``denormalize=True``.
+
+        The ``denormalize`` parameter is injected into the wrapped function's
+        ``__signature__`` so that ``help()`` and IDE introspection show it.
+        """
+
+        @wraps(func)
+        def denormalizes_wrapper(
+            self: Any, x: Any, *args: Any, denormalize: bool = False, **kwargs: Any
+        ) -> Any:
+            if denormalize:
+                x = self.denormalize(x)
+            return func(self, x, *args, **kwargs)
+
+        original = inspect.signature(func)
+        denormalize_param = inspect.Parameter(
+            "denormalize", inspect.Parameter.KEYWORD_ONLY, default=False, annotation=bool
+        )
+        new_params = list(original.parameters.values()) + [denormalize_param]
+        denormalizes_wrapper.__signature__ = original.replace(parameters=new_params)
+        return denormalizes_wrapper
+
+    def resolves_dependencies(func: Callable) -> Callable:  # type: ignore[misc]
+        """Adapter for methods that operate on a fully resolved parameter vector.
+
+        The decorated method always receives a full parameter vector of length
+        ``n_parameters`` (independent + dependent).  The decorator adds a
+        ``resolve_dependencies=True`` entry point that expands an independent-
+        only vector via ``self.get_dependent_values`` before invoking the
+        method, without changing what the implementation sees or its contract.
+
+        Hot paths that have already resolved dependencies pass the full vector
+        directly (``resolve_dependencies=False``, the default) to avoid
+        redundant resolution.
+
+        The ``resolve_dependencies`` parameter is injected into the wrapped
+        function's ``__signature__`` so that ``help()`` and IDE introspection
+        show it.
+        """
+
+        @wraps(func)
+        def resolves_dependencies_wrapper(
+            self: Any, x: Any, *args: Any, resolve_dependencies: bool = False, **kwargs: Any
+        ) -> Any:
+            if resolve_dependencies:
+                x = self.get_dependent_values(x)
+            return func(self, x, *args, **kwargs)
+
+        original = inspect.signature(func)
+        resolve_param = inspect.Parameter(
+            "resolve_dependencies",
+            inspect.Parameter.KEYWORD_ONLY,
+            default=False,
+            annotation=bool,
+        )
+        new_params = list(original.parameters.values()) + [resolve_param]
+        resolves_dependencies_wrapper.__signature__ = original.replace(parameters=new_params)
+        return resolves_dependencies_wrapper
 
     def __init__(self) -> None:
         self._evaluation_objects: list[Any] = []
@@ -434,6 +476,25 @@ class ParameterSpace:
             )
         return values
 
+    @denormalizes
+    def get_dependent_values(self, x_independent: npt.ArrayLike) -> np.ndarray:
+        """Expand independent parameter values to the full parameter vector.
+
+        Parameters
+        ----------
+        x_independent : array-like
+            Values for the ``n_variables`` independent parameters in physical units.
+            Pass ``denormalize=True`` to denormalize from normalized coordinates first.
+
+        Returns
+        -------
+        np.ndarray
+            Full parameter vector of length ``n_parameters``, in registration order
+            (independent parameters first, then dependent parameters resolved from them).
+        """
+        all_values = self._resolve_all_values(x_independent)
+        return np.array([all_values[p.name] for p in self._parameters], dtype=float)
+
     # ── Constraints ───────────────────────────────────────────────────────────
 
     def _validate_constraint_parameters(
@@ -538,13 +599,29 @@ class ParameterSpace:
         """Equality constraint matrix sliced to independent columns, shape ``(m, n_variables)``."""
         return self.A_eq[:, self._independent_indices]
 
+    @resolves_dependencies
     def evaluate_linear_constraints(self, x: npt.ArrayLike) -> np.ndarray:
-        """Return ``A @ x - b``; positive entries mean a constraint violation."""
+        """Return ``A @ x - b``; positive entries mean a constraint violation.
+
+        Parameters
+        ----------
+        x : array-like
+            Full parameter vector (length ``n_parameters``) in physical units.
+            Pass ``resolve_dependencies=True`` to expand an independent-only vector first.
+        """
         x = np.asarray(x, dtype=float).ravel()
         return self.A @ x - self.b
 
+    @resolves_dependencies
     def evaluate_linear_equality_constraints(self, x: npt.ArrayLike) -> np.ndarray:
-        """Return ``A_eq @ x - b_eq``; non-zero entries mean a constraint violation."""
+        """Return ``A_eq @ x - b_eq``; non-zero entries mean a constraint violation.
+
+        Parameters
+        ----------
+        x : array-like
+            Full parameter vector (length ``n_parameters``) in physical units.
+            Pass ``resolve_dependencies=True`` to expand an independent-only vector first.
+        """
         x = np.asarray(x, dtype=float).ravel()
         return self.A_eq @ x - self.b_eq
 
@@ -582,44 +659,97 @@ class ParameterSpace:
             dtype=float,
         )
 
-    @denormalizes
+    @resolves_dependencies
     def check_bounds(
         self,
         x: npt.ArrayLike,
         tol: float | npt.ArrayLike = 0.0,
     ) -> bool:
-        """Return True when all independent variables satisfy their bounds.
-
-        Only independent parameter bounds are checked here.  Bounds on derived
-        parameters cannot be evaluated until the dependency transform is resolved;
-        they are enforced in ``set_values`` via each parameter's ``validate``.
+        """Return True when all parameters satisfy their bounds.
 
         Parameters
         ----------
         x : array-like
-            Values for the independent parameters, in physical units by default.
-            Pass ``normalized=True`` to denormalize first.
+            Full parameter vector (length ``n_parameters``) in physical units.
+            Pass ``resolve_dependencies=True`` to expand an independent-only vector
+            (length ``n_variables``) first.
         tol : float or array-like
             Per-variable (or uniform) tolerance added to each bound.
 
         Raises
         ------
         ValueError
-            If the length of *x* does not match ``n_variables``.
+            If the length of *x* does not match ``n_parameters``.
         """
         vals = np.asarray(x, dtype=float).ravel()
-        n = self.n_variables
+        n = self.n_parameters
         if vals.size != n:
             raise ValueError(f"Expected {n} values, got {vals.size}.")
         tol_arr = np.broadcast_to(np.asarray(tol, dtype=float), n)
-        lbs = self.lower_bounds_independent
-        ubs = self.upper_bounds_independent
+        lbs = self.lower_bounds
+        ubs = self.upper_bounds
         return bool(np.all(vals >= lbs - tol_arr) and np.all(vals <= ubs + tol_arr))
 
+    @resolves_dependencies
     def evaluate_bounds(self, x: npt.ArrayLike) -> np.ndarray:
-        """Return ``[lb - x, x - ub]`` over all parameters; positive = bound violation."""
+        """Return ``[lb - x, x - ub]`` over all parameters; positive = bound violation.
+
+        Parameters
+        ----------
+        x : array-like
+            Full parameter vector (length ``n_parameters``) in physical units.
+            Pass ``resolve_dependencies=True`` to expand an independent-only vector first.
+        """
         x = np.asarray(x, dtype=float).ravel()
         return np.concatenate([self.lower_bounds - x, x - self.upper_bounds])
+
+    @resolves_dependencies
+    def validate_x(
+        self,
+        x: npt.ArrayLike,
+        tol: float = 0.0,
+        tol_eq: float = 1e-6,
+    ) -> bool | np.ndarray:
+        """Return True if *x* satisfies bounds and all linear constraints.
+
+        Parameters
+        ----------
+        x : array-like
+            Full parameter vector, shape ``(n_parameters,)`` for a single point or
+            ``(m, n_parameters)`` for a population.  Pass
+            ``resolve_dependencies=True`` to expand an independent-only 1-D vector
+            first (population input always requires the full vector).
+        tol : float
+            Tolerance applied to bounds and inequality constraints (inclusive).
+        tol_eq : float
+            Tolerance applied to equality constraints.
+
+        Returns
+        -------
+        bool or np.ndarray of bool
+            Scalar for a single point; 1-D boolean array for a population.
+        """
+        x_arr = np.asarray(x, dtype=float)
+        population = x_arr.ndim == 2
+        rows = x_arr if population else x_arr[np.newaxis, :]
+        A, b = self.A, self.b
+        Aeq, beq = self.A_eq, self.b_eq
+        results = []
+        for row in rows:
+            valid = True
+            if not self.check_bounds(row, tol=tol):
+                warnings.warn("x violates parameter bounds.")
+                valid = False
+            if A.shape[0] > 0 and not bool(np.all(A @ row <= b + tol)):
+                warnings.warn("x violates linear inequality constraints.")
+                valid = False
+            if Aeq.shape[0] > 0 and not bool(np.all(np.abs(Aeq @ row - beq) <= tol_eq)):
+                warnings.warn("x violates linear equality constraints.")
+                valid = False
+            results.append(valid)
+        if population:
+            return np.array(results)
+        return results[0]
 
     # ── Normalization ─────────────────────────────────────────────────────────
 
@@ -653,7 +783,7 @@ class ParameterSpace:
 
         Bounds are not enforced here; out-of-range normalized values are mapped
         to their corresponding physical values without raising.  This allows
-        ``check_bounds(x, normalized=True)`` to correctly return False for
+        ``check_bounds(x, denormalize=True)`` to correctly return False for
         values that are outside the normalized unit hypercube.
         """
         vals = np.asarray(x_norm, dtype=float).ravel()
@@ -691,7 +821,7 @@ class ParameterSpace:
         ----------
         x : array-like
             Values for the independent parameters, in physical units by default.
-            Pass ``normalized=True`` to denormalize first.
+            Pass ``denormalize=True`` to denormalize first.
         validate_bounds : bool
             When True, check that *x* satisfies independent bounds before writing.
         tol : float or array-like
@@ -705,7 +835,7 @@ class ParameterSpace:
             If any parameter's ``validate`` rejects its resolved value.
         """
         vals = np.asarray(x, dtype=float).ravel()
-        if validate_bounds and not self.check_bounds(vals, tol=tol):
+        if validate_bounds and not self.check_bounds(vals, tol=tol, resolve_dependencies=True):
             raise ValueError("Independent values violate bound constraints.")
 
         all_values = self._resolve_all_values(vals)

--- a/CADETProcess/parameter_space/transformed_space.py
+++ b/CADETProcess/parameter_space/transformed_space.py
@@ -248,7 +248,23 @@ class TransformedSpace:
         tol : float or array-like
             Tolerance passed to ``check_bounds`` when *validate_bounds* is True.
         """
-        self._space.set_values(x, normalized=True, validate_bounds=validate_bounds, tol=tol)
+        self._space.set_values(x, denormalize=True, validate_bounds=validate_bounds, tol=tol)
+
+    def get_dependent_values(self, x: npt.ArrayLike) -> np.ndarray:
+        """Expand normalized independent values to the full physical parameter vector.
+
+        Parameters
+        ----------
+        x : array-like
+            Values for the ``n_variables`` independent parameters in **normalized**
+            coordinates.
+
+        Returns
+        -------
+        np.ndarray
+            Full physical parameter vector of length ``n_parameters``.
+        """
+        return self._space.get_dependent_values(x, denormalize=True)
 
     def check_bounds(self, x: npt.ArrayLike, tol: float | npt.ArrayLike = 0.0) -> bool:
         """Return True when *x* (in normalized coordinates) satisfies physical bounds.
@@ -260,7 +276,42 @@ class TransformedSpace:
         tol : float or array-like
             Per-variable tolerance added to each bound before checking.
         """
-        return self._space.check_bounds(x, normalized=True, tol=tol)
+        x_phys = self._space.denormalize(x)
+        return self._space.check_bounds(x_phys, tol=tol, resolve_dependencies=True)
+
+    def validate_x(
+        self,
+        x: npt.ArrayLike,
+        tol: float = 0.0,
+        tol_eq: float = 1e-6,
+    ) -> bool | np.ndarray:
+        """Return True if *x* (normalized) satisfies bounds and all linear constraints.
+
+        Parameters
+        ----------
+        x : array-like
+            Normalized independent parameter vector, shape ``(n_variables,)`` for a
+            single point or ``(m, n_variables)`` for a population.
+        tol : float
+            Tolerance applied to bounds and inequality constraints (inclusive).
+        tol_eq : float
+            Tolerance applied to equality constraints.
+
+        Returns
+        -------
+        bool or np.ndarray of bool
+            Scalar for a single point; 1-D boolean array for a population.
+        """
+        x_arr = np.asarray(x, dtype=float)
+        population = x_arr.ndim == 2
+        rows = x_arr if population else x_arr[np.newaxis, :]
+        results = [
+            self._space.validate_x(self.get_dependent_values(row), tol=tol, tol_eq=tol_eq)
+            for row in rows
+        ]
+        if population:
+            return np.array(results)
+        return results[0]
 
     # ── Misc ──────────────────────────────────────────────────────────────────
 

--- a/tests/optimization/test_optimization_problem.py
+++ b/tests/optimization/test_optimization_problem.py
@@ -1016,7 +1016,6 @@ def test_evaluate_callbacks_called_per_individual(eval_obj):
         calls.append((result, individual, evaluation_object, callbacks_dir))
 
     op.add_callback(callback, requires=[evaluator])
-    op.callbacks[0]._callbacks_dir = None
 
     ind = Individual(x=np.array([0.5]))
     pop = Population()
@@ -1049,7 +1048,6 @@ def test_evaluate_callbacks_optional_args_injected_by_signature(eval_obj):
         calls.append(result)
 
     op.add_callback(callback, requires=[evaluator])
-    op.callbacks[0]._callbacks_dir = None
 
     ind = Individual(x=np.array([0.3]))
     pop = Population()
@@ -1059,6 +1057,91 @@ def test_evaluate_callbacks_optional_args_injected_by_signature(eval_obj):
 
     assert len(calls) == 1
     np.testing.assert_allclose(calls[0], 0.3)
+
+
+def test_evaluate_callbacks_no_chain_sees_current_x(eval_obj):
+    """No-chain callback must receive eval_obj with parameters set for individual.x.
+
+    Regression: the pipeline refactor dropped set_values for the no-chain path,
+    so eval_obj attributes reflected the previous individual's x instead.
+    """
+    op = OptimizationProblem("cb_no_chain", use_diskcache=False)
+    op.add_evaluation_object(eval_obj)
+    op.add_variable("scalar_param", lb=0, ub=1)
+
+    seen_values = []
+
+    def callback(result):
+        seen_values.append(result.scalar_param)
+
+    op.add_callback(callback)
+
+    for x_val in [0.2, 0.7]:
+        ind = Individual(x=np.array([x_val]))
+        pop = Population()
+        pop.add_individual(ind)
+        op.evaluate_callbacks(pop, current_iteration=0)
+
+    np.testing.assert_allclose(seen_values, [0.2, 0.7])
+
+
+def test_evaluate_callbacks_callbacks_dir_passthrough(eval_obj, tmp_path):
+    """callbacks_dir passed to evaluate_callbacks reaches the callback function."""
+    op = OptimizationProblem("cb_dir", use_diskcache=False)
+    op.add_evaluation_object(eval_obj)
+    op.add_variable("scalar_param", lb=0, ub=1)
+
+    received_dirs = []
+
+    def callback(result, callbacks_dir):
+        received_dirs.append(callbacks_dir)
+
+    op.add_callback(callback)
+
+    ind = Individual(x=np.array([0.5]))
+    pop = Population()
+    pop.add_individual(ind)
+
+    op.evaluate_callbacks(pop, current_iteration=0, callbacks_dir=tmp_path)
+
+    assert len(received_dirs) == 1
+    assert received_dirs[0] == tmp_path
+
+
+def test_evaluate_callbacks_pipeline_cache_reuse(eval_obj):
+    """Evaluator runs once even when both an objective and a callback require it."""
+    op = OptimizationProblem("cb_cache", use_diskcache=False)
+    op.add_evaluation_object(eval_obj)
+    op.add_variable("scalar_param", lb=0, ub=1)
+
+    call_count = 0
+
+    def evaluator(evaluation_object):
+        nonlocal call_count
+        call_count += 1
+        return evaluation_object.scalar_param * 2
+
+    op.add_evaluator(evaluator)
+    op.add_objective(lambda result: result, requires=[evaluator])
+
+    cb_results = []
+
+    def callback(result):
+        cb_results.append(result)
+
+    op.add_callback(callback, requires=[evaluator])
+
+    ind = Individual(x=np.array([0.5]))
+    pop = Population()
+    pop.add_individual(ind)
+
+    op.evaluate_objectives(ind.x)
+    op.evaluate_callbacks(pop, current_iteration=0)
+
+    # Evaluator must have run exactly once; callback gets the cached result.
+    assert call_count == 1
+    assert len(cb_results) == 1
+    np.testing.assert_allclose(cb_results[0], 1.0)
 
 
 # ── create_individual cv fields (T7) ─────────────────────────────────────────

--- a/tests/parameter_space/test_space.py
+++ b/tests/parameter_space/test_space.py
@@ -9,6 +9,7 @@ from CADETProcess.parameter_space import (
     LinearEqualityConstraint,
     ParameterSpace,
     RangedParameter,
+    TransformedSpace,
 )
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
@@ -261,10 +262,11 @@ def test_check_bounds_normalized(space_with_column):
     space_with_column.add_parameter(
         RangedParameter("a", float, lb=0.0, ub=10.0, normalization="linear")
     )
+    ts = TransformedSpace(space_with_column)
     # 0.5 normalized → 5.0 physical, which is within [0, 10]
-    assert space_with_column.check_bounds([0.5], normalized=True) is True
+    assert ts.check_bounds([0.5]) is True
     # 1.5 normalized → 15.0 physical, which is outside [0, 10]
-    assert space_with_column.check_bounds([1.5], normalized=True) is False
+    assert ts.check_bounds([1.5]) is False
 
 
 # ── normalization ─────────────────────────────────────────────────────────────
@@ -302,7 +304,7 @@ def test_set_values_normalized(space_with_column, column):
         RangedParameter("length", float, lb=0.0, ub=1.0, normalization="linear"),
         path="length",
     )
-    space_with_column.set_values([1.0], normalized=True)  # 1.0 normalized → 1.0 physical
+    space_with_column.set_values([1.0], denormalize=True)  # 1.0 normalized → 1.0 physical
     assert column.length == pytest.approx(1.0)
 
 
@@ -463,3 +465,110 @@ def test_evaluate_linear_equality_constraints_violated(space_with_lineqcon):
     cv = space_with_lineqcon.evaluate_linear_equality_constraints([0.3, 0.5])
     # 0.3 + 0.5 - 1.0 = -0.2
     assert cv == pytest.approx([-0.2])
+
+
+# ── get_dependent_values ──────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def space_with_dependent(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=10.0)
+    b = RangedParameter("b", float, lb=0.0, ub=5.0)
+    space.add_parameter(a)
+    space.add_parameter(b)
+    space.add_dependency(b, [a], transform=lambda x: x * 0.5)
+    return space
+
+
+def test_get_dependent_values_shape(space_with_dependent):
+    x_full = space_with_dependent.get_dependent_values([4.0])
+    assert x_full.shape == (2,)
+
+
+def test_get_dependent_values_resolves_correctly(space_with_dependent):
+    x_full = space_with_dependent.get_dependent_values([4.0])
+    np.testing.assert_allclose(x_full, [4.0, 2.0])
+
+
+def test_get_dependent_values_wrong_length_raises(space_with_dependent):
+    with pytest.raises(ValueError):
+        space_with_dependent.get_dependent_values([1.0, 2.0])
+
+
+# ── check_bounds with resolve_dependencies ────────────────────────────────────
+
+
+def test_check_bounds_resolve_dependencies(space_with_dependent):
+    # Independent x=4.0 → b=2.0; both within bounds
+    assert space_with_dependent.check_bounds([4.0], resolve_dependencies=True) is True
+
+
+def test_check_bounds_resolve_dependencies_violation(space_with_dependent):
+    # Independent x=8.0 → b=4.0 (within b's [0,5]) but a=8.0 within [0,10]: still valid
+    assert space_with_dependent.check_bounds([8.0], resolve_dependencies=True) is True
+
+
+def test_check_bounds_full_vector_directly(space_with_dependent):
+    assert space_with_dependent.check_bounds([4.0, 2.0]) is True
+    assert space_with_dependent.check_bounds([4.0, 6.0]) is False  # b > 5.0
+
+
+# ── validate_x ───────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def space_two_vars(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=1.0)
+    b = RangedParameter("b", float, lb=0.0, ub=1.0)
+    space.add_parameter(a)
+    space.add_parameter(b)
+    return space, a, b
+
+
+def test_validate_x_valid(space_two_vars):
+    space, _, _ = space_two_vars
+    assert space.validate_x([0.5, 0.5]) is True
+
+
+def test_validate_x_bounds_violation_warns_and_returns_false(space_two_vars):
+    space, _, _ = space_two_vars
+    with pytest.warns(UserWarning, match="bounds"):
+        result = space.validate_x([1.5, 0.5])
+    assert result is False
+
+
+def test_validate_x_linear_inequality_violation(space_two_vars):
+    space, a, b = space_two_vars
+    space.add_linear_constraint(LinearConstraint([a, b], lhs=[1.0, 1.0], b=1.0))
+    with pytest.warns(UserWarning, match="inequality"):
+        result = space.validate_x([0.6, 0.6])
+    assert result is False
+
+
+def test_validate_x_linear_equality_violation(space_two_vars):
+    space, a, b = space_two_vars
+    space.add_linear_equality_constraint(
+        LinearEqualityConstraint([a, b], lhs=[1.0, 1.0], b=1.0)
+    )
+    with pytest.warns(UserWarning, match="equality"):
+        result = space.validate_x([0.3, 0.5])
+    assert result is False
+
+
+def test_validate_x_population_returns_bool_array(space_two_vars):
+    space, _, _ = space_two_vars
+    x = np.array([[0.5, 0.5], [1.5, 0.5]])
+    with pytest.warns(UserWarning):
+        result = space.validate_x(x)
+    assert result.dtype == bool
+    assert result[0] is np.bool_(True)
+    assert result[1] is np.bool_(False)
+
+
+def test_validate_x_resolve_dependencies(space_with_dependent):
+    # Independent x=4.0 → b=2.0; both within bounds: valid
+    assert space_with_dependent.validate_x([4.0], resolve_dependencies=True) is True


### PR DESCRIPTION
Callbacks re-ran the evaluator chain manually, duplicating simulation work already cached from objective evaluation for the same individual. `evaluate_callbacks` now calls `pipeline.evaluate()` for the chain, returning cached results when the same `x` was already evaluated, with a fallback to direct execution if the pipeline call fails.

`callbacks_dir` is now a proper parameter of `evaluate_callbacks` instead of a private attribute mutated onto `_MetricRecord` by the optimizer before each call. Per-callback directory resolution and `cleanup` both move into `evaluate_callbacks`, eliminating the side-channel and resolving the limitation from #133 where `callbacks_dir` could not be passed from outside the optimization loop.

`EvaluationPipeline.add_evaluator` gains a `cache` parameter (default `True`).

Also fixes several edge cases: `current_iteration="final"` no longer passed to `cleanup`; `callbacks_dir` coerced to `Path`; pipeline fallback logged at debug with traceback instead of silently swallowed; multi-eval-obj result indexing uses `id()`-based map; `frequency < 1` rejected at registration; `inspect.signature` guarded for non-standard callables; callback exception warnings preserve traceback via `exc_info=True`.

Closes #133.