### PR TITLE
Tear down parallelization worker pool after optimization

### DIFF
--- a/CADETProcess/optimization/optimizer.py
+++ b/CADETProcess/optimization/optimizer.py
@@ -292,6 +292,7 @@ class OptimizerBase(Structure):
                 )
         finally:
             plt.switch_backend(backend)
+            self.parallelization_backend.shutdown()
 
         return self.results
 

--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -63,6 +63,17 @@ class ParallelizationBackendBase(Structure):
         """
         pass
 
+    def shutdown(self) -> None:
+        """
+        Release any persistent worker resources held by the backend.
+
+        Called once at the end of an optimization run. Backends that keep a
+        worker pool alive across generations override this to tear it down;
+        the default is a no-op. Must be safe to call repeatedly and without a
+        prior ``evaluate``.
+        """
+        pass
+
     def __str__(self) -> str:
         """Return the class name as a string."""
         return self.__class__.__name__
@@ -154,6 +165,12 @@ class Joblib(ParallelizationBackendBase):
 
         return results
 
+    def shutdown(self) -> None:
+        """Shut down joblib's reusable (loky) worker pool."""
+        from joblib.externals.loky import get_reusable_executor
+
+        get_reusable_executor().shutdown(wait=True)
+
 
 try:
     import pathos
@@ -182,6 +199,15 @@ class Pathos(ParallelizationBackendBase):
         list
             List of results of function evaluations.
         """
-        with pathos.pools.ProcessPool(ncpus=self.n_cores) as pool:
-            results = pool.map(function, population)
-        return results
+        pool = getattr(self, "_pool", None)
+        if pool is None:
+            pool = self._pool = pathos.pools.ProcessPool(ncpus=self.n_cores)
+        return pool.map(function, population)
+
+    def shutdown(self) -> None:
+        """Terminate and release the cached worker pool."""
+        pool = getattr(self, "_pool", None)
+        if pool is not None:
+            pool.terminate()
+            pool.clear()
+            self._pool = None

--- a/docs/source/release_notes/v0.13.0.md
+++ b/docs/source/release_notes/v0.13.0.md
@@ -76,3 +76,4 @@ and the Comparator no longer needs to hold a reference registry.
 - Test suite restructured to mirror package layout; shared fixtures moved to `conftest.py` ([#378](https://github.com/fau-advanced-separations/CADET-Process/pull/378), [#379](https://github.com/fau-advanced-separations/CADET-Process/pull/379))
 - Coverage baseline established at 73% (2026-05-16)
 - Docs CI check added (`.github/workflows/docs.yml`); runs on all PRs with `nb_execution_mode=off`
+- Fix leaked worker processes after optimization: parallelization backends now release their worker pool at the end of `optimize()`, so a run no longer hangs at interpreter exit (Pathos) or stalls on loky's idle timeout (Joblib) ([#408](https://github.com/fau-advanced-separations/CADET-Process/pull/408))

--- a/tests/simulator/test_parallelization_adapter.py
+++ b/tests/simulator/test_parallelization_adapter.py
@@ -100,6 +100,7 @@ class TestParallelEvaluation(unittest.TestCase):
                 backend.n_cores = n_cores
             results = backend.evaluate(evaluation_function, [0.01] * 4)
             self.assertTrue(all(results))
+            backend.shutdown()
 
     @unittest.skipIf(found_cadet is False, "Skip if CADET is not installed.")
     def test_parallel_cadet_initialization(self):
@@ -124,6 +125,36 @@ class TestParallelEvaluation(unittest.TestCase):
             results = backend.evaluate(evaluation_function, [0.01] * 4)
 
             self.assertTrue(all(results))
+            backend.shutdown()
+
+
+class TestBackendShutdown(unittest.TestCase):
+    """Shutdown releases the worker pool without breaking reuse.
+
+    The pool is kept alive across an optimization's generations and torn down
+    once at the end; shutdown must therefore be safe to call before any
+    evaluation, be idempotent, and leave the backend usable again afterwards.
+    """
+
+    def test_sequential_shutdown_is_noop(self):
+        SequentialBackend().shutdown()
+
+    def test_shutdown_before_evaluate_does_not_raise(self):
+        for Backend in parallel_backends:
+            Backend(n_cores=n_cores).shutdown()
+
+    def test_shutdown_is_idempotent_and_pool_is_reusable(self):
+        for Backend in parallel_backends:
+            backend = Backend(n_cores=n_cores)
+
+            self.assertTrue(all(backend.evaluate(bool, [1, 1])))
+
+            backend.shutdown()
+            backend.shutdown()
+
+            # The pool is transparently recreated after teardown.
+            self.assertTrue(all(backend.evaluate(bool, [1, 1])))
+            backend.shutdown()
 
 
 class TestOptimizerParallelizationBackend(unittest.TestCase):


### PR DESCRIPTION
A leaked worker pool (pathos's cached pool, joblib's loky executor) could wedge interpreter teardown after the test suite passed, letting a CI job run to GitHub's 6h ceiling. Backends now expose `shutdown()`, which `optimize()` calls once in its `finally`; the pool is still spawned once and reused across generations, only released at the end of the run. Companion to the 30-minute CI timeout on `pipeline.yml`.