### PR TITLE
Add sampling backends for ParameterSpace

### DIFF
--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -994,7 +994,6 @@ class OptimizationProblem:
             n_samples,
             seed=seed,
             include_dependent=False,
-            validate=lambda x: self.check_individual(x, check_nonlinear_constraints=False),
         )
         ts = self._space.transformed_space
         rows = []

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -10,17 +10,14 @@ from __future__ import annotations
 import inspect
 import logging
 import math
-import random
 import shutil
 import warnings
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any, Literal, Optional
 
-import hopsy
 import numpy as np
 import numpy.typing as npt
-from packaging.version import Version
 
 from CADETProcess import CADETProcessError, log
 from CADETProcess.dataStructure.deprecation import deprecated_alias
@@ -964,23 +961,15 @@ class OptimizationProblem:
         self, include_dependent_variables: bool = True
     ) -> np.ndarray:
         """Compute the Chebyshev center of the independent-variable polytope."""
-        problem = hopsy.Problem(self._space.A_independent, self._space.b)
-        problem = hopsy.add_box_constraints(
-            problem,
-            self._space.lower_bounds_independent,
-            self._space.upper_bounds_independent,
-            simplify=False,
+        from CADETProcess.parameter_space.sampling import chebyshev_center
+
+        assignment = chebyshev_center(self._space)
+        center = np.array(
+            [assignment[p.name] for p in self._space.independent_parameters]
         )
-        if self._space._linear_equality_constraints:
-            problem = hopsy.add_equality_constraints(
-                problem, self._space.A_eq_independent, self._space.b_eq
-            )
-        chebyshev = hopsy.compute_chebyshev_center(problem, original_space=True)
-        if Version(hopsy.__version__.strip('"')) < Version("1.7.0b"):
-            chebyshev = chebyshev[:, 0]
         if include_dependent_variables:
-            chebyshev = self.get_dependent_values(chebyshev)
-        return chebyshev
+            return self.get_dependent_values(center)
+        return center
 
     def create_initial_values(
         self,
@@ -991,81 +980,30 @@ class OptimizationProblem:
     ) -> np.ndarray:
         """Draw feasible initial values from the independent-variable polytope.
 
-        Uses hopsy for uniform polytope sampling.  Derived-variable constraints
-        are enforced by post-hoc filtering.
+        Delegates to HopsySampler with pool_size=burn_in; encodes the resulting
+        named assignments back to numeric vectors via TransformedSpace.encode.
 
         Returns
         -------
         np.ndarray, shape (n_samples, n_variables or n_independent_variables)
         """
-        burn_in = int(burn_in)
-        if seed is None:
-            seed = random.randint(0, 255)
+        from CADETProcess.parameter_space.sampling import HopsySampler
 
-        log_indices = [
-            i
-            for i, p in enumerate(self._space.independent_parameters)
-            if isinstance(p, RangedParameter) and not p.normalizer.is_linear
-        ]
-
-        class _LogSpaceModel:
-            def __init__(self, li: list[int]) -> None:
-                self.log_space_indices = li
-
-            def compute_negative_log_likelihood(self, x: np.ndarray) -> float:
-                return float(np.sum(np.log(x[self.log_space_indices])))
-
-        model = _LogSpaceModel(log_indices) if log_indices else None
-        problem = hopsy.Problem(self._space.A_independent, self._space.b, model)
-        problem = hopsy.add_box_constraints(
-            problem,
-            self._space.lower_bounds_independent,
-            self._space.upper_bounds_independent,
-            simplify=False,
+        assignments = HopsySampler(pool_size=int(burn_in)).sample(
+            self._space,
+            n_samples,
+            seed=seed,
+            include_dependent=False,
+            validate=lambda x: self.check_individual(x, check_nonlinear_constraints=False),
         )
-        if self._space._linear_equality_constraints:
-            problem = hopsy.add_equality_constraints(
-                problem, self._space.A_eq_independent, self._space.b_eq
+        ts = self._space.transformed_space
+        rows = []
+        for a in assignments:
+            x_ind = ts.encode(a)
+            rows.append(
+                self.get_dependent_values(x_ind) if include_dependent_variables else x_ind
             )
-
-        with warnings.catch_warnings():
-            warnings.simplefilter("ignore")
-            problem = hopsy.round(problem, simplify=False)
-            mc = hopsy.MarkovChain(
-                problem, proposal=hopsy.UniformCoordinateHitAndRunProposal
-            )
-            rng_hopsy = hopsy.RandomNumberGenerator(seed=seed)
-            _, states = hopsy.sample(mc, rng_hopsy, n_samples=burn_in, thinning=2)
-
-        independent_values = states[0]  # shape (burn_in, n_ind_vars)
-        rng = np.random.default_rng(seed)
-
-        values = []
-        counter = 0
-        while len(values) < n_samples:
-            if counter > burn_in:
-                raise CADETProcessError(
-                    "Cannot find individuals that fulfill constraints."
-                )
-            counter += 1
-            idx = int(rng.integers(0, burn_in))
-
-            ind: list[float] = []
-            for i_var, p in enumerate(self._space.independent_parameters):
-                v = float(independent_values[idx, i_var])
-                if isinstance(p, RangedParameter) and p.significant_digits is not None:
-                    from CADETProcess.numerics import round_to_significant_digits
-                    v = float(round_to_significant_digits(v, p.significant_digits))
-                ind.append(v)
-
-            if not self.check_individual(ind, check_nonlinear_constraints=False):
-                continue
-
-            values.append(
-                self.get_dependent_values(ind) if include_dependent_variables else ind
-            )
-
-        return np.array(values, ndmin=2)
+        return np.array(rows, ndmin=2)
 
     # ── Individual / config validation ────────────────────────────────────────
 

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -14,7 +14,7 @@ import shutil
 import warnings
 from collections.abc import Callable
 from pathlib import Path
-from typing import Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import numpy as np
 import numpy.typing as npt
@@ -40,6 +40,9 @@ from CADETProcess.parameter_space.parameters import (
     RangedParameter,
 )
 from CADETProcess.parameter_space.transformed_space import TransformedSpace
+
+if TYPE_CHECKING:
+    from CADETProcess.parameter_space.sampling import SamplerBase
 
 __all__ = ["OptimizationProblem"]
 
@@ -977,11 +980,20 @@ class OptimizationProblem:
         seed: Optional[int] = None,
         burn_in: int = 100_000,
         include_dependent_variables: bool = False,
+        sampler: Optional[SamplerBase] = None,
     ) -> np.ndarray:
         """Draw feasible initial values from the independent-variable polytope.
 
-        Delegates to HopsySampler with pool_size=burn_in; encodes the resulting
-        named assignments back to numeric vectors via TransformedSpace.encode.
+        Delegates to *sampler* (default: HopsySampler with pool_size=burn_in);
+        encodes the resulting named assignments back to numeric vectors via
+        TransformedSpace.encode.
+
+        Parameters
+        ----------
+        sampler : SamplerBase, optional
+            Sampling strategy, e.g. LatinHypercubeSampler or SobolSampler for
+            box-bounded problems.  *burn_in* applies only to the default
+            HopsySampler.
 
         Returns
         -------
@@ -989,7 +1001,9 @@ class OptimizationProblem:
         """
         from CADETProcess.parameter_space.sampling import HopsySampler
 
-        assignments = HopsySampler(pool_size=int(burn_in)).sample(
+        if sampler is None:
+            sampler = HopsySampler(pool_size=int(burn_in))
+        assignments = sampler.sample(
             self._space,
             n_samples,
             seed=seed,

--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -99,6 +99,7 @@ class OptimizerBase(Structure):
     supports_bounds = False
     supports_integer_variables = False
     supports_categorical_variables = False
+    supports_unbounded_parameters = False
 
     ignore_linear_constraints_config = False
 
@@ -252,6 +253,15 @@ class OptimizerBase(Structure):
         else:
             callbacks_dir = None
         self.callbacks_dir = callbacks_dir
+
+        if x0 is None and self.supports_unbounded_parameters and (
+            np.any(np.isinf(optimization_problem.lower_bounds_independent))
+            or np.any(np.isinf(optimization_problem.upper_bounds_independent))
+        ):
+            raise ValueError(
+                "x0 must be provided explicitly when the optimization problem has "
+                "unbounded parameters; the sampler cannot draw initial values."
+            )
 
         if x0 is not None:
             flag, x0 = self.check_x0(optimization_problem, x0)
@@ -434,6 +444,16 @@ class OptimizerBase(Structure):
                 "Optimizer does not support categorical variables."
             )
             flag = False
+
+        if np.any(np.isinf(optimization_problem.lower_bounds_independent)) or np.any(
+            np.isinf(optimization_problem.upper_bounds_independent)
+        ):
+            if not self.supports_unbounded_parameters:
+                warnings.warn(
+                    "Optimizer does not support unbounded parameters. "
+                    "Set lb/ub on all variables."
+                )
+                flag = False
 
         return flag
 

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -615,9 +615,9 @@ class OptimizationResults(Structure):
         Parameters
         ----------
         plot_evolution : bool, optional
-            If True, the Pareto front is Gplotted for each generation.
+            If True, the Pareto front is plotted for each generation.
             Else, only final Pareto front is plotted.
-            The default is False.
+            The default is True.
         *args : Any
             Additional positional arguments passed to `gen.plot_pareto`.
         ax : np.ndarray[plt.Axes] | None, default=None

--- a/CADETProcess/parameter_space/__init__.py
+++ b/CADETProcess/parameter_space/__init__.py
@@ -15,7 +15,13 @@ from CADETProcess.parameter_space.parameters import (
     ParameterBase,
     RangedParameter,
 )
-from CADETProcess.parameter_space.sampling import HopsySampler, SamplerBase, chebyshev_center
+from CADETProcess.parameter_space.sampling import (
+    HopsySampler,
+    LatinHypercubeSampler,
+    SamplerBase,
+    SobolSampler,
+    chebyshev_center,
+)
 from CADETProcess.parameter_space.space import ParameterSpace
 from CADETProcess.parameter_space.transformed_space import TransformedSpace
 
@@ -24,6 +30,8 @@ __all__ = [
     "TransformedSpace",
     "SamplerBase",
     "HopsySampler",
+    "LatinHypercubeSampler",
+    "SobolSampler",
     "chebyshev_center",
     "ParameterBase",
     "RangedParameter",

--- a/CADETProcess/parameter_space/__init__.py
+++ b/CADETProcess/parameter_space/__init__.py
@@ -15,12 +15,16 @@ from CADETProcess.parameter_space.parameters import (
     ParameterBase,
     RangedParameter,
 )
+from CADETProcess.parameter_space.sampling import HopsySampler, SamplerBase, chebyshev_center
 from CADETProcess.parameter_space.space import ParameterSpace
 from CADETProcess.parameter_space.transformed_space import TransformedSpace
 
 __all__ = [
     "ParameterSpace",
     "TransformedSpace",
+    "SamplerBase",
+    "HopsySampler",
+    "chebyshev_center",
     "ParameterBase",
     "RangedParameter",
     "ChoiceParameter",

--- a/CADETProcess/parameter_space/sampling.py
+++ b/CADETProcess/parameter_space/sampling.py
@@ -2,14 +2,18 @@
 Sampler strategies for ParameterSpace.
 
 SamplerBase defines the postprocessing contract (significant-digits snap, integer
-rounding via decode, categorical merge, dependency resolution, validation).
-Concrete backends implement _candidates to produce numeric candidate rows.
+rounding via decode, categorical merge, dependency resolution, validation, and
+rejection of candidates violating linear constraints that reference dependent
+parameters).
+Concrete backends implement _candidates to produce numeric candidate rows and
+declare via _sequential_candidates whether the row order carries structure.
 """
 
 from __future__ import annotations
 
 import warnings
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional
 
 import hopsy
@@ -40,8 +44,16 @@ class SamplerBase(ABC):
 
     Concrete subclasses implement _candidates; this base class handles
     postprocessing: significant-digits snap, integer rounding (via decode),
-    categorical merge, dependency resolution, and validation.
+    categorical merge, dependency resolution, validation, and rejection of
+    candidates that violate linear constraints referencing dependent
+    parameters (those constraints cannot be part of the candidate polytope).
     """
+
+    #: When True, candidates are consumed in row order because the order
+    #: carries structure (QMC designs).  When False, candidates are consumed
+    #: in random order without replacement (MCMC pools, where sequential
+    #: consumption would surface chain autocorrelation).
+    _sequential_candidates = False
 
     def sample(
         self,
@@ -49,12 +61,24 @@ class SamplerBase(ABC):
         n: int,
         seed: Optional[int] = None,
         include_dependent: bool = False,
+        validate: Optional[Callable[[np.ndarray], bool]] = None,
     ) -> list[dict[str, Any]]:
-        """Draw n feasible samples as named assignments."""
+        """Draw n feasible samples as named assignments.
+
+        Parameters
+        ----------
+        validate : callable, optional
+            Extra feasibility check called with the independent numeric vector
+            (physical units) after parameter-level validation passes.  Intended
+            for callers that enforce constraints not captured by the polytope
+            (e.g. linear constraints referencing dependent parameters).
+        """
         import random as _random
 
         if seed is None:
-            seed = _random.randint(0, 255)
+            # 32-bit range: a narrow default (e.g. 0..255) makes unseeded
+            # calls collide and silently repeat "random" populations
+            seed = _random.randint(0, 2**32 - 1)
 
         independent = space.independent_parameters
         numeric = [p for p in independent if isinstance(p, RangedParameter)]
@@ -66,29 +90,36 @@ class SamplerBase(ABC):
                 "Narrow lb/ub on all parameters before sampling."
             )
 
-        candidates = self._candidates(space, seed)  # shape (pool_size, n_numeric)
+        if n <= 0:
+            return []
+
+        candidates = self._candidates(space, n, seed)  # shape (pool_size, n_numeric)
         pool_size = candidates.shape[0]
 
         ts = space.transformed_space
         rng = np.random.default_rng(seed)
+
+        # Constraints referencing dependent parameters cannot be expressed in
+        # the independent-variable polytope; they are enforced by rejection.
+        ind_names = {p.name for p in independent}
+        dependent_constraints = [
+            c for c in space._linear_constraints
+            if any(p.name not in ind_names for p in c.parameters)
+        ]
+
+        order = (
+            np.arange(pool_size)
+            if self._sequential_candidates
+            else rng.permutation(pool_size)
+        )
         results = []
-        counter = 0
 
-        while len(results) < n:
-            if counter >= pool_size:
-                raise ValueError(
-                    f"Could not find {n} feasible samples after exhausting the "
-                    f"{pool_size} candidates. "
-                    "Increase pool_size or relax dependent-parameter constraints."
-                )
-            idx = int(rng.integers(0, pool_size))
-            counter += 1
-
+        for idx in order:
             categorical_values = {
                 c.name: c.valid_values[int(rng.integers(len(c.valid_values)))]
                 for c in categorical
             } or None
-            assignment = ts.decode(candidates[idx], categorical_values)
+            assignment = ts.decode(candidates[int(idx)], categorical_values)
 
             for p in numeric:
                 if p.significant_digits is not None:
@@ -103,13 +134,37 @@ class SamplerBase(ABC):
             except (TypeError, ValueError):
                 continue
 
+            if any(
+                sum(coeff * all_values[p.name] for p, coeff in zip(c.parameters, c.lhs))
+                > c.b
+                for c in dependent_constraints
+            ):
+                continue
+
+            if validate is not None and not validate(ts.encode(assignment)):
+                continue
+
             results.append(all_values if include_dependent else assignment)
+            if len(results) == n:
+                break
+
+        if len(results) < n:
+            raise ValueError(
+                f"Only {len(results)} of {n} requested samples are feasible within "
+                f"the {pool_size} candidates. "
+                "Increase pool_size or relax dependent-parameter constraints."
+            )
 
         return results
 
     @abstractmethod
-    def _candidates(self, space: ParameterSpace, seed: int) -> np.ndarray:
-        """Return float array of shape (pool_size, n_numeric_independent)."""
+    def _candidates(self, space: ParameterSpace, n: int, seed: int) -> np.ndarray:
+        """Return float array of shape (pool_size, n_numeric_independent).
+
+        *n* is the number of feasible samples requested; backends whose
+        candidate count must match the request (QMC designs) size the pool
+        from it, pool-based backends may ignore it.
+        """
 
 
 class HopsySampler(SamplerBase):
@@ -117,12 +172,17 @@ class HopsySampler(SamplerBase):
 
     The only correct choice when linear inequality or equality constraints are
     present. Uses a log-space model for parameters with nonlinear normalizers.
+
+    Inequality constraints referencing dependent parameters are excluded from
+    the polytope (a relaxation); SamplerBase enforces them by rejection.
+    Equality constraints referencing dependent parameters raise, because an
+    equality on continuous values cannot be met by rejection sampling.
     """
 
     def __init__(self, pool_size: int = 100_000) -> None:
         self.pool_size = pool_size
 
-    def _candidates(self, space: ParameterSpace, seed: int) -> np.ndarray:
+    def _candidates(self, space: ParameterSpace, n: int, seed: int) -> np.ndarray:  # noqa: ARG002
         independent = space.independent_parameters
         numeric = [p for p in independent if isinstance(p, RangedParameter)]
         numeric_idx = [
@@ -132,6 +192,24 @@ class HopsySampler(SamplerBase):
         if not numeric:
             return np.zeros((self.pool_size, 0))
 
+        ind_names = {p.name for p in independent}
+        if any(
+            any(p.name not in ind_names for p in c.parameters)
+            for c in space._linear_equality_constraints
+        ):
+            raise ValueError(
+                "Linear equality constraints referencing dependent parameters "
+                "cannot be enforced by sampling; express the constraint in "
+                "independent parameters instead."
+            )
+        independent_rows = np.array(
+            [
+                all(p.name in ind_names for p in c.parameters)
+                for c in space._linear_constraints
+            ],
+            dtype=bool,
+        )
+
         log_indices = [
             i for i, p in enumerate(numeric) if not p.normalizer.is_linear
         ]
@@ -139,7 +217,11 @@ class HopsySampler(SamplerBase):
 
         lb_num = np.array([p.lb for p in numeric], dtype=float)
         ub_num = np.array([p.ub for p in numeric], dtype=float)
-        problem = hopsy.Problem(space.A_independent[:, numeric_idx], space.b, model)
+        problem = hopsy.Problem(
+            space.A_independent[independent_rows][:, numeric_idx],
+            space.b[independent_rows],
+            model,
+        )
         problem = hopsy.add_box_constraints(problem, lb_num, ub_num, simplify=False)
         if space._linear_equality_constraints:
             problem = hopsy.add_equality_constraints(
@@ -163,8 +245,22 @@ def chebyshev_center(space: ParameterSpace) -> np.ndarray:
     """Compute the Chebyshev center of the independent-variable polytope.
 
     Returns an independent-variable float vector in physical units.
+
+    Raises
+    ------
+    ValueError
+        If the space contains categorical parameters; a center is undefined
+        for them, and the polytope matrices would contain their all-zero
+        columns with infinite box bounds.
     """
     from packaging.version import Version
+
+    if space.categorical_parameters:
+        raise ValueError(
+            "The Chebyshev center is undefined for spaces with categorical "
+            "parameters. Compute it per category or remove the categorical "
+            "parameters."
+        )
 
     problem = hopsy.Problem(space.A_independent, space.b)
     problem = hopsy.add_box_constraints(

--- a/CADETProcess/parameter_space/sampling.py
+++ b/CADETProcess/parameter_space/sampling.py
@@ -5,12 +5,14 @@ SamplerBase defines the postprocessing contract (significant-digits snap, intege
 rounding via decode, categorical merge, dependency resolution, validation, and
 rejection of candidates violating linear constraints that reference dependent
 parameters).
-Concrete backends implement _candidates to produce numeric candidate rows and
+Concrete backends implement _candidates to produce numeric candidate rows,
+optionally with unit-interval columns for stratified categorical coverage, and
 declare via _sequential_candidates whether the row order carries structure.
 """
 
 from __future__ import annotations
 
+import math
 import warnings
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -93,8 +95,16 @@ class SamplerBase(ABC):
         if n <= 0:
             return []
 
-        candidates = self._candidates(space, n, seed)  # shape (pool_size, n_numeric)
+        candidates = self._candidates(space, n, seed)
         pool_size = candidates.shape[0]
+        n_numeric = len(numeric)
+        # Backends may append one unit-interval column per categorical
+        # parameter (QMC designs stratify categories); otherwise categories
+        # are drawn uniformly at random per candidate.
+        stratified_categoricals = (
+            bool(categorical)
+            and candidates.shape[1] == n_numeric + len(categorical)
+        )
 
         ts = space.transformed_space
         rng = np.random.default_rng(seed)
@@ -115,11 +125,20 @@ class SamplerBase(ABC):
         results = []
 
         for idx in order:
-            categorical_values = {
-                c.name: c.valid_values[int(rng.integers(len(c.valid_values)))]
-                for c in categorical
-            } or None
-            assignment = ts.decode(candidates[int(idx)], categorical_values)
+            row = candidates[int(idx)]
+            if stratified_categoricals:
+                categorical_values = {
+                    c.name: c.valid_values[
+                        min(int(u * len(c.valid_values)), len(c.valid_values) - 1)
+                    ]
+                    for c, u in zip(categorical, row[n_numeric:])
+                }
+            else:
+                categorical_values = {
+                    c.name: c.valid_values[int(rng.integers(len(c.valid_values)))]
+                    for c in categorical
+                } or None
+            assignment = ts.decode(row[:n_numeric], categorical_values)
 
             for p in numeric:
                 if p.significant_digits is not None:
@@ -164,6 +183,11 @@ class SamplerBase(ABC):
         *n* is the number of feasible samples requested; backends whose
         candidate count must match the request (QMC designs) size the pool
         from it, pool-based backends may ignore it.
+
+        Backends that stratify categorical parameters append one column per
+        categorical parameter (in ``space.categorical_parameters`` order)
+        holding unit-interval values; SamplerBase maps each value *u* to
+        category index ``floor(u * n_categories)``.
         """
 
 
@@ -239,6 +263,85 @@ class HopsySampler(SamplerBase):
                 mc, rng_hopsy, n_samples=self.pool_size, thinning=2
             )
         return states[0]  # shape (pool_size, n_numeric)
+
+
+class LatinHypercubeSampler(SamplerBase):
+    """Latin Hypercube sampler via scipy.stats.qmc.
+
+    Generates exactly *n* points, so the one-point-per-stratum property holds
+    for the returned set; a subset of a larger design would not be a Latin
+    Hypercube. Categorical parameters are stratified as extra design
+    dimensions, giving balanced category counts. Box-bounded spaces only:
+    raises if linear constraints are present, and any candidate rejected
+    during postprocessing exhausts the pool (a filtered design loses
+    stratification). Use HopsySampler for spaces that require rejection.
+    """
+
+    _sequential_candidates = True
+
+    def _candidates(self, space: ParameterSpace, n: int, seed: int) -> np.ndarray:
+        return _qmc_candidates(space, n, seed, "lhs")
+
+
+class SobolSampler(SamplerBase):
+    """Sobol sequence sampler via scipy.stats.qmc.
+
+    Generates the first ``2**ceil(log2(n))`` points of a scrambled Sobol
+    sequence and consumes them in order; prefixes of the sequence retain low
+    discrepancy, so a few postprocessing rejections are tolerated. Categorical
+    parameters are covered as extra sequence dimensions, giving balanced
+    category counts over full ``2**m`` blocks. Box-bounded spaces only: raises
+    if linear constraints are present. Use HopsySampler when linear
+    constraints are present.
+    """
+
+    _sequential_candidates = True
+
+    def _candidates(self, space: ParameterSpace, n: int, seed: int) -> np.ndarray:
+        return _qmc_candidates(space, n, seed, "sobol")
+
+
+def _qmc_candidates(
+    space: ParameterSpace,
+    n: int,
+    seed: int,
+    kind: str,
+) -> np.ndarray:
+    """Generate QMC candidates in physical units (box bounds only).
+
+    Categorical parameters are included as extra unit-interval design
+    dimensions (one column per categorical parameter, appended after the
+    numeric columns), so category coverage inherits the design's uniformity
+    instead of being drawn independently at random.
+    """
+    from scipy.stats.qmc import LatinHypercube, Sobol
+
+    independent = space.independent_parameters
+    numeric = [p for p in independent if isinstance(p, RangedParameter)]
+    categorical = space.categorical_parameters
+
+    if space._linear_constraints or space._linear_equality_constraints:
+        raise ValueError(
+            f"{kind.upper()} sampler requires a box-bounded space with no linear "
+            "constraints. Use HopsySampler when linear constraints are present."
+        )
+
+    d = len(numeric) + len(categorical)
+    if d == 0:
+        return np.zeros((n, 0))
+
+    if kind == "lhs":
+        engine = LatinHypercube(d=d, seed=seed)
+        unit = engine.random(n=n)
+    else:
+        engine = Sobol(d=d, seed=seed, scramble=True)
+        unit = engine.random_base2(m=max(0, math.ceil(math.log2(n))))
+
+    lb = np.array([p.lb for p in numeric], dtype=float)
+    ub = np.array([p.ub for p in numeric], dtype=float)
+    scaled = unit.copy()
+    scaled[:, : len(numeric)] = lb + unit[:, : len(numeric)] * (ub - lb)
+    return scaled
 
 
 def chebyshev_center(space: ParameterSpace) -> np.ndarray:

--- a/CADETProcess/parameter_space/sampling.py
+++ b/CADETProcess/parameter_space/sampling.py
@@ -1,0 +1,183 @@
+"""
+Sampler strategies for ParameterSpace.
+
+SamplerBase defines the postprocessing contract (significant-digits snap, integer
+rounding via decode, categorical merge, dependency resolution, validation).
+Concrete backends implement _candidates to produce numeric candidate rows.
+"""
+
+from __future__ import annotations
+
+import warnings
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Optional
+
+import hopsy
+import numpy as np
+
+from CADETProcess.numerics import round_to_significant_digits
+from CADETProcess.parameter_space.parameters import RangedParameter
+
+if TYPE_CHECKING:
+    from CADETProcess.parameter_space.space import ParameterSpace
+
+
+class _LogSpaceModel:
+    """hopsy log-space model for parameters with nonlinear normalizers (e.g. LogNormalizer).
+
+    Injects a Jacobian correction so hopsy draws are uniform in transformed space.
+    """
+
+    def __init__(self, log_indices: list[int]) -> None:
+        self.log_space_indices = log_indices
+
+    def compute_negative_log_likelihood(self, x: np.ndarray) -> float:
+        return float(np.sum(np.log(x[self.log_space_indices])))
+
+
+class SamplerBase(ABC):
+    """Abstract sampler strategy.
+
+    Concrete subclasses implement _candidates; this base class handles
+    postprocessing: significant-digits snap, integer rounding (via decode),
+    categorical merge, dependency resolution, and validation.
+    """
+
+    def sample(
+        self,
+        space: ParameterSpace,
+        n: int,
+        seed: Optional[int] = None,
+        include_dependent: bool = False,
+    ) -> list[dict[str, Any]]:
+        """Draw n feasible samples as named assignments."""
+        import random as _random
+
+        if seed is None:
+            seed = _random.randint(0, 255)
+
+        independent = space.independent_parameters
+        numeric = [p for p in independent if isinstance(p, RangedParameter)]
+        categorical = space.categorical_parameters
+
+        if numeric and any(np.isinf(p.lb) or np.isinf(p.ub) for p in numeric):
+            raise ValueError(
+                "Cannot sample a space with unbounded parameters. "
+                "Narrow lb/ub on all parameters before sampling."
+            )
+
+        candidates = self._candidates(space, seed)  # shape (pool_size, n_numeric)
+        pool_size = candidates.shape[0]
+
+        ts = space.transformed_space
+        rng = np.random.default_rng(seed)
+        results = []
+        counter = 0
+
+        while len(results) < n:
+            if counter >= pool_size:
+                raise ValueError(
+                    f"Could not find {n} feasible samples after exhausting the "
+                    f"{pool_size} candidates. "
+                    "Increase pool_size or relax dependent-parameter constraints."
+                )
+            idx = int(rng.integers(0, pool_size))
+            counter += 1
+
+            categorical_values = {
+                c.name: c.valid_values[int(rng.integers(len(c.valid_values)))]
+                for c in categorical
+            } or None
+            assignment = ts.decode(candidates[idx], categorical_values)
+
+            for p in numeric:
+                if p.significant_digits is not None:
+                    assignment[p.name] = float(
+                        round_to_significant_digits(assignment[p.name], p.significant_digits)
+                    )
+
+            try:
+                all_values = space.resolve(assignment)
+                for p in space._parameters:
+                    p.validate(all_values[p.name])
+            except (TypeError, ValueError):
+                continue
+
+            results.append(all_values if include_dependent else assignment)
+
+        return results
+
+    @abstractmethod
+    def _candidates(self, space: ParameterSpace, seed: int) -> np.ndarray:
+        """Return float array of shape (pool_size, n_numeric_independent)."""
+
+
+class HopsySampler(SamplerBase):
+    """Uniform polytope sampler using hopsy (Hit-and-Run MCMC).
+
+    The only correct choice when linear inequality or equality constraints are
+    present. Uses a log-space model for parameters with nonlinear normalizers.
+    """
+
+    def __init__(self, pool_size: int = 100_000) -> None:
+        self.pool_size = pool_size
+
+    def _candidates(self, space: ParameterSpace, seed: int) -> np.ndarray:
+        independent = space.independent_parameters
+        numeric = [p for p in independent if isinstance(p, RangedParameter)]
+        numeric_idx = [
+            i for i, p in enumerate(independent) if isinstance(p, RangedParameter)
+        ]
+
+        if not numeric:
+            return np.zeros((self.pool_size, 0))
+
+        log_indices = [
+            i for i, p in enumerate(numeric) if not p.normalizer.is_linear
+        ]
+        model = _LogSpaceModel(log_indices) if log_indices else None
+
+        lb_num = np.array([p.lb for p in numeric], dtype=float)
+        ub_num = np.array([p.ub for p in numeric], dtype=float)
+        problem = hopsy.Problem(space.A_independent[:, numeric_idx], space.b, model)
+        problem = hopsy.add_box_constraints(problem, lb_num, ub_num, simplify=False)
+        if space._linear_equality_constraints:
+            problem = hopsy.add_equality_constraints(
+                problem, space.A_eq_independent[:, numeric_idx], space.b_eq
+            )
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            problem = hopsy.round(problem, simplify=False)
+            mc = hopsy.MarkovChain(
+                problem, proposal=hopsy.UniformCoordinateHitAndRunProposal
+            )
+            rng_hopsy = hopsy.RandomNumberGenerator(seed=seed)
+            _, states = hopsy.sample(
+                mc, rng_hopsy, n_samples=self.pool_size, thinning=2
+            )
+        return states[0]  # shape (pool_size, n_numeric)
+
+
+def chebyshev_center(space: ParameterSpace) -> np.ndarray:
+    """Compute the Chebyshev center of the independent-variable polytope.
+
+    Returns an independent-variable float vector in physical units.
+    """
+    from packaging.version import Version
+
+    problem = hopsy.Problem(space.A_independent, space.b)
+    problem = hopsy.add_box_constraints(
+        problem,
+        space.lower_bounds_independent,
+        space.upper_bounds_independent,
+        simplify=False,
+    )
+    if space._linear_equality_constraints:
+        problem = hopsy.add_equality_constraints(
+            problem, space.A_eq_independent, space.b_eq
+        )
+    center = hopsy.compute_chebyshev_center(problem, original_space=True)
+    if Version(hopsy.__version__.strip('"')) < Version("1.7.0b"):
+        center = center[:, 0]
+    return center

--- a/CADETProcess/parameter_space/sampling.py
+++ b/CADETProcess/parameter_space/sampling.py
@@ -330,17 +330,26 @@ def _qmc_candidates(
     return scaled
 
 
-def chebyshev_center(space: ParameterSpace) -> np.ndarray:
+def chebyshev_center(space: ParameterSpace) -> dict[str, float | int]:
     """Compute the Chebyshev center of the independent-variable polytope.
 
-    Returns an independent-variable float vector in physical units.
+    Returns an independent-variable named assignment in physical units,
+    typed and snapped the same way as ``SamplerBase.sample()`` (``int`` for
+    integer parameters, significant-digits rounding where declared).
+
+    Linear inequality constraints referencing dependent parameters cannot be
+    part of the polytope (dependencies are arbitrary callables); they are
+    dropped with a warning and the center of the relaxed polytope is verified
+    against them a posteriori.
 
     Raises
     ------
     ValueError
-        If the space contains categorical parameters; a center is undefined
-        for them, and the polytope matrices would contain their all-zero
-        columns with infinite box bounds.
+        If the space contains categorical parameters (a center is undefined
+        for them), if any independent parameter is unbounded, if a linear
+        equality constraint references a dependent parameter (a dropped
+        equality can never survive a point check), or if the relaxed center
+        violates a dropped inequality constraint.
     """
     from packaging.version import Version
 
@@ -351,7 +360,41 @@ def chebyshev_center(space: ParameterSpace) -> np.ndarray:
             "parameters."
         )
 
-    problem = hopsy.Problem(space.A_independent, space.b)
+    if any(
+        np.isinf(p.lb) or np.isinf(p.ub) for p in space.independent_parameters
+    ):
+        raise ValueError(
+            "Cannot compute the Chebyshev center of an unbounded space. "
+            "Narrow lb/ub on all parameters first."
+        )
+
+    ind_names = {p.name for p in space.independent_parameters}
+    if any(
+        any(p.name not in ind_names for p in c.parameters)
+        for c in space._linear_equality_constraints
+    ):
+        raise ValueError(
+            "Linear equality constraints referencing dependent parameters "
+            "cannot be included in the Chebyshev polytope; express the "
+            "constraint in independent parameters instead."
+        )
+    keep = np.array(
+        [
+            all(p.name in ind_names for p in c.parameters)
+            for c in space._linear_constraints
+        ],
+        dtype=bool,
+    )
+    dropped = [c for c, k in zip(space._linear_constraints, keep) if not k]
+    if dropped:
+        warnings.warn(
+            f"{len(dropped)} linear constraint(s) reference dependent "
+            "parameters and cannot be included in the Chebyshev polytope; "
+            "computing the center of the relaxed polytope and verifying it "
+            "against the full constraints."
+        )
+
+    problem = hopsy.Problem(space.A_independent[keep], space.b[keep])
     problem = hopsy.add_box_constraints(
         problem,
         space.lower_bounds_independent,
@@ -365,4 +408,28 @@ def chebyshev_center(space: ParameterSpace) -> np.ndarray:
     center = hopsy.compute_chebyshev_center(problem, original_space=True)
     if Version(hopsy.__version__.strip('"')) < Version("1.7.0b"):
         center = center[:, 0]
-    return center
+
+    assignment = space.transformed_space.decode(center)
+    for p in space.independent_parameters:
+        if p.significant_digits is not None:
+            assignment[p.name] = float(
+                round_to_significant_digits(assignment[p.name], p.significant_digits)
+            )
+
+    if dropped:
+        all_values = space.resolve(assignment)
+        violated = [
+            c for c in dropped
+            if sum(coeff * all_values[p.name] for p, coeff in zip(c.parameters, c.lhs))
+            > c.b
+        ]
+        if violated:
+            raise ValueError(
+                "The center of the relaxed polytope violates "
+                f"{len(violated)} linear constraint(s) referencing dependent "
+                "parameters. Express the constraint in independent parameters, "
+                "or use create_initial_values / sampling for a feasible "
+                "starting point."
+            )
+
+    return assignment

--- a/CADETProcess/parameter_space/sampling.py
+++ b/CADETProcess/parameter_space/sampling.py
@@ -3,8 +3,8 @@ Sampler strategies for ParameterSpace.
 
 SamplerBase defines the postprocessing contract (significant-digits snap, integer
 rounding via decode, categorical merge, dependency resolution, validation, and
-rejection of candidates violating linear constraints that reference dependent
-parameters).
+rejection of candidates violating linear inequality constraints on the resolved
+values).
 Concrete backends implement _candidates to produce numeric candidate rows,
 optionally with unit-interval columns for stratified categorical coverage, and
 declare via _sequential_candidates whether the row order carries structure.
@@ -15,7 +15,6 @@ from __future__ import annotations
 import math
 import warnings
 from abc import ABC, abstractmethod
-from collections.abc import Callable
 from typing import TYPE_CHECKING, Any, Optional
 
 import hopsy
@@ -47,8 +46,10 @@ class SamplerBase(ABC):
     Concrete subclasses implement _candidates; this base class handles
     postprocessing: significant-digits snap, integer rounding (via decode),
     categorical merge, dependency resolution, validation, and rejection of
-    candidates that violate linear constraints referencing dependent
-    parameters (those constraints cannot be part of the candidate polytope).
+    candidates that violate linear inequality constraints on the resolved
+    values (constraints referencing dependent parameters cannot be part of
+    the candidate polytope, and the snap and integer rounding perturb
+    candidates after polytope enforcement).
     """
 
     #: When True, candidates are consumed in row order because the order
@@ -63,18 +64,8 @@ class SamplerBase(ABC):
         n: int,
         seed: Optional[int] = None,
         include_dependent: bool = False,
-        validate: Optional[Callable[[np.ndarray], bool]] = None,
     ) -> list[dict[str, Any]]:
-        """Draw n feasible samples as named assignments.
-
-        Parameters
-        ----------
-        validate : callable, optional
-            Extra feasibility check called with the independent numeric vector
-            (physical units) after parameter-level validation passes.  Intended
-            for callers that enforce constraints not captured by the polytope
-            (e.g. linear constraints referencing dependent parameters).
-        """
+        """Draw n feasible samples as named assignments."""
         import random as _random
 
         if seed is None:
@@ -109,13 +100,11 @@ class SamplerBase(ABC):
         ts = space.transformed_space
         rng = np.random.default_rng(seed)
 
-        # Constraints referencing dependent parameters cannot be expressed in
-        # the independent-variable polytope; they are enforced by rejection.
-        ind_names = {p.name for p in independent}
-        dependent_constraints = [
-            c for c in space._linear_constraints
-            if any(p.name not in ind_names for p in c.parameters)
-        ]
+        # All inequality constraints are re-checked on the resolved values:
+        # constraints referencing dependent parameters cannot be expressed in
+        # the independent-variable polytope, and the significant-digits snap
+        # and integer rounding perturb candidates after polytope enforcement.
+        inequality_constraints = space._linear_constraints
 
         order = (
             np.arange(pool_size)
@@ -156,11 +145,8 @@ class SamplerBase(ABC):
             if any(
                 sum(coeff * all_values[p.name] for p, coeff in zip(c.parameters, c.lhs))
                 > c.b
-                for c in dependent_constraints
+                for c in inequality_constraints
             ):
-                continue
-
-            if validate is not None and not validate(ts.encode(assignment)):
                 continue
 
             results.append(all_values if include_dependent else assignment)

--- a/CADETProcess/parameter_space/space.py
+++ b/CADETProcess/parameter_space/space.py
@@ -53,7 +53,6 @@ when transformed constraint matrices are assembled by ``TransformedSpace``; see
 from __future__ import annotations
 
 import inspect
-import random
 import warnings
 from collections.abc import Callable, Mapping
 from functools import wraps
@@ -62,7 +61,6 @@ from typing import TYPE_CHECKING, Any, Optional
 if TYPE_CHECKING:
     from CADETProcess.parameter_space.transformed_space import TransformedSpace
 
-import hopsy
 import numpy as np
 import numpy.typing as npt
 
@@ -998,34 +996,21 @@ class ParameterSpace:
     ) -> list[dict[str, Any]]:
         """Draw *n* feasible samples as named assignments.
 
-        Numeric independent parameters are drawn with hopsy (Highly Optimized
-        toolbox for Polytope Sampling) over the numeric polytope; categorical
-        parameters are drawn uniformly over their ``valid_values`` and merged
-        into the assignment.  For parameters with a non-linear normalizer
-        (e.g. ``LogNormalizer``) a custom log-likelihood model is injected so
-        that samples are distributed uniformly in the transformed space.
-        Integer positions are rounded by ``decode``.
-
-        Derived parameter feasibility is enforced by post-hoc filtering: each
-        candidate is resolved via ``resolve`` and validated; infeasible
-        candidates are discarded and new draws are attempted.
+        Delegates to :class:`HopsySampler` with the given *pool_size*.
+        See :class:`~CADETProcess.parameter_space.sampling.SamplerBase` for
+        the full postprocessing contract (significant-digits snap, integer
+        rounding, categorical merge, dependency resolution, validation).
 
         Parameters
         ----------
         n : int
             Number of feasible samples to return.
         seed : int, optional
-            Random seed for hopsy and the draw RNG.  A random seed in [0, 255] is
-            used when not specified, matching the behaviour of
-            ``OptimizationProblem.create_initial_values``.
+            Random seed.  A random seed in [0, 255] is used when not specified.
         pool_size : int
-            Number of MCMC steps used to build the candidate pool.  The default
-            (100 000) is sufficient for most problems; reduce for fast tests.
+            MCMC steps used to build the candidate pool.
         include_dependent : bool
-            When False (default) each assignment contains only the independent
-            parameters.  When True each assignment contains all parameters in
-            registration order, with dependent parameters resolved from the
-            independent ones.
+            When True each assignment includes resolved dependent parameters.
 
         Returns
         -------
@@ -1037,88 +1022,11 @@ class ParameterSpace:
         ValueError
             If *n* feasible samples cannot be found within the *pool_size* budget.
         """
+        from CADETProcess.parameter_space.sampling import HopsySampler
 
-        class _LogSpaceModel:
-            def __init__(self, log_indices: list[int]) -> None:
-                self.log_space_indices = log_indices
-
-            def compute_negative_log_likelihood(self, x: np.ndarray) -> float:
-                # Jacobian correction: uniform in log-transformed coordinates
-                return float(np.sum(np.log(x[self.log_space_indices])))
-
-        independent = self.independent_parameters
-        numeric = [p for p in independent if isinstance(p, RangedParameter)]
-        numeric_idx = [
-            i for i, p in enumerate(independent) if isinstance(p, RangedParameter)
-        ]
-        categorical = self.categorical_parameters
-
-        log_indices = [
-            i for i, p in enumerate(numeric) if not p.normalizer.is_linear
-        ]
-        model = _LogSpaceModel(log_indices) if log_indices else None
-
-        if seed is None:
-            seed = random.randint(0, 255)
-
-        if numeric:
-            # Constraints never reference categorical parameters (rejected at
-            # declaration time), so slicing to the numeric columns drops only
-            # zeros.
-            lb_num = np.array([p.lb for p in numeric], dtype=float)
-            ub_num = np.array([p.ub for p in numeric], dtype=float)
-            problem = hopsy.Problem(self.A_independent[:, numeric_idx], self.b, model)
-            problem = hopsy.add_box_constraints(problem, lb_num, ub_num, simplify=False)
-            if self._linear_equality_constraints:
-                problem = hopsy.add_equality_constraints(
-                    problem, self.A_eq_independent[:, numeric_idx], self.b_eq
-                )
-
-            with warnings.catch_warnings():
-                warnings.simplefilter("ignore")
-                problem = hopsy.round(problem, simplify=False)
-                mc = hopsy.MarkovChain(
-                    problem, proposal=hopsy.UniformCoordinateHitAndRunProposal
-                )
-                rng_hopsy = hopsy.RandomNumberGenerator(seed=seed)
-                _, states = hopsy.sample(
-                    mc, rng_hopsy, n_samples=pool_size, thinning=2
-                )
-            candidates = states[0]  # shape (pool_size, len(numeric))
-        else:
-            # Purely categorical space: the numeric polytope is empty.
-            candidates = np.zeros((pool_size, 0))
-        ts = self.transformed_space
-        rng = np.random.default_rng(seed)
-        results = []
-        counter = 0
-
-        while len(results) < n:
-            if counter >= pool_size:
-                raise ValueError(
-                    f"Could not find {n} feasible samples after exhausting the "
-                    f"{pool_size} candidates. "
-                    "Increase pool_size or relax dependent-parameter constraints."
-                )
-            idx = int(rng.integers(0, pool_size))
-            counter += 1
-
-            categorical_values = {
-                c.name: c.valid_values[int(rng.integers(len(c.valid_values)))]
-                for c in categorical
-            } or None
-            assignment = ts.decode(candidates[idx], categorical_values)
-
-            try:
-                all_values = self.resolve(assignment)
-                for p in self._parameters:
-                    p.validate(all_values[p.name])
-            except (TypeError, ValueError):
-                continue
-
-            results.append(all_values if include_dependent else assignment)
-
-        return results
+        return HopsySampler(pool_size=pool_size).sample(
+            self, n, seed=seed, include_dependent=include_dependent
+        )
 
     def __repr__(self) -> str:
         """Return a readable representation."""

--- a/CADETProcess/parameter_space/space.py
+++ b/CADETProcess/parameter_space/space.py
@@ -1006,7 +1006,7 @@ class ParameterSpace:
         n : int
             Number of feasible samples to return.
         seed : int, optional
-            Random seed.  A random seed in [0, 255] is used when not specified.
+            Random seed. A random 32-bit seed is drawn when not specified.
         pool_size : int
             MCMC steps used to build the candidate pool.
         include_dependent : bool

--- a/docs/source/release_notes/v0.13.0.md
+++ b/docs/source/release_notes/v0.13.0.md
@@ -31,6 +31,16 @@ The `diskcache` dependency is replaced by pipefunc's built-in cache backends; pa
 `add_variable` now accepts `parameter_type=int` for integer variables, and a new `add_choice_variable` method registers categorical variables with a finite set of allowed values.
 Optimizers declare support via `supports_integer_variables` and `supports_categorical_variables` flags (default False); `check_optimization_problem` rejects problems with unsupported variable types before the run starts.
 
+### Sampler abstraction ([#405](https://github.com/fau-advanced-separations/CADET-Process/pull/405))
+
+Sampling strategies are now pluggable.
+`SamplerBase` owns the feasibility contract; concrete backends supply candidates.
+`HopsySampler` (uniform polytope sampling, the default) is joined by `LatinHypercubeSampler` and `SobolSampler`, which produce space-filling designs for box-bounded problems, e.g. surrogate training data, and can be passed to `create_initial_values` via the new `sampler` argument.
+Sampled values carry proper types: `int` for integer variables, declared values for categorical ones.
+`get_chebyshev_center` now verifies the returned point against linear constraints referencing dependent variables and raises rather than returning an infeasible point.
+Optimizers declare `supports_unbounded_parameters` (default False); unbounded problems are rejected up front for optimizers that need a sampled initial population.
+A new user guide page, Parameter Spaces and Sampling, covers standalone usage.
+
 ### Jacobian methods support caller-specified evaluation space
 
 `OptimizationProblem.objective_jacobian` and `nonlinear_constraint_jacobian` accept `untransform`, `get_dependent_values`, and `ensure_minimization` as explicit keyword arguments, forwarded through `approximate_jac` so that perturbation and function evaluation occur in the same space.

--- a/docs/source/user_guide/optimization/index.md
+++ b/docs/source/user_guide/optimization/index.md
@@ -61,4 +61,5 @@ multi_objective_optimization
 variable_indices
 variable_normalization
 variable_dependencies
+parameter_space
 ```

--- a/docs/source/user_guide/optimization/optimization_problem.md
+++ b/docs/source/user_guide/optimization/optimization_problem.md
@@ -294,8 +294,8 @@ To facilitate the definition of starting points, the {class}`~CADETProcess.optim
 ```{note}
 This method only works if all optimization variables have defined lower and upper bounds.
 
-Moreover, this method only guarantees that linear constraints are fulfilled.
-Any nonlinear constraints may not be satisfied by the generated samples, and nonlinear parameter dependencies can be challenging to incorporate.
+Generated samples satisfy bounds and linear constraints, including bounds on dependent variables and linear constraints referencing dependent variables, which are enforced by rejection.
+Nonlinear constraints are not checked; samples may violate them.
 ```
 
 ```{code-cell} ipython3
@@ -322,7 +322,7 @@ optimization_problem.get_chebyshev_center()
 ```
 
 It is also possible to generate multiple samples at once.
-For this purpose, [hopsy](https://modsim.github.io/hopsy/) is used to efficiently (uniformly) sample the parameter space.
+By default, [hopsy](https://modsim.github.io/hopsy/) is used to efficiently (uniformly) sample the parameter space; alternative strategies such as Latin Hypercube sampling can be passed via the `sampler` argument (see {ref}`parameter_space_guide`).
 
 ```{code-cell} ipython3
 x = optimization_problem.create_initial_values(n_samples=1000)

--- a/docs/source/user_guide/optimization/optimizer.md
+++ b/docs/source/user_guide/optimization/optimizer.md
@@ -149,12 +149,12 @@ The {meth}`~CADETProcess.optimization.OptimizationResults.plot_convergence` meth
 _ = optimization_results.plot_convergence()
 ```
 
-The {meth}`~CADETProcess.optimization.OptimizationResults.plot_corner` method plots each evaluated variable value against every other variable in a set of scatter plots.
+The {meth}`~CADETProcess.optimization.OptimizationResults.plot_pairwise` method plots each evaluated variable value against every other variable in a set of scatter plots.
 The corner plot is particularly useful when exploring high-dimensional data or parameter spaces, as it allows us to identify correlations and dependencies between variables, and to visualize the marginal distributions of each variable.
 It is also useful when we want to compare the distribution of variables across different subsets of the data or parameter space.
 
 ```{code-cell} ipython3
-optimization_results.plot_corner()
+optimization_results.plot_pairwise()
 ```
 
 ```{code-cell} ipython3

--- a/docs/source/user_guide/optimization/parameter_space.md
+++ b/docs/source/user_guide/optimization/parameter_space.md
@@ -1,0 +1,205 @@
+---
+jupytext:
+  text_representation:
+    format_name: myst
+kernelspec:
+  display_name: Python 3
+  name: python3
+---
+
+(parameter_space_guide)=
+# Parameter Spaces and Sampling
+
+The {class}`~CADETProcess.parameter_space.ParameterSpace` defines a feasible domain and writes parameter values into model objects.
+It is the foundation that {class}`~CADETProcess.optimization.OptimizationProblem` builds on, but it is also useful on its own: design-of-experiments studies, surrogate training data, and sensitivity screenings all need feasible parameter samples without any optimizer involved.
+This guide shows how to build a space, assign values, and draw samples with different strategies.
+
+## Defining a Parameter Space
+
+A parameter space connects parameter declarations to attributes of one or more evaluation objects.
+Any Python object with writable attributes works; in practice this is usually a {class}`~CADETProcess.processModel.Process`.
+
+```{code-cell} ipython3
+from dataclasses import dataclass
+
+from CADETProcess.parameter_space import ParameterSpace, RangedParameter
+
+
+@dataclass
+class Column:
+    length: float = 0.5
+    diameter: float = 0.05
+
+
+column = Column()
+
+space = ParameterSpace()
+space.add_evaluation_object(column)
+space.add_parameter(
+    RangedParameter("length", float, lb=0.1, ub=1.0), path="length"
+)
+space.add_parameter(
+    RangedParameter("diameter", float, lb=0.01, ub=0.2), path="diameter"
+)
+space
+```
+
+Each {class}`~CADETProcess.parameter_space.RangedParameter` declares a name, a type, and bounds; the `path` tells the space where the value lives on the evaluation object.
+
+## Named Assignments
+
+Values are written as named assignments, plain dictionaries mapping parameter names to physical values.
+
+```{code-cell} ipython3
+space.set_values({"length": 0.75, "diameter": 0.04})
+column
+```
+
+Reading goes through {meth}`~CADETProcess.parameter_space.ParameterSpace.get_value`.
+
+```{code-cell} ipython3
+space.get_value("length")
+```
+
+## Dependencies
+
+A dependent parameter is computed from other parameters via a transform.
+The assignment then only contains the independent parameters; the space resolves the rest.
+
+```{code-cell} ipython3
+length, diameter = space.independent_parameters
+space.add_dependency(diameter, [length], transform=lambda le: le / 10)
+
+space.set_values({"length": 0.6})
+column
+```
+
+{meth}`~CADETProcess.parameter_space.ParameterSpace.resolve` returns the full assignment without writing anything.
+
+```{code-cell} ipython3
+space.resolve({"length": 0.6})
+```
+
+## Linear Constraints
+
+Linear inequality constraints of the form $A x \le b$ restrict the feasible domain beyond the box bounds.
+
+```{code-cell} ipython3
+from CADETProcess.parameter_space import LinearConstraint
+
+flow = ParameterSpace()
+flow.add_evaluation_object(Column())
+q_load = RangedParameter("q_load", float, lb=0.0, ub=10.0)
+q_elute = RangedParameter("q_elute", float, lb=0.0, ub=10.0)
+flow.add_parameter(q_load, path="length")
+flow.add_parameter(q_elute, path="diameter")
+
+# q_load must not exceed q_elute
+flow.add_linear_constraint(LinearConstraint([q_load, q_elute], lhs=[1, -1], b=0))
+```
+
+## Sampling
+
+{meth}`~CADETProcess.parameter_space.ParameterSpace.sample` draws feasible points as named assignments.
+All samples respect bounds, linear constraints, and dependencies; constraints referencing dependent parameters are enforced by rejection.
+
+```{code-cell} ipython3
+flow.sample(3, seed=42)
+```
+
+Passing a `seed` makes the draw reproducible; unseeded calls use a fresh random seed.
+
+### Sampling Strategies
+
+Three sampler backends are available, all sharing the same interface.
+
+{class}`~CADETProcess.parameter_space.HopsySampler` draws uniformly from the constrained polytope via Markov chain Monte Carlo ([hopsy](https://modsim.github.io/hopsy/)).
+It is the default used by `space.sample()` and the only correct choice when linear constraints are present.
+
+{class}`~CADETProcess.parameter_space.LatinHypercubeSampler` and {class}`~CADETProcess.parameter_space.SobolSampler` produce space-filling designs for box-bounded spaces, the right tool for surrogate training data and design-of-experiments.
+Both raise when linear constraints are present, because filtering a quasi-Monte-Carlo design destroys its uniformity guarantees.
+
+```{code-cell} ipython3
+from CADETProcess.parameter_space import HopsySampler, LatinHypercubeSampler
+
+box = ParameterSpace()
+box.add_evaluation_object(Column())
+box.add_parameter(RangedParameter("x_0", float, lb=0.0, ub=1.0), path="length")
+box.add_parameter(RangedParameter("x_1", float, lb=0.0, ub=1.0), path="diameter")
+
+uniform = HopsySampler(pool_size=2000).sample(box, 64, seed=0)
+lhs = LatinHypercubeSampler().sample(box, 64, seed=0)
+```
+
+The difference is visible directly: uniform draws cluster and leave gaps, the Latin Hypercube covers every stratum exactly once per dimension.
+
+```{code-cell} ipython3
+import matplotlib.pyplot as plt
+
+fig, axes = plt.subplots(1, 2, figsize=(8, 4), sharey=True)
+for ax, samples, title in [
+    (axes[0], uniform, "HopsySampler (uniform)"),
+    (axes[1], lhs, "LatinHypercubeSampler"),
+]:
+    ax.scatter([s["x_0"] for s in samples], [s["x_1"] for s in samples])
+    ax.set_title(title)
+    ax.set_xlabel(r"$x_0$")
+axes[0].set_ylabel(r"$x_1$")
+fig.tight_layout()
+```
+
+### Integer and Categorical Parameters
+
+Integer parameters are declared with `int` as the parameter type; sampled assignments carry proper `int` values.
+Categorical parameters are declared as {class}`~CADETProcess.parameter_space.ChoiceParameter` and have no numeric position; samplers draw them alongside the numeric dimensions.
+The quasi-Monte-Carlo samplers treat each categorical parameter as an extra design dimension, so category counts come out balanced.
+
+```{code-cell} ipython3
+from CADETProcess.parameter_space import ChoiceParameter
+
+mixed = ParameterSpace()
+mixed.add_evaluation_object(Column())
+mixed.add_parameter(RangedParameter("n_plates", int, lb=10, ub=100), path="length")
+mixed.add_parameter(ChoiceParameter("resin", ["A", "B"]))
+
+samples = LatinHypercubeSampler().sample(mixed, 10, seed=0)
+samples[:3]
+```
+
+```{code-cell} ipython3
+[s["resin"] for s in samples].count("A")
+```
+
+## Chebyshev Center
+
+The Chebyshev center is the center of the largest ball inscribed in the constrained polytope, a robust interior starting point.
+
+```{code-cell} ipython3
+from CADETProcess.parameter_space import chebyshev_center
+
+chebyshev_center(flow)
+```
+
+```{note}
+The center is undefined for spaces with categorical parameters and raises in that case.
+Linear constraints referencing dependent parameters cannot enter the polytope; they are dropped with a warning and the returned point is verified against them, so the result is either feasible or a `ValueError`.
+```
+
+```{note}
+The center is the center of the largest inscribed ball, not the midpoint of the box bounds.
+In an anisotropic space (e.g. one parameter spanning `1` to `600`, another spanning `1e-8` to `1e-4`), the ball's radius is capped by the narrowest dimension, leaving it free to slide along the wider ones: the center can land close to a bound on the wide dimension rather than near its middle.
+```
+
+## Use with OptimizationProblem
+
+{meth}`~CADETProcess.optimization.OptimizationProblem.create_initial_values` accepts any sampler via the `sampler` argument, which is useful when the initial population doubles as a space-filling design.
+
+```{code-cell} ipython3
+from CADETProcess.optimization import OptimizationProblem
+
+problem = OptimizationProblem("sampling_demo", use_diskcache=False)
+problem.add_variable("x_0", lb=0, ub=8)
+problem.add_variable("x_1", lb=0, ub=1)
+
+problem.create_initial_values(8, seed=1, sampler=LatinHypercubeSampler())
+```

--- a/tests/optimization/test_optimization_problem.py
+++ b/tests/optimization/test_optimization_problem.py
@@ -139,6 +139,30 @@ def test_create_initial_values_invariants(op_with_linear_constraint):
     assert not np.allclose(x, x_other)
 
 
+def test_create_initial_values_with_custom_sampler():
+    from CADETProcess.parameter_space import LatinHypercubeSampler
+
+    op = OptimizationProblem("box", use_diskcache=False)
+    op.add_variable("x_0", lb=0, ub=8)
+    op.add_variable("x_1", lb=0, ub=1)
+
+    x = op.create_initial_values(8, seed=1, sampler=LatinHypercubeSampler())
+    assert x.shape == (8, 2)
+    assert np.all(x >= op.lower_bounds)
+    assert np.all(x <= op.upper_bounds)
+    # LHS stratification: one point per unit stratum along x_0
+    assert sorted(int(np.floor(v)) for v in x[:, 0]) == list(range(8))
+
+
+def test_create_initial_values_custom_sampler_rejects_linear_constraints(
+    op_with_linear_constraint,
+):
+    from CADETProcess.parameter_space import SobolSampler
+
+    with pytest.raises(ValueError, match="linear constraints"):
+        op_with_linear_constraint.create_initial_values(4, seed=0, sampler=SobolSampler())
+
+
 # ── Dependent variables ──────────────────────────────────────────────────────
 
 

--- a/tests/optimization/test_optimization_problem.py
+++ b/tests/optimization/test_optimization_problem.py
@@ -172,19 +172,23 @@ def test_dependent_variable_names(op_with_dependent_variable):
         op.add_variable_dependency("spam", ["bar", "spam"], transform=None)
 
 
-def test_chebyshev_center_with_dependent_variable(op_with_dependent_variable):
+def test_chebyshev_center_dependent_constraints_never_silently_violated(
+    op_with_dependent_variable,
+):
+    # Constraints referencing the dependent 'spam' are dropped from the
+    # polytope with a warning; the contract is that the returned center is
+    # verified against them, so the outcome is either a feasible point or a
+    # ValueError, never a silently infeasible point.  Which of the two occurs
+    # depends on where the LP places the degenerate 'bar' coordinate.
     op = op_with_dependent_variable
-
-    x_ind = op.get_chebyshev_center(include_dependent_variables=False)
-    assert x_ind.shape == (3,)
-
-    x_full = op.get_dependent_values(x_ind)
-    assert x_full.shape == (4,)
-    # spam is a copy of bar.
-    np.testing.assert_allclose(x_full[2], x_full[1])
-
-    x_full_direct = op.get_chebyshev_center(include_dependent_variables=True)
-    np.testing.assert_allclose(x_full, x_full_direct)
+    with pytest.warns(UserWarning, match="relaxed polytope"):
+        try:
+            x = op.get_chebyshev_center(include_dependent_variables=True)
+        except ValueError:
+            return
+    assert op.check_individual(
+        x, get_dependent_values=False, check_nonlinear_constraints=False
+    )
 
 
 def test_create_initial_values_with_dependent_variable(op_with_dependent_variable):

--- a/tests/optimization/test_optimization_problem.py
+++ b/tests/optimization/test_optimization_problem.py
@@ -1028,6 +1028,41 @@ def test_optimizer_rejects_categorical_variables():
     assert any("categorical" in str(warning.message).lower() for warning in w)
 
 
+def test_optimizer_rejects_unbounded_parameters():
+    from CADETProcess.optimization.scipyAdapter import NelderMead
+
+    op = OptimizationProblem("unbound_reject", use_diskcache=False)
+    op.add_variable("x", lb=0, ub=float("inf"), evaluation_objects=None)
+    op.add_objective(lambda x: x[0])
+
+    optimizer = NelderMead()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        result = optimizer.check_optimization_problem(op)
+    assert not result
+    assert any("unbounded" in str(warning.message).lower() for warning in w)
+
+
+def test_optimizer_supporting_unbounded_requires_x0():
+    from CADETProcess.optimization.optimizer import OptimizerBase
+
+    class UnboundedOptimizer(OptimizerBase):
+        supports_single_objective = True
+        supports_bounds = True
+        supports_unbounded_parameters = True
+
+        def _run(self, op, x0, *args, **kwargs):
+            pass
+
+    op = OptimizationProblem("unbound_x0", use_diskcache=False)
+    op.add_variable("x", lb=0, ub=float("inf"), evaluation_objects=None)
+    op.add_objective(lambda x: x[0])
+
+    optimizer = UnboundedOptimizer()
+    with pytest.raises(ValueError, match="x0 must be provided"):
+        optimizer.optimize(op, x0=None)
+
+
 # ── Multi-criteria decision functions ─────────────────────────────────────────
 
 

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -4,6 +4,7 @@ import numpy as np
 import pytest
 from CADETProcess.parameter_space import (
     ChoiceParameter,
+    HopsySampler,
     LinearConstraint,
     ParameterSpace,
     RangedParameter,
@@ -216,3 +217,56 @@ def test_sample_exhausted_budget_raises(column):
     space.add_dependency(b, [a], transform=lambda x: x * 100)
     with pytest.raises(ValueError, match="pool_size"):
         space.sample(1, seed=0, pool_size=50)
+
+
+# ── HopsySampler: direct use ──────────────────────────────────────────────────
+
+
+def test_hopsy_sampler_direct_use(column):
+    space = _space_2d(column)
+    sampler = HopsySampler(pool_size=BURN_IN)
+    samples = sampler.sample(space, 5, seed=0)
+    assert len(samples) == 5
+    assert all(0.0 <= s["length"] <= 5.0 for s in samples)
+    assert all(0.0 <= s["diameter"] <= 2.0 for s in samples)
+
+
+def test_hopsy_sampler_same_result_as_space_sample(column):
+    space = _space_1d(column)
+    sampler = HopsySampler(pool_size=BURN_IN)
+    direct = sampler.sample(space, 5, seed=99)
+    via_space = space.sample(5, seed=99, pool_size=BURN_IN)
+    assert direct == via_space
+
+
+# ── unbounded guard ───────────────────────────────────────────────────────────
+
+
+def test_sample_raises_on_unbounded_parameter(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=float("inf")), path="length"
+    )
+    with pytest.raises(ValueError, match="unbounded"):
+        space.sample(1, seed=0, pool_size=50)
+
+
+# ── significant-digits snap ───────────────────────────────────────────────────
+
+
+def test_sample_significant_digits_snap(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.001, ub=0.999, significant_digits=2),
+        path="length",
+    )
+    samples = space.sample(20, seed=0, pool_size=BURN_IN)
+    for s in samples:
+        v = s["length"]
+        # After snapping to 2 significant digits the value must equal itself re-rounded
+        import math
+        if v != 0.0:
+            magnitude = 10 ** (math.floor(math.log10(abs(v))) - 1)
+            assert abs(v - round(v / magnitude) * magnitude) < 1e-12 * abs(v) + 1e-15

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -284,6 +284,19 @@ def test_sample_dependent_linear_constraint_not_overtightened(column):
     assert any(s["a"] > 2.0 for s in samples)
 
 
+def test_sample_integer_rounding_cannot_violate_linear_constraint(column):
+    # candidates in (3.5, 3.6] satisfy the polytope but round to 4; the
+    # resolved-value re-check must reject them, since the polytope only
+    # constrains the pre-rounding value
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    n = RangedParameter("n", int, lb=1, ub=10)
+    space.add_parameter(n, path="length")
+    space.add_linear_constraint(LinearConstraint([n], lhs=[1.0], b=3.6))
+    samples = space.sample(20, seed=0, pool_size=BURN_IN)
+    assert all(s["n"] <= 3.6 for s in samples)
+
+
 def test_sample_raises_on_dependent_equality_constraint(column):
     space = ParameterSpace()
     space.add_evaluation_object(column)

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -6,8 +6,10 @@ from CADETProcess.parameter_space import (
     ChoiceParameter,
     HopsySampler,
     LinearConstraint,
+    LinearEqualityConstraint,
     ParameterSpace,
     RangedParameter,
+    chebyshev_center,
 )
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
@@ -239,6 +241,62 @@ def test_hopsy_sampler_same_result_as_space_sample(column):
     assert direct == via_space
 
 
+def test_sample_candidates_drawn_without_replacement(column):
+    space = _space_1d(column)
+    samples = space.sample(30, seed=2, pool_size=50)
+    values = [s["length"] for s in samples]
+    assert len(set(values)) == len(values)
+
+
+# ── linear constraints referencing dependent parameters ──────────────────────
+
+
+def test_sample_enforces_dependent_linear_constraint_by_rejection(column):
+    # a + b <= 4 with b = a means a <= 2; the polytope only sees the
+    # independent column (a <= 4), so rejection must enforce the rest
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=5.0)
+    b = RangedParameter("b", float, lb=0.0, ub=10.0)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_dependency(b, [a], transform=lambda x: x)
+    space.add_linear_constraint(LinearConstraint([a, b], lhs=[1.0, 1.0], b=4.0))
+    samples = space.sample(20, seed=0, pool_size=BURN_IN)
+    assert all(2 * s["a"] <= 4.0 + 1e-9 for s in samples)
+
+
+def test_sample_dependent_linear_constraint_not_overtightened(column):
+    # a + b <= 0 with b = -a holds everywhere; slicing the dependent column
+    # away would wrongly enforce a <= 0 and reject the entire box
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=5.0)
+    b = RangedParameter("b", float, lb=-5.0, ub=0.0)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_dependency(b, [a], transform=lambda x: -x)
+    space.add_linear_constraint(LinearConstraint([a, b], lhs=[1.0, 1.0], b=0.0))
+    samples = space.sample(20, seed=1, pool_size=BURN_IN)
+    assert len(samples) == 20
+    assert any(s["a"] > 2.0 for s in samples)
+
+
+def test_sample_raises_on_dependent_equality_constraint(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=5.0)
+    b = RangedParameter("b", float, lb=0.0, ub=10.0)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_dependency(b, [a], transform=lambda x: x)
+    space.add_linear_equality_constraint(
+        LinearEqualityConstraint([a, b], lhs=[1.0, -1.0], b=0.0)
+    )
+    with pytest.raises(ValueError, match="dependent"):
+        space.sample(1, seed=0, pool_size=50)
+
+
 # ── unbounded guard ───────────────────────────────────────────────────────────
 
 
@@ -270,3 +328,29 @@ def test_sample_significant_digits_snap(column):
         if v != 0.0:
             magnitude = 10 ** (math.floor(math.log10(abs(v))) - 1)
             assert abs(v - round(v / magnitude) * magnitude) < 1e-12 * abs(v) + 1e-15
+
+
+# ── chebyshev center ──────────────────────────────────────────────────────────
+
+
+def test_chebyshev_center_raises_on_categorical_space(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=5.0), path="length"
+    )
+    space.add_parameter(ChoiceParameter("mode", ["a", "b"]))
+    with pytest.raises(ValueError, match="categorical"):
+        chebyshev_center(space)
+
+
+# ── unseeded sampling ─────────────────────────────────────────────────────────
+
+
+def test_sample_unseeded_calls_differ(column):
+    # pins that unseeded calls do not share a default seed; with the former
+    # 0..255 seed range this collided once every 256 calls
+    space = _space_1d(column)
+    s1 = space.sample(3, pool_size=200)
+    s2 = space.sample(3, pool_size=200)
+    assert s1 != s2

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -467,6 +467,71 @@ def test_chebyshev_center_raises_on_categorical_space(column):
         chebyshev_center(space)
 
 
+def _space_with_dependent_constraint(column, b_constraint):
+    # b = 2a; constraint a + b <= b_constraint means the true constraint
+    # is 3a <= b_constraint, invisible to the independent-only polytope
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=1.0)
+    b = RangedParameter("b", float, lb=0.0, ub=10.0)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_dependency(b, [a], transform=lambda x: 2 * x)
+    space.add_linear_constraint(LinearConstraint([a, b], lhs=[1.0, 1.0], b=b_constraint))
+    return space
+
+
+def test_chebyshev_center_warns_and_verifies_slack_dependent_constraint(column):
+    # relaxed center a = 0.5 satisfies 3a <= 100: warn, verify, return
+    space = _space_with_dependent_constraint(column, b_constraint=100.0)
+    with pytest.warns(UserWarning, match="relaxed polytope"):
+        center = chebyshev_center(space)
+    assert center.keys() == {"a"}
+    np.testing.assert_allclose(center["a"], 0.5)
+
+
+def test_chebyshev_center_raises_when_relaxed_center_infeasible(column):
+    # relaxed center a = 0.5 violates 3a <= 1.0: must fail, not return it
+    space = _space_with_dependent_constraint(column, b_constraint=1.0)
+    with pytest.warns(UserWarning, match="relaxed polytope"):
+        with pytest.raises(ValueError, match="dependent"):
+            chebyshev_center(space)
+
+
+def test_chebyshev_center_raises_on_dependent_equality_constraint(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=1.0)
+    b = RangedParameter("b", float, lb=0.0, ub=10.0)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_dependency(b, [a], transform=lambda x: 2 * x)
+    space.add_linear_equality_constraint(
+        LinearEqualityConstraint([a, b], lhs=[1.0, -1.0], b=0.0)
+    )
+    with pytest.raises(ValueError, match="equality"):
+        chebyshev_center(space)
+
+
+def test_chebyshev_center_raises_on_unbounded_parameter(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=np.inf), path="length"
+    )
+    with pytest.raises(ValueError, match="unbounded"):
+        chebyshev_center(space)
+
+
+def test_chebyshev_center_rounds_integer_parameter(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(RangedParameter("n", int, lb=10, ub=13), path="length")
+    center = chebyshev_center(space)
+    assert center["n"] == 12
+    assert isinstance(center["n"], int)
+
+
 # ── unseeded sampling ─────────────────────────────────────────────────────────
 
 

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -5,10 +5,12 @@ import pytest
 from CADETProcess.parameter_space import (
     ChoiceParameter,
     HopsySampler,
+    LatinHypercubeSampler,
     LinearConstraint,
     LinearEqualityConstraint,
     ParameterSpace,
     RangedParameter,
+    SobolSampler,
     chebyshev_center,
 )
 
@@ -167,7 +169,7 @@ def test_sample_integer_values_are_whole_numbers(column):
     space.add_evaluation_object(column)
     space.add_parameter(RangedParameter("n", int, lb=1, ub=100), path="length")
     samples = space.sample(10, seed=6, pool_size=BURN_IN)
-    assert all(s["n"] == round(s["n"]) for s in samples)
+    assert all(type(s["n"]) is int for s in samples)
     assert all(1 <= s["n"] <= 100 for s in samples)
 
 
@@ -328,6 +330,114 @@ def test_sample_significant_digits_snap(column):
         if v != 0.0:
             magnitude = 10 ** (math.floor(math.log10(abs(v))) - 1)
             assert abs(v - round(v / magnitude) * magnitude) < 1e-12 * abs(v) + 1e-15
+
+
+# ── LHS and Sobol samplers ────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("SamplerClass", [LatinHypercubeSampler, SobolSampler])
+def test_qmc_bounds_containment(column, SamplerClass):
+    space = _space_2d(column)
+    samples = SamplerClass().sample(space, 20, seed=0)
+    assert all(0.0 <= s["length"] <= 5.0 for s in samples)
+    assert all(0.0 <= s["diameter"] <= 2.0 for s in samples)
+
+
+@pytest.mark.parametrize("SamplerClass", [LatinHypercubeSampler, SobolSampler])
+def test_qmc_seed_determinism(column, SamplerClass):
+    space = _space_1d(column)
+    sampler = SamplerClass()
+    s1 = sampler.sample(space, 10, seed=7)
+    s2 = sampler.sample(space, 10, seed=7)
+    assert s1 == s2
+
+
+@pytest.mark.parametrize("SamplerClass", [LatinHypercubeSampler, SobolSampler])
+def test_qmc_raises_on_linear_constraints(column, SamplerClass):
+    space = _space_2d(column)
+    p1, p2 = space.independent_parameters
+    space.add_linear_constraint(LinearConstraint([p1, p2], lhs=[1.0, 1.0], b=4.0))
+    with pytest.raises(ValueError, match="linear constraints"):
+        SamplerClass().sample(space, 5, seed=0)
+
+
+@pytest.mark.parametrize("SamplerClass", [LatinHypercubeSampler, SobolSampler])
+def test_qmc_integer_and_categorical(column, SamplerClass):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(RangedParameter("n", int, lb=1, ub=10), path="length")
+    space.add_parameter(ChoiceParameter("mode", ["a", "b"]))
+    samples = SamplerClass().sample(space, 10, seed=0)
+    assert all(type(s["n"]) is int for s in samples)
+    assert all(s["mode"] in ("a", "b") for s in samples)
+
+
+def test_lhs_returned_set_is_stratified(column):
+    # the defining LHS property: n samples, exactly one per axis-aligned
+    # stratum; a random subset of a larger design would fail this
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(RangedParameter("length", float, lb=0.0, ub=8.0), path="length")
+    samples = LatinHypercubeSampler().sample(space, 8, seed=3)
+    strata = sorted(int(np.floor(s["length"])) for s in samples)
+    assert strata == list(range(8))
+
+
+def test_sobol_samples_are_sequence_prefix(column):
+    # sequential consumption: a smaller request must be a prefix of a larger
+    # one for the same seed, which random pool draws would not satisfy
+    space = _space_1d(column)
+    s4 = SobolSampler().sample(space, 4, seed=5)
+    s8 = SobolSampler().sample(space, 8, seed=5)
+    assert s8[:4] == s4
+
+
+def test_sobol_emits_no_balance_warning(column):
+    import warnings
+
+    space = _space_1d(column)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", UserWarning)
+        SobolSampler().sample(space, 10, seed=0)
+
+
+def _categorical_space(column, categories):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=5.0), path="length"
+    )
+    space.add_parameter(ChoiceParameter("mode", categories))
+    return space
+
+
+def test_lhs_categorical_counts_are_balanced(column):
+    # categoricals are extra design dimensions: 10 samples over 2 categories
+    # must split 5/5, whereas an independent random draw would not
+    space = _categorical_space(column, ["a", "b"])
+    samples = LatinHypercubeSampler().sample(space, 10, seed=0)
+    modes = [s["mode"] for s in samples]
+    assert modes.count("a") == 5
+    assert modes.count("b") == 5
+
+
+def test_sobol_categorical_counts_balanced_over_full_block(column):
+    # 8 = 2**3 samples over 2 categories: Sobol base-2 balance gives 4/4
+    space = _categorical_space(column, ["a", "b"])
+    samples = SobolSampler().sample(space, 8, seed=0)
+    modes = [s["mode"] for s in samples]
+    assert modes.count("a") == 4
+    assert modes.count("b") == 4
+
+
+def test_lhs_categorical_only_space_is_balanced(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(ChoiceParameter("mode", ["a", "b", "c"]))
+    samples = LatinHypercubeSampler().sample(space, 9, seed=1)
+    modes = [s["mode"] for s in samples]
+    assert sorted(set(modes)) == ["a", "b", "c"]
+    assert all(modes.count(m) == 3 for m in "abc")
 
 
 # ── chebyshev center ──────────────────────────────────────────────────────────


### PR DESCRIPTION
The hopsy-based construction was previously duplicated across `ParameterSpace.sample()`, `create_initial_values`, and `get_chebyshev_center`, making the implementation harder to maintain and preventing alternative sampling strategies from being plugged in. This PR consolidates that logic behind a sampler abstraction. `SamplerBase` now owns the complete feasibility pipeline—including bounds (with dependent parameters), linear constraints (including those involving dependent variables), integer rounding, and categorical sampling—while concrete backends are responsible only for generating candidate points.

`HopsySampler` remains the default for constrained parameter spaces, while the new `LatinHypercubeSampler` and `SobolSampler` provide space-filling designs for box-bounded surrogate modeling and DoE workflows. These designs are consumed in generation order, with categorical variables treated as additional stratified dimensions.

`get_chebyshev_center` now follows the same feasibility pipeline and returns either a verified feasible point or fails explicitly, rather than silently returning an infeasible one. `create_initial_values` gains a `sampler` argument, and a new user guide page documents `ParameterSpace` and its sampling interface independently.

The abstraction is intentionally extensible: additional backends, such as full-factorial grids, can be added by implementing `_candidates`.