### PR TITLE
Fix evaluation pipeline cache process leak (Python 3.12 CI hang)

### DIFF
--- a/CADETProcess/evaluation_pipeline/pipeline.py
+++ b/CADETProcess/evaluation_pipeline/pipeline.py
@@ -289,13 +289,25 @@ class EvaluationPipeline:
                 self._pipeline = Pipeline(
                     list(self._nodes),
                     cache_type="disk",
-                    cache_kwargs={"cache_dir": str(self._cache_dir)},
+                    # lru_shared=False keeps the in-memory LRU a plain dict; the
+                    # shared variant backs it with a multiprocessing.Manager
+                    # process that is never torn down and deadlocks interpreter
+                    # exit on Python 3.12.  A process-shared cache buys nothing
+                    # here: parallelism is per-individual, so each worker holds
+                    # its own pipeline copy.
+                    cache_kwargs={
+                        "cache_dir": str(self._cache_dir),
+                        "lru_shared": False,
+                    },
                     validate_type_annotations=False,
                 )
             else:
                 self._pipeline = Pipeline(
                     list(self._nodes),
                     cache_type="hybrid",
+                    # shared=False: plain in-process dict instead of a
+                    # Manager-backed one.  See the disk branch above.
+                    cache_kwargs={"shared": False},
                     validate_type_annotations=False,
                 )
             _guard_recoverable_writes(self._pipeline.cache)

--- a/docs/source/release_notes/v0.13.0.md
+++ b/docs/source/release_notes/v0.13.0.md
@@ -126,3 +126,4 @@ and the Comparator no longer needs to hold a reference registry.
 - Coverage baseline established at 73% (2026-05-16)
 - Docs CI check added (`.github/workflows/docs.yml`); runs on all PRs with `nb_execution_mode=off`
 - Fix leaked worker processes after optimization: parallelization backends now release their worker pool at the end of `optimize()`, so a run no longer hangs at interpreter exit (Pathos) or stalls on loky's idle timeout (Joblib) ([#408](https://github.com/fau-advanced-separations/CADET-Process/pull/408))
+- Fix leaked manager processes from the evaluation pipeline cache: the pipeline no longer backs its result cache with a `multiprocessing.Manager`, whose process was never torn down and hung interpreter exit on Python 3.12. The cache stays in-process, which is sufficient because parallelism is per-individual.

--- a/tests/evaluation_pipeline/test_pipeline.py
+++ b/tests/evaluation_pipeline/test_pipeline.py
@@ -207,6 +207,27 @@ def test_different_x_invalidates_cache(single_space):
     assert r1["result"] != r2["result"]
 
 
+def test_evaluate_leaves_no_manager_process(single_space):
+    """Building and evaluating a pipeline must not leak a SyncManager process.
+
+    A process-shared cache backs its dict with a ``multiprocessing.Manager``,
+    whose SyncManager process is never torn down and deadlocks interpreter exit
+    on Python 3.12.  The cache must stay in-process.
+    """
+    import multiprocessing as mp
+
+    def _managers() -> list:
+        return [
+            p for p in mp.active_children() if type(p).__name__ == "SyncManager"
+        ]
+
+    before = len(_managers())
+    pipeline = EvaluationPipeline(single_space)
+    pipeline.add_evaluator(lambda model: model.value, output_name="result")
+    pipeline.evaluate({})
+    assert len(_managers()) == before
+
+
 def test_evaluate_rejects_vector_pointing_at_decode(single_space):
     pipeline = EvaluationPipeline(single_space)
     pipeline.add_evaluator(lambda model: model.value, output_name="v")

--- a/tests/test_problem.py
+++ b/tests/test_problem.py
@@ -413,6 +413,36 @@ def test_evaluate_batch_dispatches_rows_via_parallelization_backend(
     assert results[1]["squared"] == pytest.approx(0.25)
 
 
+def test_evaluate_batch_reuses_cache_across_sequential_calls():
+    """A later batch must reuse results computed by an earlier one.
+
+    Guards the in-process cache persistence that lets sequential batch
+    evaluations reuse previously computed results.  This is the property that
+    makes disabling the process-shared cache (``shared=False``) free of cost
+    for sequential use.
+    """
+    call_count = 0
+
+    def expensive(assignment):
+        nonlocal call_count
+        call_count += 1
+        return assignment["v"] ** 2
+
+    parameter_space = ParameterSpace()
+    parameter_space.add_parameter(RangedParameter("v", float, lb=0.0, ub=1.0))
+    pipeline = EvaluationPipeline(parameter_space)
+    pipeline.add_evaluator(expensive, output_name="squared")
+    metric_space = MetricSpace()
+    metric_space.add_objective(Metric("squared"))
+    problem = Problem(parameter_space, metric_space, backend=pipeline)
+
+    problem.evaluate_batch([{"v": 0.2}, {"v": 0.5}])
+    assert call_count == 2
+    # Second batch: 0.2 repeats the first batch (cache hit), 0.7 is new.
+    problem.evaluate_batch([{"v": 0.2}, {"v": 0.7}])
+    assert call_count == 3
+
+
 def test_evaluate_batch_unknown_target_raises_before_dispatch(
     yield_and_purity_space,
 ):


### PR DESCRIPTION
The evaluation pipeline backed its result cache with a process-shared pipefunc cache (`cache_type="hybrid"/"disk"`, default `shared=True`/`lru_shared=True`), which spawns a `multiprocessing.Manager` whose `SyncManager` process is never torn down. Pipeline rebuilds on node changes orphan one per rebuild; on Python 3.12 the leftover non-daemon managers deadlock the interpreter's atexit join, hanging the 3.12 CI job (3.13/3.14 reap them, so those pass). This is distinct from #408, which fixed parallelization-backend pool teardown.

The cache is now a plain in-process dict (`shared=False`/`lru_shared=False`). A process-shared cache buys nothing under per-individual parallelism (each worker holds its own pickled pipeline copy) and cache keys are exact-X, so cross-process reuse only ever hit on repeated points. In-process reuse within an evaluate and across sequential calls is unaffected, pinned by a new batch-level reuse test; a regression test asserts no `SyncManager` is left after an evaluate.