### PR TITLE
Pass parameter values by name in ParameterSpace and EvaluationPipeline

### DIFF
--- a/CADETProcess/evaluation_pipeline/pipeline.py
+++ b/CADETProcess/evaluation_pipeline/pipeline.py
@@ -152,8 +152,9 @@ class EvaluationPipeline:
     Parameters
     ----------
     space : ParameterSpace
-        Owns the evaluation objects and knows how to write a parameter vector
-        into them.  `evaluate` delegates to `space.set_values(x)`.
+        Owns the evaluation objects and knows how to write parameter values
+        into them.  `evaluate` decodes the vector and delegates to
+        `space.set_values`.
 
     Examples
     --------
@@ -292,7 +293,8 @@ class EvaluationPipeline:
         Parameters
         ----------
         x : array-like
-            Parameter vector passed to `space.set_values`.
+            Independent parameter vector in physical units; decoded to a named
+            assignment before `space.set_values` writes it.
         targets : list[str], optional
             Output names to compute.  `None` computes all registered outputs.
             Requesting a subset exploits pipefunc's lazy evaluation: only the
@@ -315,7 +317,7 @@ class EvaluationPipeline:
             # Append a nonce so every node sees a guaranteed cache miss.
             # Existing entries for other x values are unaffected.
             x_key = x_key + (_uuid_mod.uuid4().hex,)
-        self._space.set_values(x)
+        self._space.set_values(self._space.transformed_space.decode(x))
 
         if targets is None:
             targets = self._output_names

--- a/CADETProcess/evaluation_pipeline/pipeline.py
+++ b/CADETProcess/evaluation_pipeline/pipeline.py
@@ -3,12 +3,11 @@ from __future__ import annotations
 import inspect
 import re
 import uuid as _uuid_mod
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import wraps
 from pathlib import Path
 from typing import Any
 
-import numpy as np
 from pipefunc import PipeFunc, Pipeline
 
 from CADETProcess.parameter_space.space import ParameterSpace
@@ -22,7 +21,7 @@ _CONTEXT_ARG = "__eval_context__"
 
 
 class _EvaluationContext:
-    """Stable, serializable cache key combining a parameter vector and an evaluation object.
+    """Stable, serializable cache key combining a parameter assignment and an evaluation object.
 
     Pipefunc caches by argument value.  Evaluation objects are mutable, so passing
     the raw object would produce stale cache hits whenever ``set_values`` mutates it.
@@ -164,7 +163,7 @@ class EvaluationPipeline:
     ...     fractionate, output_name="fractionation_results",
     ...     requires=["simulation_results"],
     ... )
-    >>> results = pipeline.evaluate(x)
+    >>> results = pipeline.evaluate({"length": 0.5})
     >>> results["fractionation_results"]
     """
 
@@ -278,7 +277,7 @@ class EvaluationPipeline:
 
     def evaluate(
         self,
-        x: Any,
+        assignment: Mapping[str, Any],
         targets: list[str] | None = None,
         bypass_cache: bool = False,
     ) -> dict[str, Any]:
@@ -286,15 +285,20 @@ class EvaluationPipeline:
 
         The `Pipeline` instance is reused across calls.  Cache invalidation is
         handled by ``_EvaluationContext``: each call constructs a context keyed on
-        ``(x_key, obj_uuid)``, so results for different x values are naturally
-        distinct cache entries without manual cache clearing.  Intermediate nodes
-        shared by multiple targets within a single call are computed only once.
+        ``(x_key, obj_uuid)``, where ``x_key`` is the registration-ordered
+        ``(name, value)`` tuple of the independent assignment.  Results for
+        different assignments are naturally distinct cache entries without manual
+        cache clearing; assignments that only differ in a categorical value are
+        distinct entries too.  Intermediate nodes shared by multiple targets
+        within a single call are computed only once.
 
         Parameters
         ----------
-        x : array-like
-            Independent parameter vector in physical units; decoded to a named
-            assignment before `space.set_values` writes it.
+        assignment : Mapping
+            Values for the independent parameters by name, in physical units.
+            Order-insensitive.  Numeric vectors are an encoding owned by
+            ``TransformedSpace``; decode first:
+            ``pipeline.evaluate(space.transformed_space.decode(x))``.
         targets : list[str], optional
             Output names to compute.  `None` computes all registered outputs.
             Requesting a subset exploits pipefunc's lazy evaluation: only the
@@ -312,12 +316,22 @@ class EvaluationPipeline:
             evaluation objects the values are lists indexed by evaluation object.
             Results may be `EvaluationFailure` instances when a node failed.
         """
-        x_key: tuple = tuple(np.asarray(x, dtype=float).ravel())
+        if not isinstance(assignment, Mapping):
+            raise TypeError(
+                "evaluate takes a named assignment (Mapping of parameter name "
+                "to value); numeric vectors are an encoding owned by "
+                "TransformedSpace — decode first: "
+                "pipeline.evaluate(space.transformed_space.decode(x))."
+            )
+        self._space.set_values(assignment)
+        x_key: tuple = tuple(
+            (p.name, assignment[p.name])
+            for p in self._space.independent_parameters
+        )
         if bypass_cache:
             # Append a nonce so every node sees a guaranteed cache miss.
-            # Existing entries for other x values are unaffected.
+            # Existing entries for other assignments are unaffected.
             x_key = x_key + (_uuid_mod.uuid4().hex,)
-        self._space.set_values(self._space.transformed_space.decode(x))
 
         if targets is None:
             targets = self._output_names

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -664,7 +664,7 @@ class OptimizationProblem:
 
     def set_variables(self, x: npt.ArrayLike) -> None:
         """Write *x* (independent values) into evaluation objects."""
-        self._space.set_values(x)
+        self._space.set_values(self._space.transformed_space.decode(x))
 
     def get_variable_value(self, name: str) -> Any:
         """Read the current value of variable *name* from its evaluation object.
@@ -1708,7 +1708,7 @@ class OptimizationProblem:
         elif not all_ev_names:
             # No evaluator chain — set_values still needs to happen for inline metrics.
             try:
-                self._space.set_values(x)
+                self._space.set_values(self._space.transformed_space.decode(x))
             except CADETProcessError as e:
                 self.logger.warning(
                     "set_values failed at x=%s: %s. Returning bad metrics.", x, e
@@ -2139,7 +2139,7 @@ class OptimizationProblem:
                 sig = {}
             for individual in population:
                 x_ind = self.untransform(individual.x_transformed)
-                self._space.set_values(x_ind)
+                self._space.set_values(self._space.transformed_space.decode(x_ind))
                 # Use the pipeline to get evaluator chain outputs, benefiting
                 # from results already cached during objective/constraint
                 # evaluation for this individual.

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -1685,7 +1685,9 @@ class OptimizationProblem:
         eval_objs = self._space.evaluation_objects
         if all_ev_names and eval_objs:
             try:
-                outputs = self._pipeline.evaluate(x, targets=all_ev_names)
+                outputs = self._pipeline.evaluate(
+                    self._space.transformed_space.decode(x), targets=all_ev_names
+                )
             except CADETProcessError as e:
                 self.logger.warning(
                     "Evaluation failed at x=%s: %s. Returning bad metrics.", x, e
@@ -2139,7 +2141,8 @@ class OptimizationProblem:
                 sig = {}
             for individual in population:
                 x_ind = self.untransform(individual.x_transformed)
-                self._space.set_values(self._space.transformed_space.decode(x_ind))
+                assignment = self._space.transformed_space.decode(x_ind)
+                self._space.set_values(assignment)
                 # Use the pipeline to get evaluator chain outputs, benefiting
                 # from results already cached during objective/constraint
                 # evaluation for this individual.
@@ -2147,7 +2150,7 @@ class OptimizationProblem:
                 if cb.evaluator_chain and eval_objs:
                     try:
                         ev_outputs = self._pipeline.evaluate(
-                            x_ind, targets=cb.evaluator_chain
+                            assignment, targets=cb.evaluator_chain
                         )
                     except Exception:
                         _logger.debug(

--- a/CADETProcess/parameter_space/space.py
+++ b/CADETProcess/parameter_space/space.py
@@ -995,16 +995,19 @@ class ParameterSpace:
         seed: Optional[int] = None,
         pool_size: int = 100_000,
         include_dependent: bool = False,
-    ) -> np.ndarray:
-        """Draw *n* feasible samples from the independent parameter polytope.
+    ) -> list[dict[str, Any]]:
+        """Draw *n* feasible samples as named assignments.
 
-        Uses hopsy (Highly Optimized toolbox for Polytope Sampling) to produce
-        uniformly distributed samples.  For parameters with a non-linear normalizer
-        (e.g. ``LogNormalizer``) a custom log-likelihood model is injected so that
-        samples are distributed uniformly in the transformed space.
+        Numeric independent parameters are drawn with hopsy (Highly Optimized
+        toolbox for Polytope Sampling) over the numeric polytope; categorical
+        parameters are drawn uniformly over their ``valid_values`` and merged
+        into the assignment.  For parameters with a non-linear normalizer
+        (e.g. ``LogNormalizer``) a custom log-likelihood model is injected so
+        that samples are distributed uniformly in the transformed space.
+        Integer positions are rounded by ``decode``.
 
         Derived parameter feasibility is enforced by post-hoc filtering: each
-        candidate is resolved via ``_resolve_all_values`` and validated; infeasible
+        candidate is resolved via ``resolve`` and validated; infeasible
         candidates are discarded and new draws are attempted.
 
         Parameters
@@ -1019,16 +1022,15 @@ class ParameterSpace:
             Number of MCMC steps used to build the candidate pool.  The default
             (100 000) is sufficient for most problems; reduce for fast tests.
         include_dependent : bool
-            When False (default) each row contains only the ``n_variables``
-            independent parameter values.  When True each row contains all
-            ``n_parameters`` values in registration order, with dependent parameters
-            resolved from the independent ones.
+            When False (default) each assignment contains only the independent
+            parameters.  When True each assignment contains all parameters in
+            registration order, with dependent parameters resolved from the
+            independent ones.
 
         Returns
         -------
-        np.ndarray
-            Shape ``(n, n_variables)`` or ``(n, n_parameters)`` depending on
-            *include_dependent*.
+        list[dict]
+            *n* named assignments, each ordered by registration.
 
         Raises
         ------
@@ -1044,47 +1046,49 @@ class ParameterSpace:
                 # Jacobian correction: uniform in log-transformed coordinates
                 return float(np.sum(np.log(x[self.log_space_indices])))
 
+        independent = self.independent_parameters
+        numeric = [p for p in independent if isinstance(p, RangedParameter)]
+        numeric_idx = [
+            i for i, p in enumerate(independent) if isinstance(p, RangedParameter)
+        ]
+        categorical = self.categorical_parameters
+
         log_indices = [
-            i
-            for i, p in enumerate(self.independent_parameters)
-            if isinstance(p, RangedParameter) and not p.normalizer.is_linear
+            i for i, p in enumerate(numeric) if not p.normalizer.is_linear
         ]
         model = _LogSpaceModel(log_indices) if log_indices else None
-
-        if self.categorical_parameters:
-            raise NotImplementedError(
-                "Polytope sampling does not support ChoiceParameter. "
-                "Remove categorical parameters or sample them independently."
-            )
 
         if seed is None:
             seed = random.randint(0, 255)
 
-        problem = hopsy.Problem(self.A_independent, self.b, model)
-        problem = hopsy.add_box_constraints(
-            problem, self.lower_bounds_independent, self.upper_bounds_independent, simplify=False
-        )
-        if self._linear_equality_constraints:
-            problem = hopsy.add_equality_constraints(
-                problem, self.A_eq_independent, self.b_eq
-            )
+        if numeric:
+            # Constraints never reference categorical parameters (rejected at
+            # declaration time), so slicing to the numeric columns drops only
+            # zeros.
+            lb_num = np.array([p.lb for p in numeric], dtype=float)
+            ub_num = np.array([p.ub for p in numeric], dtype=float)
+            problem = hopsy.Problem(self.A_independent[:, numeric_idx], self.b, model)
+            problem = hopsy.add_box_constraints(problem, lb_num, ub_num, simplify=False)
+            if self._linear_equality_constraints:
+                problem = hopsy.add_equality_constraints(
+                    problem, self.A_eq_independent[:, numeric_idx], self.b_eq
+                )
 
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            problem = hopsy.round(problem, simplify=False)
-            mc = hopsy.MarkovChain(
-                problem, proposal=hopsy.UniformCoordinateHitAndRunProposal
-            )
-            rng_hopsy = hopsy.RandomNumberGenerator(seed=seed)
-            _, states = hopsy.sample(mc, rng_hopsy, n_samples=pool_size, thinning=2)
-
-        candidates = states[0]  # shape (pool_size, n_variables)
-        int_indices = [
-            i for i, p in enumerate(self.independent_parameters)
-            if isinstance(p, RangedParameter) and p.parameter_type is int
-        ]
-        if int_indices:
-            candidates[:, int_indices] = np.round(candidates[:, int_indices])
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                problem = hopsy.round(problem, simplify=False)
+                mc = hopsy.MarkovChain(
+                    problem, proposal=hopsy.UniformCoordinateHitAndRunProposal
+                )
+                rng_hopsy = hopsy.RandomNumberGenerator(seed=seed)
+                _, states = hopsy.sample(
+                    mc, rng_hopsy, n_samples=pool_size, thinning=2
+                )
+            candidates = states[0]  # shape (pool_size, len(numeric))
+        else:
+            # Purely categorical space: the numeric polytope is empty.
+            candidates = np.zeros((pool_size, 0))
+        ts = self.transformed_space
         rng = np.random.default_rng(seed)
         results = []
         counter = 0
@@ -1097,22 +1101,24 @@ class ParameterSpace:
                     "Increase pool_size or relax dependent-parameter constraints."
                 )
             idx = int(rng.integers(0, pool_size))
-            x_ind = candidates[idx]
             counter += 1
 
+            categorical_values = {
+                c.name: c.valid_values[int(rng.integers(len(c.valid_values)))]
+                for c in categorical
+            } or None
+            assignment = ts.decode(candidates[idx], categorical_values)
+
             try:
-                all_values = self._resolve_all_values(x_ind)
+                all_values = self.resolve(assignment)
                 for p in self._parameters:
                     p.validate(all_values[p.name])
             except (TypeError, ValueError):
                 continue
 
-            if include_dependent:
-                results.append([all_values[p.name] for p in self._parameters])
-            else:
-                results.append(list(x_ind))
+            results.append(all_values if include_dependent else assignment)
 
-        return np.array(results)
+        return results
 
     def __repr__(self) -> str:
         """Return a readable representation."""

--- a/CADETProcess/parameter_space/space.py
+++ b/CADETProcess/parameter_space/space.py
@@ -55,7 +55,7 @@ from __future__ import annotations
 import inspect
 import random
 import warnings
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from functools import wraps
 from typing import TYPE_CHECKING, Any, Optional
 
@@ -101,7 +101,7 @@ class ParameterSpace:
             RangedParameter("length", float, lb=0.1, ub=1.0),
             path="column.length",
         )
-        space.set_values([0.5])
+        space.set_values({"length": 0.5})
     """
 
     # ── Method decorators ─────────────────────────────────────────────────────
@@ -462,20 +462,60 @@ class ParameterSpace:
             if isinstance(p, ChoiceParameter)
         ]
 
-    def _resolve_all_values(self, x_independent: npt.ArrayLike) -> dict[str, Any]:
-        """Compute values for all parameters given the independent values.
+    def resolve(self, assignment: Mapping[str, Any]) -> dict[str, Any]:
+        """Resolve a named independent assignment to the full parameter assignment.
 
-        Returns a dict mapping parameter name to value.  Independent values are
-        inserted first; dependent values are computed in topological order.
+        Dependent parameter values are computed from the independent values in
+        topological order.
+
+        Parameters
+        ----------
+        assignment : Mapping
+            Values for the independent parameters by name, in physical units.
+            Order-insensitive; the result is ordered by registration.
+
+        Returns
+        -------
+        dict
+            Values for all parameters (independent and dependent), ordered by
+            registration.
+
+        Raises
+        ------
+        TypeError
+            If *assignment* is not a Mapping.
+        ValueError
+            If *assignment* contains unknown names, misses an independent
+            parameter, or supplies a value for a dependent parameter.
+        RuntimeError
+            If dependency declarations leave a parameter unresolvable.
         """
-        x = np.asarray(x_independent, dtype=object).ravel()
-        if x.size != self.n_variables:
-            raise ValueError(
-                f"Expected {self.n_variables} independent values, got {x.size}."
+        if not isinstance(assignment, Mapping):
+            raise TypeError(
+                "resolve takes a named assignment (Mapping of parameter name to "
+                "value); numeric vectors are an encoding owned by "
+                "TransformedSpace — decode first: "
+                "space.resolve(space.transformed_space.decode(x))."
             )
-        values: dict[str, Any] = {
-            p.name: v for p, v in zip(self.independent_parameters, x)
-        }
+        independent = self.independent_parameters
+        independent_names = {p.name for p in independent}
+        registered_names = {p.name for p in self._parameters}
+        unknown = [n for n in assignment if n not in registered_names]
+        if unknown:
+            raise ValueError(f"Unknown parameter names: {unknown!r}.")
+        dependent_supplied = [n for n in assignment if n not in independent_names]
+        if dependent_supplied:
+            raise ValueError(
+                f"Assignment supplies values for dependent parameters "
+                f"{dependent_supplied!r}; dependent values are resolved, not set."
+            )
+        missing = [p.name for p in independent if p.name not in assignment]
+        if missing:
+            raise ValueError(
+                f"Assignment misses independent parameters: {missing!r}."
+            )
+
+        values: dict[str, Any] = dict(assignment)
         changed = True
         while changed:
             changed = False
@@ -489,13 +529,27 @@ class ParameterSpace:
                     continue
                 values[name] = dep.transform(*args)
                 changed = True
-        missing = [p.name for p in self._parameters if p.name not in values]
-        if missing:
+        unresolved = [p.name for p in self._parameters if p.name not in values]
+        if unresolved:
             raise RuntimeError(
-                f"Could not resolve parameter values for {missing!r}. "
+                f"Could not resolve parameter values for {unresolved!r}. "
                 "Check dependency declarations."
             )
-        return values
+        return {p.name: values[p.name] for p in self._parameters}
+
+    def _resolve_all_values(self, x_independent: npt.ArrayLike) -> dict[str, Any]:
+        """Resolve an independent-value vector; vector adapter over ``resolve``.
+
+        Positions follow the registration order of the independent parameters.
+        """
+        x = np.asarray(x_independent, dtype=object).ravel()
+        if x.size != self.n_variables:
+            raise ValueError(
+                f"Expected {self.n_variables} independent values, got {x.size}."
+            )
+        return self.resolve(
+            {p.name: v for p, v in zip(self.independent_parameters, x)}
+        )
 
     @denormalizes
     def get_dependent_values(self, x_independent: npt.ArrayLike) -> np.ndarray:
@@ -826,10 +880,9 @@ class ParameterSpace:
 
     # ── Writing ───────────────────────────────────────────────────────────────
 
-    @denormalizes
     def set_values(
         self,
-        x: npt.ArrayLike,
+        assignment: Mapping[str, Any],
         *,
         validate_bounds: bool = False,
         tol: float | npt.ArrayLike = 0.0,
@@ -842,26 +895,46 @@ class ParameterSpace:
 
         Parameters
         ----------
-        x : array-like
-            Values for the independent parameters, in physical units by default.
-            Pass ``denormalize=True`` to denormalize first.
+        assignment : Mapping
+            Values for the independent parameters by name, in physical units.
+            Order-insensitive.  Numeric vectors are an encoding owned by
+            ``TransformedSpace``; decode first:
+            ``space.set_values(space.transformed_space.decode(x))``.
         validate_bounds : bool
-            When True, check that *x* satisfies independent bounds before writing.
+            When True, check that the resolved values satisfy parameter bounds
+            before writing.
         tol : float or array-like
-            Tolerance passed to ``check_bounds`` when *validate_bounds* is True.
+            Per-parameter (or uniform) tolerance added to each bound when
+            *validate_bounds* is True.
 
         Raises
         ------
+        TypeError
+            If *assignment* is not a Mapping, or a parameter's ``validate``
+            rejects its resolved value.
         ValueError
-            If *validate_bounds* is True and *x* violates independent bounds.
-        TypeError, ValueError
-            If any parameter's ``validate`` rejects its resolved value.
+            If *assignment* violates the input contract (unknown names, missing
+            independent parameters, supplied dependent values), if
+            *validate_bounds* is True and a bound is violated, or if a
+            parameter's ``validate`` rejects its resolved value.
         """
-        vals = np.asarray(x, dtype=float).ravel()
-        if validate_bounds and not self.check_bounds(vals, tol=tol, resolve_dependencies=True):
-            raise ValueError("Independent values violate bound constraints.")
+        if not isinstance(assignment, Mapping):
+            raise TypeError(
+                "set_values takes a named assignment (Mapping of parameter name "
+                "to value); numeric vectors are an encoding owned by "
+                "TransformedSpace — decode first: "
+                "space.set_values(space.transformed_space.decode(x))."
+            )
+        all_values = self.resolve(assignment)
+        if validate_bounds:
+            tol_arr = np.broadcast_to(np.asarray(tol, dtype=float), self.n_parameters)
+            for i, p in enumerate(self._parameters):
+                if not isinstance(p, RangedParameter):
+                    continue
+                value = float(all_values[p.name])
+                if not (p.lb - tol_arr[i] <= value <= p.ub + tol_arr[i]):
+                    raise ValueError("Values violate bound constraints.")
 
-        all_values = self._resolve_all_values(vals)
         for p in self._parameters:
             value = all_values[p.name]
             if isinstance(p, RangedParameter) and p.significant_digits is not None:

--- a/CADETProcess/parameter_space/transformed_space.py
+++ b/CADETProcess/parameter_space/transformed_space.py
@@ -1,7 +1,9 @@
 """TransformedSpace: optimizer-facing view of a ParameterSpace in normalized coordinates.
 
-``TransformedSpace`` wraps a ``ParameterSpace`` and presents bounds, constraint
-matrices, and write operations in normalized coordinates.  Three spaces are in play:
+``TransformedSpace`` wraps a ``ParameterSpace`` and presents bounds and constraint
+matrices in normalized coordinates.  It has no write method: the single write path
+is ``ParameterSpace.set_values``, and vector-coordinate callers compose explicitly,
+``space.set_values(ts.decode(space.denormalize(x)))``.  Three spaces are in play:
 
 * **Optimizer space** — the ``n_variables`` independent parameters in normalized
   coordinates; the domain the optimizer directly controls.
@@ -25,7 +27,7 @@ Linear constraint transformation
 Constraints are defined over the optimizer basis (independent parameters only).
 Dependent parameters are excluded: lifting constraints through the dependency embedding
 is not defined in the linear constraint formalism.  Feasibility of dependent parameters
-is enforced after embedding in ``set_values`` via parameter validation.
+is enforced after embedding in ``ParameterSpace.set_values`` via parameter validation.
 
 The affine transform ``x_phys = lb + span * x_norm`` (where ``span = ub - lb``) holds
 only for parameters with an active affine normalizer.  Parameters without normalization
@@ -35,7 +37,7 @@ constrained parameter uses a non-affine normalizer (e.g. ``LogNormalizer``); use
 
 As a result, constraint satisfaction in optimizer space is not equivalent to physical
 feasibility when nonlinear normalizers or dependency transforms are involved.  Sampling
-must be followed by post-hoc validation via ``set_values``.
+must be followed by post-hoc validation via ``ParameterSpace.set_values``.
 """
 
 from __future__ import annotations
@@ -59,9 +61,11 @@ __all__ = ["TransformedSpace"]
 class TransformedSpace:
     """Optimizer-facing view of a ``ParameterSpace`` in normalized coordinates.
 
-    All bounds, constraint matrices, and ``set_values`` calls operate in the
-    normalized coordinate system.  The underlying ``ParameterSpace`` is the
-    source of truth; ``TransformedSpace`` derives everything from it lazily.
+    All bounds and constraint matrices are expressed in the normalized
+    coordinate system.  The underlying ``ParameterSpace`` is the source of
+    truth; ``TransformedSpace`` derives everything from it lazily.  Every
+    method is a pure function: writing goes through ``ParameterSpace``
+    exclusively.
 
     Parameters
     ----------
@@ -79,7 +83,8 @@ class TransformedSpace:
             path="column.length",
         )
         ts = TransformedSpace(space)
-        ts.set_values([0.5])   # 0.5 normalized → 0.55 physical
+        # 0.5 normalized → 0.55 physical
+        space.set_values(ts.decode(space.denormalize([0.5])))
     """
 
     def __init__(self, space: ParameterSpace) -> None:
@@ -346,31 +351,7 @@ class TransformedSpace:
         """Equality constraint RHS in normalized coordinates, shape ``(m,)``."""
         return self._assemble_matrices(self._space.linear_equality_constraints)[1]
 
-    # ── Write / validate ──────────────────────────────────────────────────────
-
-    def set_values(
-        self,
-        x: npt.ArrayLike,
-        *,
-        validate_bounds: bool = False,
-        tol: float | npt.ArrayLike = 0.0,
-    ) -> None:
-        """Resolve, denormalize, and write *x* into the evaluation objects.
-
-        Parameters
-        ----------
-        x : array-like
-            Values for the independent parameters in **normalized** coordinates.
-        validate_bounds : bool
-            When True, check that the denormalized values satisfy physical bounds.
-        tol : float or array-like
-            Tolerance passed to ``check_bounds`` when *validate_bounds* is True.
-        """
-        self._space.set_values(
-            self.decode(self._space.denormalize(x)),
-            validate_bounds=validate_bounds,
-            tol=tol,
-        )
+    # ── Validate ──────────────────────────────────────────────────────────────
 
     def get_dependent_values(self, x: npt.ArrayLike) -> np.ndarray:
         """Expand normalized independent values to the full physical parameter vector.

--- a/CADETProcess/parameter_space/transformed_space.py
+++ b/CADETProcess/parameter_space/transformed_space.py
@@ -366,7 +366,11 @@ class TransformedSpace:
         tol : float or array-like
             Tolerance passed to ``check_bounds`` when *validate_bounds* is True.
         """
-        self._space.set_values(x, denormalize=True, validate_bounds=validate_bounds, tol=tol)
+        self._space.set_values(
+            self.decode(self._space.denormalize(x)),
+            validate_bounds=validate_bounds,
+            tol=tol,
+        )
 
     def get_dependent_values(self, x: npt.ArrayLike) -> np.ndarray:
         """Expand normalized independent values to the full physical parameter vector.

--- a/CADETProcess/parameter_space/transformed_space.py
+++ b/CADETProcess/parameter_space/transformed_space.py
@@ -40,6 +40,7 @@ must be followed by post-hoc validation via ``set_values``.
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
@@ -136,6 +137,123 @@ class TransformedSpace:
         globally comparable.
         """
         return self._space.normalize(self._space.upper_bounds_independent)
+
+    # ── Vectorization ─────────────────────────────────────────────────────────
+
+    @property
+    def _numeric_independent_parameters(self) -> list[RangedParameter]:
+        """Independent numeric parameters, in registration order."""
+        return [
+            p for p in self._space.independent_parameters
+            if isinstance(p, RangedParameter)
+        ]
+
+    def encode(self, assignment: Mapping[str, Any]) -> np.ndarray:
+        """Project a named assignment onto the numeric parameter vector.
+
+        The vector spans the independent numeric parameters in registration
+        order.  Dependent and categorical parameters have no vector position;
+        their entries are dropped (``encode`` is a lossy projection).
+
+        Parameters
+        ----------
+        assignment : Mapping
+            Named values in physical units.  Must contain every independent
+            numeric parameter; registered dependent or categorical names are
+            ignored.
+
+        Returns
+        -------
+        np.ndarray
+            Values of the independent numeric parameters, in physical units.
+
+        Raises
+        ------
+        ValueError
+            If the assignment contains unknown names or misses an independent
+            numeric parameter.
+        """
+        known = {p.name for p in self._space.parameters}
+        unknown = [name for name in assignment if name not in known]
+        if unknown:
+            raise ValueError(f"Unknown parameter names: {unknown!r}.")
+        numeric = self._numeric_independent_parameters
+        missing = [p.name for p in numeric if p.name not in assignment]
+        if missing:
+            raise ValueError(
+                f"Assignment misses independent numeric parameters: {missing!r}."
+            )
+        return np.array([float(assignment[p.name]) for p in numeric])
+
+    def decode(
+        self,
+        x_num: npt.ArrayLike,
+        categorical_values: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Embed a numeric parameter vector into a named assignment.
+
+        The returned assignment carries canonical Python types: ``int`` for
+        integer parameters (rounded), ``float`` for continuous ones, plus the
+        caller-supplied categorical values.  When the space contains
+        categorical parameters, the assignment cannot be reconstructed from
+        the vector alone; *categorical_values* must supply every categorical
+        parameter.
+
+        Parameters
+        ----------
+        x_num : array-like
+            Values of the independent numeric parameters in **physical** units,
+            in registration order.
+        categorical_values : Mapping, optional
+            Values for the categorical parameters.  Required when the space
+            contains categorical parameters; must cover exactly those.
+
+        Returns
+        -------
+        dict
+            Named physical assignment of the independent parameters, ordered
+            by registration.
+
+        Raises
+        ------
+        ValueError
+            If the vector length does not match the number of independent
+            numeric parameters, if *categorical_values* contains unknown names,
+            or if it misses a categorical parameter (including the case where
+            the space has categorical parameters and *categorical_values* is
+            None).
+        """
+        numeric = self._numeric_independent_parameters
+        x = np.asarray(x_num, dtype=float).ravel()
+        if x.size != len(numeric):
+            raise ValueError(
+                f"Expected {len(numeric)} numeric values, got {x.size}."
+            )
+        categorical = self._space.categorical_parameters
+        categorical_names = {p.name for p in categorical}
+        if categorical_values is None:
+            categorical_values = {}
+        unknown = [n for n in categorical_values if n not in categorical_names]
+        if unknown:
+            raise ValueError(f"Unknown categorical parameter names: {unknown!r}.")
+        missing = [p.name for p in categorical if p.name not in categorical_values]
+        if missing:
+            raise ValueError(
+                f"Values for categorical parameters {missing!r} are required; "
+                "they have no position in the numeric vector."
+            )
+        numeric_values = {
+            p.name: int(np.round(v)) if p.parameter_type is int else float(v)
+            for p, v in zip(numeric, x)
+        }
+        return {
+            p.name: (
+                categorical_values[p.name]
+                if p.name in categorical_names
+                else numeric_values[p.name]
+            )
+            for p in self._space.independent_parameters
+        }
 
     # ── Constraint matrices ───────────────────────────────────────────────────
 

--- a/tests/evaluation_pipeline/test_pipeline.py
+++ b/tests/evaluation_pipeline/test_pipeline.py
@@ -78,7 +78,7 @@ def test_rejects_non_parameter_space():
 def test_evaluate_before_add_evaluator_raises(single_space):
     pipeline = EvaluationPipeline(single_space)
     with pytest.raises(RuntimeError, match="No evaluators"):
-        pipeline.evaluate([])
+        pipeline.evaluate({})
 
 
 def test_output_names_empty_initially(single_space):
@@ -120,7 +120,7 @@ def test_add_evaluator_invalid_output_name_raises(single_space):
 def test_evaluate_single_object_returns_dict(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(lambda model: model.value * 2, output_name="doubled")
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert isinstance(results, dict)
     assert "doubled" in results
 
@@ -137,7 +137,7 @@ def test_evaluate_passes_set_values_to_model(single_space, model):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(lambda model: model.value, output_name="v")
 
-    results = pipeline.evaluate([0.42])
+    results = pipeline.evaluate({"v": 0.42})
     assert results["v"] == pytest.approx(0.42)
 
 
@@ -163,7 +163,7 @@ def test_evaluate_shared_intermediate_computed_once(single_space):
         requires=["intermediate"],
     )
 
-    pipeline.evaluate([], targets=["doubled", "shifted"])
+    pipeline.evaluate({}, targets=["doubled", "shifted"])
     assert call_count == 1
 
 
@@ -179,8 +179,8 @@ def test_repeated_x_hits_cache(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(expensive, output_name="result")
 
-    pipeline.evaluate([])
-    pipeline.evaluate([])  # same x — should be a cache hit
+    pipeline.evaluate({})
+    pipeline.evaluate({})  # same x — should be a cache hit
     assert call_count == 1
 
 
@@ -201,10 +201,83 @@ def test_different_x_invalidates_cache(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(expensive, output_name="result")
 
-    r1 = pipeline.evaluate([0.1])
-    r2 = pipeline.evaluate([0.9])
+    r1 = pipeline.evaluate({"v": 0.1})
+    r2 = pipeline.evaluate({"v": 0.9})
     assert call_count == 2
     assert r1["result"] != r2["result"]
+
+
+def test_evaluate_rejects_vector_pointing_at_decode(single_space):
+    pipeline = EvaluationPipeline(single_space)
+    pipeline.add_evaluator(lambda model: model.value, output_name="v")
+    with pytest.raises(TypeError, match="decode"):
+        pipeline.evaluate([0.5])
+
+
+def test_cache_key_is_order_insensitive(single_space):
+    """Assignments differing only in key order must hit the same cache entry."""
+    from CADETProcess.parameter_space.parameters import RangedParameter
+
+    single_space.add_parameter(RangedParameter("a", float, lb=0.0, ub=1.0))
+    single_space.add_parameter(RangedParameter("b", float, lb=0.0, ub=1.0))
+
+    call_count = 0
+
+    def counting(model):
+        nonlocal call_count
+        call_count += 1
+        return model.value
+
+    pipeline = EvaluationPipeline(single_space)
+    pipeline.add_evaluator(counting, output_name="result")
+
+    pipeline.evaluate({"a": 0.1, "b": 0.2})
+    pipeline.evaluate({"b": 0.2, "a": 0.1})
+    assert call_count == 1
+
+
+def test_distinct_cache_entries_per_categorical_value(single_space):
+    """Assignments differing only in a categorical value must not collide."""
+    from CADETProcess.parameter_space.parameters import ChoiceParameter
+
+    single_space.add_parameter(ChoiceParameter("mode", ["a", "b"]))
+
+    call_count = 0
+
+    def counting(model):
+        nonlocal call_count
+        call_count += 1
+        return model.value
+
+    pipeline = EvaluationPipeline(single_space)
+    pipeline.add_evaluator(counting, output_name="result")
+
+    pipeline.evaluate({"mode": "a"})
+    pipeline.evaluate({"mode": "b"})
+    pipeline.evaluate({"mode": "a"})  # cache hit on the first entry
+    assert call_count == 2
+
+
+def test_same_integer_normalizations_collapse_to_one_entry(single_space):
+    """Numeric inputs that decode to the same integer share one cache entry."""
+    from CADETProcess.parameter_space.parameters import RangedParameter
+
+    single_space.add_parameter(RangedParameter("n", int, lb=1, ub=100), path="value")
+
+    call_count = 0
+
+    def counting(model):
+        nonlocal call_count
+        call_count += 1
+        return model.value
+
+    pipeline = EvaluationPipeline(single_space)
+    pipeline.add_evaluator(counting, output_name="result")
+
+    ts = single_space.transformed_space
+    pipeline.evaluate(ts.decode([29.6]))
+    pipeline.evaluate(ts.decode([30.4]))  # both round to n=30
+    assert call_count == 1
 
 
 def test_evaluate_partial_targets_skips_unneeded_nodes(single_space):
@@ -220,7 +293,7 @@ def test_evaluate_partial_targets_skips_unneeded_nodes(single_space):
     pipeline.add_evaluator(lambda model: model.value, output_name="a")
     pipeline.add_evaluator(side_branch, output_name="b")
 
-    pipeline.evaluate([], targets=["a"])
+    pipeline.evaluate({}, targets=["a"])
     assert not side_branch_called
 
 
@@ -228,7 +301,7 @@ def test_evaluate_unknown_target_raises(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(lambda model: model.value, output_name="a")
     with pytest.raises(ValueError, match="Unknown target"):
-        pipeline.evaluate([], targets=["nonexistent"])
+        pipeline.evaluate({}, targets=["nonexistent"])
 
 
 # ── evaluate: multiple evaluation objects ────────────────────────────────────
@@ -237,7 +310,7 @@ def test_evaluate_unknown_target_raises(single_space):
 def test_evaluate_multiple_objects_returns_lists(two_space, two_models):
     pipeline = EvaluationPipeline(two_space)
     pipeline.add_evaluator(lambda model: model.value, output_name="v")
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert isinstance(results["v"], list)
     assert len(results["v"]) == 2
 
@@ -250,7 +323,7 @@ def test_evaluate_multiple_objects_independent_results(two_space, two_models):
     pipeline = EvaluationPipeline(two_space)
     pipeline.add_evaluator(lambda model: model.value, output_name="v")
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert results["v"] == [1.0, 2.0]
 
 
@@ -264,7 +337,7 @@ def test_failing_node_returns_evaluation_failure(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(bad_node, output_name="result")
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert isinstance(results["result"], EvaluationFailure)
     assert results["result"].stage == "result"
     assert "boom" in results["result"].reason
@@ -285,7 +358,7 @@ def test_failure_propagates_to_downstream_node(single_space):
     pipeline.add_evaluator(bad_node, output_name="result")
     pipeline.add_evaluator(downstream, output_name="final", requires=["result"])
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert isinstance(results["final"], EvaluationFailure)
     assert results["final"].stage == "result"
     assert not downstream_called
@@ -302,7 +375,7 @@ def test_failure_preserves_original_stage_through_chain(single_space):
     pipeline.add_evaluator(lambda step1: step1, output_name="step2", requires=["step1"])
     pipeline.add_evaluator(lambda step2: step2, output_name="step3", requires=["step2"])
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert isinstance(results["step3"], EvaluationFailure)
     assert results["step3"].stage == "step1"
 
@@ -323,7 +396,7 @@ def test_requires_injects_upstream_output_by_position(single_space):
     pipeline.add_evaluator(producer, output_name="upstream_value")
     pipeline.add_evaluator(consumer, output_name="result", requires=["upstream_value"])
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert results["result"] == pytest.approx((0.0 + 5) * 3)
 
 
@@ -339,7 +412,7 @@ def test_requires_multi_input_injects_in_order(single_space):
         requires=["a", "b"],
     )
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert results["diff"] == pytest.approx(2.0 - 3.0)
 
 
@@ -380,7 +453,7 @@ def test_failure_stores_original_exception(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(bad_node, output_name="result")
 
-    results = pipeline.evaluate([])
+    results = pipeline.evaluate({})
     assert results["result"].exc is exc
 
 
@@ -404,8 +477,8 @@ def test_disk_cache_hit_evaluates_only_once(tmp_path, single_space):
     pipeline = EvaluationPipeline(single_space, cache_dir=tmp_path / "cache")
     pipeline.add_evaluator(counting_evaluator, output_name="result")
 
-    pipeline.evaluate([])
-    pipeline.evaluate([])  # same x → cache hit
+    pipeline.evaluate({})
+    pipeline.evaluate({})  # same x → cache hit
 
     assert call_count == 1
 
@@ -428,8 +501,8 @@ def test_disk_cache_miss_on_different_x(tmp_path):
     pipeline = EvaluationPipeline(space, cache_dir=tmp_path / "cache")
     pipeline.add_evaluator(counting_evaluator, output_name="result")
 
-    pipeline.evaluate([1.0])
-    pipeline.evaluate([2.0])
+    pipeline.evaluate({"v": 1.0})
+    pipeline.evaluate({"v": 2.0})
 
     assert call_count == 2
 
@@ -446,7 +519,7 @@ def test_lru_cache_is_used_when_no_cache_dir(single_space):
     pipeline = EvaluationPipeline(single_space)  # no cache_dir
     pipeline.add_evaluator(counting_evaluator, output_name="result")
 
-    pipeline.evaluate([])
-    pipeline.evaluate([])
+    pipeline.evaluate({})
+    pipeline.evaluate({})
 
     assert call_count == 1

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 from CADETProcess.parameter_space import (
+    ChoiceParameter,
     LinearConstraint,
     ParameterSpace,
     RangedParameter,
@@ -80,16 +81,17 @@ def test_A_includes_derived_parameter_column(column):
     np.testing.assert_allclose(space.A_independent, [[1.0]])
 
 
-# ── sample: shape ─────────────────────────────────────────────────────────────
+# ── sample: assignments ───────────────────────────────────────────────────────
 
 
-def test_sample_shape_independent_only(column):
+def test_sample_returns_independent_assignments(column):
     space = _space_1d(column)
     samples = space.sample(5, seed=0, pool_size=BURN_IN)
-    assert samples.shape == (5, 1)
+    assert len(samples) == 5
+    assert all(list(s) == ["length"] for s in samples)
 
 
-def test_sample_shape_include_derived(column):
+def test_sample_include_dependent_returns_full_assignments(column):
     space = ParameterSpace()
     space.add_evaluation_object(column)
     a = RangedParameter("a", float, lb=0.0, ub=5.0)
@@ -98,13 +100,13 @@ def test_sample_shape_include_derived(column):
     space.add_parameter(b, path="diameter")
     space.add_dependency(b, [a], transform=lambda x: x * 2)
     samples = space.sample(3, seed=0, pool_size=BURN_IN, include_dependent=True)
-    assert samples.shape == (3, 2)  # a + b
+    assert all(list(s) == ["a", "b"] for s in samples)
 
 
-def test_sample_two_params(column):
+def test_sample_assignments_ordered_by_registration(column):
     space = _space_2d(column)
     samples = space.sample(10, seed=1, pool_size=BURN_IN)
-    assert samples.shape == (10, 2)
+    assert all(list(s) == ["length", "diameter"] for s in samples)
 
 
 # ── sample: values within bounds ─────────────────────────────────────────────
@@ -113,14 +115,14 @@ def test_sample_two_params(column):
 def test_sample_values_within_bounds(column):
     space = _space_2d(column)
     samples = space.sample(20, seed=2, pool_size=BURN_IN)
-    assert np.all(samples[:, 0] >= 0.0) and np.all(samples[:, 0] <= 5.0)
-    assert np.all(samples[:, 1] >= 0.0) and np.all(samples[:, 1] <= 2.0)
+    assert all(0.0 <= s["length"] <= 5.0 for s in samples)
+    assert all(0.0 <= s["diameter"] <= 2.0 for s in samples)
 
 
 def test_sample_1d_within_bounds(column):
     space = _space_1d(column)
     samples = space.sample(10, seed=3, pool_size=BURN_IN)
-    assert np.all(samples >= 1.0) and np.all(samples <= 10.0)
+    assert all(1.0 <= s["length"] <= 10.0 for s in samples)
 
 
 # ── sample: derived parameters ────────────────────────────────────────────────
@@ -135,8 +137,9 @@ def test_sample_derived_value_correct(column):
     space.add_parameter(b, path="diameter")
     space.add_dependency(b, [a], transform=lambda x: x * 2)
     samples = space.sample(5, seed=4, pool_size=BURN_IN, include_dependent=True)
-    # column b = a * 2
-    np.testing.assert_allclose(samples[:, 1], samples[:, 0] * 2)
+    np.testing.assert_allclose(
+        [s["b"] for s in samples], [s["a"] * 2 for s in samples]
+    )
 
 
 def test_sample_derived_infeasible_filtered(column):
@@ -150,7 +153,43 @@ def test_sample_derived_infeasible_filtered(column):
     space.add_dependency(b, [a], transform=lambda x: x * 3)
     samples = space.sample(5, seed=5, pool_size=BURN_IN, include_dependent=False)
     # all independent values must satisfy a * 3 <= 6 → a <= 2
-    assert np.all(samples[:, 0] <= 2.0 + 1e-9)
+    assert all(s["a"] <= 2.0 + 1e-9 for s in samples)
+
+
+# ── sample: typed parameters ──────────────────────────────────────────────────
+
+
+def test_sample_integer_values_are_whole_numbers(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(RangedParameter("n", int, lb=1, ub=100), path="length")
+    samples = space.sample(10, seed=6, pool_size=BURN_IN)
+    assert all(s["n"] == round(s["n"]) for s in samples)
+    assert all(1 <= s["n"] <= 100 for s in samples)
+
+
+def test_sample_categorical_draws_from_valid_values(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=5.0), path="length"
+    )
+    space.add_parameter(ChoiceParameter("mode", ["gradient", "isocratic"]))
+    samples = space.sample(20, seed=7, pool_size=BURN_IN)
+    assert all(s["mode"] in ("gradient", "isocratic") for s in samples)
+    assert all(list(s) == ["length", "mode"] for s in samples)
+    # both categories appear over 20 draws (deterministic for the fixed seed)
+    assert {s["mode"] for s in samples} == {"gradient", "isocratic"}
+
+
+def test_sample_categorical_only_numeric_dimensions_in_polytope(column):
+    # A purely categorical space has an empty numeric polytope; the draw
+    # must still produce valid assignments.
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(ChoiceParameter("mode", ["a", "b"]))
+    samples = space.sample(5, seed=8, pool_size=100)
+    assert all(s["mode"] in ("a", "b") for s in samples)
 
 
 # ── sample: reproducibility ───────────────────────────────────────────────────
@@ -160,7 +199,7 @@ def test_sample_same_seed_reproducible(column):
     space = _space_1d(column)
     s1 = space.sample(5, seed=42, pool_size=BURN_IN)
     s2 = space.sample(5, seed=42, pool_size=BURN_IN)
-    np.testing.assert_array_equal(s1, s2)
+    assert s1 == s2
 
 
 # ── sample: exhausted budget raises ───────────────────────────────────────────

--- a/tests/parameter_space/test_space.py
+++ b/tests/parameter_space/test_space.py
@@ -20,6 +20,7 @@ class Column:
     length: float = 0.1
     diameter: float = 0.01
     ncol: int = 10
+    mode: str = "gradient"
 
 
 @dataclass
@@ -74,14 +75,14 @@ def test_evaluation_objects_preserves_insertion_order(column, feed):
 def test_add_parameter_with_path_writes(space_with_column, column):
     p = RangedParameter("length", float, lb=0.0, ub=1.0)
     space_with_column.add_parameter(p, path="length")
-    space_with_column.set_values([0.5])
+    space_with_column.set_values({"length": 0.5})
     assert column.length == pytest.approx(0.5)
 
 
 def test_add_parameter_no_mapper(space_with_column):
     p = RangedParameter("length", float, lb=0.0, ub=1.0)
     space_with_column.add_parameter(p)  # no path or mapper — valid, no write
-    space_with_column.set_values([0.5])  # should not raise
+    space_with_column.set_values({"length": 0.5})  # should not raise
 
 
 def test_add_parameter_duplicate_name_raises(space_with_column):
@@ -120,7 +121,7 @@ def test_add_parameter_subset_of_evaluation_objects(column, feed):
     space.add_evaluation_object(feed)
     p = RangedParameter("length", float, lb=0.0, ub=1.0)
     space.add_parameter(p, path="length", evaluation_objects=[column])
-    space.set_values([0.7])
+    space.set_values({"length": 0.7})
     assert column.length == pytest.approx(0.7)
     assert feed.duration == pytest.approx(60.0)  # untouched
 
@@ -138,7 +139,7 @@ def test_add_parameter_with_callable(space_with_column, column):
     space_with_column.add_parameter_with_callable(
         p, fn=lambda obj, v: calls.append((obj, v))
     )
-    space_with_column.set_values([0.3])
+    space_with_column.set_values({"length": 0.3})
     assert calls == [(column, 0.3)]
 
 
@@ -175,7 +176,7 @@ def test_dependency_resolves_correctly(space_with_column, column):
     space_with_column.add_parameter(b)
     space_with_column.add_parameter(c, path="length")
     space_with_column.add_dependency(c, [a, b], transform=lambda x, y: x + y)
-    space_with_column.set_values([3.0, 4.0])
+    space_with_column.set_values({"a": 3.0, "b": 4.0})
     assert column.length == pytest.approx(7.0)
 
 
@@ -191,7 +192,7 @@ def test_dependency_chain(space_with_column, column):
     d = space_with_column.parameters[-1]
     space_with_column.add_dependency(b, [a], transform=lambda x: x * 2)
     space_with_column.add_dependency(d, [b], transform=lambda x: x + 1)
-    space_with_column.set_values([3.0, 0.0])
+    space_with_column.set_values({"a": 3.0, "c": 0.0})
     assert column.length == pytest.approx(7.0)  # b=6, d=7
 
 
@@ -298,30 +299,101 @@ def test_set_values_writes_to_object(space_with_column, column):
     space_with_column.add_parameter(
         RangedParameter("length", float, lb=0.0, ub=1.0), path="length"
     )
-    space_with_column.set_values([0.42])
+    space_with_column.set_values({"length": 0.42})
     assert column.length == pytest.approx(0.42)
 
 
-def test_set_values_normalized(space_with_column, column):
+def test_set_values_normalized_path_composes_through_decode(space_with_column, column):
     space_with_column.add_parameter(
-        RangedParameter("length", float, lb=0.0, ub=1.0, normalization="linear"),
+        RangedParameter("length", float, lb=0.0, ub=4.0, normalization="linear"),
         path="length",
     )
-    space_with_column.set_values([1.0], denormalize=True)  # 1.0 normalized → 1.0 physical
-    assert column.length == pytest.approx(1.0)
+    ts = space_with_column.transformed_space
+    # 0.5 normalized → 2.0 physical
+    space_with_column.set_values(ts.decode(space_with_column.denormalize([0.5])))
+    assert column.length == pytest.approx(2.0)
+
+
+def test_set_values_rejects_vector_pointing_at_decode(space_with_column):
+    space_with_column.add_parameter(RangedParameter("a", float, lb=0.0, ub=1.0))
+    with pytest.raises(TypeError, match="decode"):
+        space_with_column.set_values([0.5])
+
+
+def test_set_values_is_order_insensitive(space_with_column, column):
+    space_with_column.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=1.0), path="length"
+    )
+    space_with_column.add_parameter(
+        RangedParameter("diameter", float, lb=0.0, ub=1.0), path="diameter"
+    )
+    space_with_column.set_values({"diameter": 0.02, "length": 0.5})
+    assert column.length == pytest.approx(0.5)
+    assert column.diameter == pytest.approx(0.02)
+
+
+def test_set_values_unknown_name_raises(space_with_column):
+    space_with_column.add_parameter(RangedParameter("a", float, lb=0.0, ub=1.0))
+    with pytest.raises(ValueError, match="Unknown parameter names"):
+        space_with_column.set_values({"a": 0.5, "porosity": 0.4})
+
+
+def test_set_values_missing_independent_raises(space_with_column):
+    space_with_column.add_parameter(RangedParameter("a", float, lb=0.0, ub=1.0))
+    space_with_column.add_parameter(RangedParameter("b", float, lb=0.0, ub=1.0))
+    with pytest.raises(ValueError, match="misses independent"):
+        space_with_column.set_values({"a": 0.5})
+
+
+def test_set_values_supplied_dependent_value_raises(space_with_column):
+    a = RangedParameter("a", float, lb=0.0, ub=10.0)
+    b = RangedParameter("b", float, lb=0.0, ub=10.0)
+    space_with_column.add_parameter(a)
+    space_with_column.add_parameter(b)
+    space_with_column.add_dependency(b, [a], transform=lambda x: x * 0.5)
+    with pytest.raises(ValueError, match="dependent"):
+        space_with_column.set_values({"a": 4.0, "b": 2.0})
+
+
+def test_set_values_writes_categorical_through_mapper(space_with_column, column):
+    space_with_column.add_parameter(
+        ChoiceParameter("mode", ["gradient", "isocratic"]), path="mode"
+    )
+    space_with_column.set_values({"mode": "isocratic"})
+    assert column.mode == "isocratic"
+
+
+def test_set_values_invalid_categorical_choice_raises(space_with_column):
+    space_with_column.add_parameter(
+        ChoiceParameter("mode", ["gradient", "isocratic"]), path="mode"
+    )
+    with pytest.raises(ValueError, match="must be one of"):
+        space_with_column.set_values({"mode": "step"})
+
+
+def test_set_values_mixed_types_write_together(space_with_column, column):
+    space_with_column.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=1.0), path="length"
+    )
+    space_with_column.add_parameter(
+        ChoiceParameter("mode", ["gradient", "isocratic"]), path="mode"
+    )
+    space_with_column.set_values({"length": 0.25, "mode": "gradient"})
+    assert column.length == pytest.approx(0.25)
+    assert column.mode == "gradient"
 
 
 def test_set_values_validate_bounds_raises_on_violation(space_with_column):
     space_with_column.add_parameter(RangedParameter("a", float, lb=0.0, ub=1.0))
     with pytest.raises(ValueError, match="bound"):
-        space_with_column.set_values([1.5], validate_bounds=True)
+        space_with_column.set_values({"a": 1.5}, validate_bounds=True)
 
 
 def test_set_values_integer_whole_number_float(space_with_column, column):
     space_with_column.add_parameter(
         RangedParameter("ncol", int, lb=1, ub=100), path="ncol"
     )
-    space_with_column.set_values([50.0])
+    space_with_column.set_values({"ncol": 50.0})
     assert column.ncol == 50
     assert type(column.ncol) is int
 
@@ -331,7 +403,7 @@ def test_set_values_integer_not_rounded(space_with_column):
         RangedParameter("ncol", int, lb=1, ub=100), path="ncol"
     )
     with pytest.raises(TypeError):
-        space_with_column.set_values([50.7])
+        space_with_column.set_values({"ncol": 50.7})
 
 
 def test_set_values_validate_catches_derived_out_of_bounds(space_with_column, column):
@@ -341,7 +413,54 @@ def test_set_values_validate_catches_derived_out_of_bounds(space_with_column, co
     space_with_column.add_parameter(b, path="length")
     space_with_column.add_dependency(b, [a], transform=lambda x: x * 2)
     with pytest.raises(ValueError, match="outside"):
-        space_with_column.set_values([4.0])  # b = 8.0 > 5.0
+        space_with_column.set_values({"a": 4.0})  # b = 8.0 > 5.0
+
+
+# ── resolve ───────────────────────────────────────────────────────────────────
+
+
+def test_resolve_returns_registration_ordered_full_assignment(space_with_dependent):
+    resolved = space_with_dependent.resolve({"a": 4.0})
+    assert resolved == {"a": 4.0, "b": 2.0}
+    assert list(resolved) == ["a", "b"]
+
+
+def test_resolve_is_order_insensitive(space_two_vars):
+    space, _, _ = space_two_vars
+    assert list(space.resolve({"b": 0.7, "a": 0.3})) == ["a", "b"]
+
+
+def test_resolve_unknown_name_raises(space_with_dependent):
+    with pytest.raises(ValueError, match="Unknown parameter names"):
+        space_with_dependent.resolve({"a": 4.0, "z": 1.0})
+
+
+def test_resolve_missing_independent_raises(space_two_vars):
+    space, _, _ = space_two_vars
+    with pytest.raises(ValueError, match="'b'"):
+        space.resolve({"a": 0.5})
+
+
+def test_resolve_supplied_dependent_value_raises(space_with_dependent):
+    with pytest.raises(ValueError, match="dependent"):
+        space_with_dependent.resolve({"a": 4.0, "b": 2.0})
+
+
+def test_resolve_rejects_vector_pointing_at_decode(space_two_vars):
+    space, _, _ = space_two_vars
+    with pytest.raises(TypeError, match="decode"):
+        space.resolve([0.5, 0.5])
+
+
+def test_resolve_dependency_chain(space_with_column):
+    a = RangedParameter("a", float, lb=0.0, ub=10.0)
+    b = RangedParameter("b", float, lb=0.0, ub=20.0)
+    c = RangedParameter("c", float, lb=0.0, ub=40.0)
+    for p in (a, b, c):
+        space_with_column.add_parameter(p)
+    space_with_column.add_dependency(b, [a], transform=lambda x: x * 2)
+    space_with_column.add_dependency(c, [b], transform=lambda x: x + 1)
+    assert space_with_column.resolve({"a": 3.0}) == {"a": 3.0, "b": 6.0, "c": 7.0}
 
 
 # ── typed parameter subsets ──────────────────────────────────────────────────

--- a/tests/parameter_space/test_transformed_space.py
+++ b/tests/parameter_space/test_transformed_space.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 import numpy as np
 import pytest
 from CADETProcess.parameter_space import (
+    ChoiceParameter,
     LinearConstraint,
     LinearEqualityConstraint,
     ParameterSpace,
@@ -205,6 +206,117 @@ def test_set_values_roundtrip(column):
     ts.set_values([0.3, 0.7])
     assert column.length == pytest.approx(3.0)
     assert column.diameter == pytest.approx(0.7)
+
+
+# ── encode / decode ───────────────────────────────────────────────────────────
+
+
+def _mixed_type_space(column):
+    """Numeric, integer, and categorical parameters in registration order."""
+    space = _two_param_space(column)
+    space.add_parameter(ChoiceParameter("resin", valid_values=["A", "B"]))
+    space.add_parameter(RangedParameter("n_plates", int, lb=1, ub=100))
+    return space
+
+
+def _dependent_space(column):
+    space = _two_param_space(column)
+    length, diameter = space.independent_parameters
+    space.add_dependency(diameter, [length], lambda le: le / 10.0)
+    return space
+
+
+def test_encode_decode_roundtrip_numeric(column):
+    ts = TransformedSpace(_two_param_space(column))
+    assignment = {"length": 3.0, "diameter": 0.7}
+    np.testing.assert_array_equal(ts.encode(assignment), [3.0, 0.7])
+    assert ts.decode(ts.encode(assignment)) == assignment
+
+
+def test_encode_orders_by_registration(column):
+    ts = TransformedSpace(_two_param_space(column))
+    np.testing.assert_array_equal(
+        ts.encode({"diameter": 0.7, "length": 3.0}), [3.0, 0.7]
+    )
+
+
+def test_encode_drops_categorical_and_dependent_names(column):
+    ts = TransformedSpace(_mixed_type_space(column))
+    x = ts.encode({"length": 3.0, "diameter": 0.7, "n_plates": 30, "resin": "A"})
+    np.testing.assert_array_equal(x, [3.0, 0.7, 30.0])
+
+    ts_dep = TransformedSpace(_dependent_space(column))
+    x_dep = ts_dep.encode({"length": 3.0, "diameter": 0.3})
+    np.testing.assert_array_equal(x_dep, [3.0])
+
+
+def test_encode_unknown_name_raises(column):
+    ts = TransformedSpace(_two_param_space(column))
+    with pytest.raises(ValueError, match="Unknown parameter names"):
+        ts.encode({"length": 3.0, "diameter": 0.7, "porosity": 0.4})
+
+
+def test_encode_missing_numeric_name_raises(column):
+    ts = TransformedSpace(_two_param_space(column))
+    with pytest.raises(ValueError, match="diameter"):
+        ts.encode({"length": 3.0})
+
+
+def test_decode_names_positions_by_registration(column):
+    ts = TransformedSpace(_two_param_space(column))
+    assert ts.decode([3.0, 0.7]) == {"length": 3.0, "diameter": 0.7}
+
+
+def test_decode_rounds_integer_positions(column):
+    ts = TransformedSpace(_mixed_type_space(column))
+    assignment = ts.decode([3.0, 0.7, 29.6], categorical_values={"resin": "B"})
+    assert assignment["n_plates"] == 30
+    assert assignment["length"] == pytest.approx(3.0)
+
+
+def test_decode_returns_canonical_python_types(column):
+    # the named assignment is the canonical representation, so it carries
+    # canonical types: int for integer parameters, float for continuous ones,
+    # no numpy scalars
+    ts = TransformedSpace(_mixed_type_space(column))
+    assignment = ts.decode(
+        np.array([3.0, 0.7, 29.6]), categorical_values={"resin": "B"}
+    )
+    assert type(assignment["n_plates"]) is int
+    assert type(assignment["length"]) is float
+    assert type(assignment["diameter"]) is float
+
+
+def test_decode_length_mismatch_raises(column):
+    ts = TransformedSpace(_two_param_space(column))
+    with pytest.raises(ValueError, match="Expected 2 numeric values"):
+        ts.decode([3.0])
+
+
+def test_decode_without_categorical_values_raises(column):
+    ts = TransformedSpace(_mixed_type_space(column))
+    with pytest.raises(ValueError, match="resin"):
+        ts.decode([3.0, 0.7, 30.0])
+
+
+def test_decode_merges_categoricals_in_registration_order(column):
+    ts = TransformedSpace(_mixed_type_space(column))
+    assignment = ts.decode([3.0, 0.7, 30.0], categorical_values={"resin": "B"})
+    assert assignment == {
+        "length": 3.0, "diameter": 0.7, "resin": "B", "n_plates": 30.0
+    }
+    assert list(assignment) == ["length", "diameter", "resin", "n_plates"]
+
+
+def test_decode_unknown_categorical_name_raises(column):
+    ts = TransformedSpace(_two_param_space(column))
+    with pytest.raises(ValueError, match="Unknown categorical parameter names"):
+        ts.decode([3.0, 0.7], categorical_values={"resin": "A"})
+
+
+def test_decode_excludes_dependent_parameters(column):
+    ts = TransformedSpace(_dependent_space(column))
+    assert ts.decode([3.0]) == {"length": 3.0}
 
 
 # ── delegation ────────────────────────────────────────────────────────────────

--- a/tests/parameter_space/test_transformed_space.py
+++ b/tests/parameter_space/test_transformed_space.py
@@ -77,25 +77,36 @@ def test_bounds_two_params(column):
     np.testing.assert_array_equal(ts.upper_bounds, [1.0, 1.0])
 
 
-# ── set_values ────────────────────────────────────────────────────────────────
+# ── normalized write composition ──────────────────────────────────────────────
+# TransformedSpace has no write method; the normalized path composes explicitly.
 
 
-def test_set_values_denormalizes(column):
-    ts = TransformedSpace(_linear_space(column))
-    ts.set_values([0.5])
+def _write_normalized(space, x_norm):
+    ts = space.transformed_space
+    space.set_values(ts.decode(space.denormalize(x_norm)))
+
+
+def test_normalized_write_denormalizes(column):
+    space = _linear_space(column)
+    _write_normalized(space, [0.5])
     assert column.length == pytest.approx(5.0)
 
 
-def test_set_values_zero_maps_to_lb(column):
-    ts = TransformedSpace(_linear_space(column))
-    ts.set_values([0.0])
+def test_normalized_write_zero_maps_to_lb(column):
+    space = _linear_space(column)
+    _write_normalized(space, [0.0])
     assert column.length == pytest.approx(0.0)
 
 
-def test_set_values_one_maps_to_ub(column):
-    ts = TransformedSpace(_linear_space(column))
-    ts.set_values([1.0])
+def test_normalized_write_one_maps_to_ub(column):
+    space = _linear_space(column)
+    _write_normalized(space, [1.0])
     assert column.length == pytest.approx(10.0)
+
+
+def test_transformed_space_has_no_write_method(column):
+    ts = TransformedSpace(_linear_space(column))
+    assert not hasattr(ts, "set_values")
 
 
 # ── check_bounds ──────────────────────────────────────────────────────────────
@@ -200,10 +211,9 @@ def test_nonlinear_normalizer_raises(column):
 # ── roundtrip ─────────────────────────────────────────────────────────────────
 
 
-def test_set_values_roundtrip(column):
+def test_normalized_write_roundtrip(column):
     space = _two_param_space(column)
-    ts = TransformedSpace(space)
-    ts.set_values([0.3, 0.7])
+    _write_normalized(space, [0.3, 0.7])
     assert column.length == pytest.approx(3.0)
     assert column.diameter == pytest.approx(0.7)
 


### PR DESCRIPTION
In the optimization layer, a point in the search space was passed as a positional float vector: `set_values([0.5, 3.0])` relied on registration order to know which value belongs to which parameter. A float vector cannot hold a categorical value (`ChoiceParameter` could be registered but never written or sampled), and its limits leaked into everything built on it: the evaluation cache keyed on the raw float tuple (two vectors normalizing to the same integer created duplicate entries, and categorical choices could never be keyed at all), and integer variables needed ad-hoc rounding at each call site.

This PR makes the named assignment `{"length": 0.5, "resin": "A"}` the canonical input. `ParameterSpace.set_values` and the new `resolve` take a mapping and validate it strictly: unknown names, missing independent parameters, and caller-supplied dependent values raise. The positional vector remains for optimizers and polytope sampling, but as an explicit encoding: `TransformedSpace.encode`/`decode` convert between the two, with `decode` owning integer rounding and the categorical side-channel. `TransformedSpace` no longer has a write method, so every write goes through the one validated path. The pipeline cache is keyed by the `(name, value)` tuple, and `space.sample()` returns assignments, drawing categoricals uniformly from their valid values.

The public `OptimizationProblem` API is unchanged; optimizer vectors are decoded at the boundary. This completes the framework side of categorical support; the first optimizer that consumes categorical variables natively arrives with the BoFire adapter.