### PR TITLE
Deprecate Pathos parallelization backend

### DIFF
--- a/CADETProcess/optimization/parallelizationBackend.py
+++ b/CADETProcess/optimization/parallelizationBackend.py
@@ -1,6 +1,8 @@
 import multiprocessing
+import warnings
 from abc import abstractmethod
 from collections.abc import Iterable
+from typing import Any
 
 from CADETProcess.dataStructure import (
     Constant,
@@ -181,7 +183,22 @@ except ModuleNotFoundError:
 
 
 class Pathos(ParallelizationBackendBase):
-    """Parallelization backend using the pathos library."""
+    """
+    Parallelization backend using the pathos library.
+
+    .. deprecated:: 0.13
+        Use the default :class:`Joblib` backend instead. ``Pathos`` will be
+        removed in v0.14, and the ``pathos`` dependency dropped with it.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        warnings.warn(
+            "The Pathos backend is deprecated and will be removed in v0.14. "
+            "Use the default Joblib backend instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        super().__init__(*args, **kwargs)
 
     def evaluate(self, function: callable, population: Iterable) -> list:
         """

--- a/docs/source/release_notes/v0.13.0.md
+++ b/docs/source/release_notes/v0.13.0.md
@@ -115,6 +115,11 @@ Both will be removed in v1.0.
 The new API decouples metric construction from registration: users configure metrics directly,
 and the Comparator no longer needs to hold a reference registry.
 
+### Pathos parallelization backend
+
+The `Pathos` parallelization backend is deprecated in favor of the default `Joblib` backend, which covers the same ground.
+Instantiating it emits a `DeprecationWarning`; it will be removed in v0.14, which also drops the `pathos` dependency.
+
 ## Other changes
 
 - Fix `EvaluationFailure` cache policy: an unclassified exception now defaults to `recoverable=True` and is never cached, so a transient failure (OOM, cluster hiccup) can no longer permanently poison a legitimately good x. Deterministic failures (solver divergence, validation rejection) are still cached; a node author classifies one explicitly by setting `recoverable = False` on the raised exception.

--- a/docs/source/user_guide/optimization/parallel_evaluation.md
+++ b/docs/source/user_guide/optimization/parallel_evaluation.md
@@ -23,12 +23,12 @@ In this tutorial, the parallelization backend module of **CADET-Process** is int
 This module allows choosing between different parallelization strategies, each tailored to suit different hardware configuration and optimization needs.
 By selecting an appropriate backend, the workload can efficiently be distributed across multiple cores, reducing the time required for function evaluations and improving overall optimization performance.
 
-The parallelization backend module consists of four classes:
+The parallelization backend module consists of three classes:
 - {class}`~CADETProcess.optimization.ParallelizationBackendBase`: This class serves as the base for all parallelization backend adapters.
   It provides common attributes and methods that any parallelization backend must implement, such as {attr}`~CADETProcess.optimization.ParallelizationBackendBase.n_cores`, the number of cores to be used for parallelization.
 - {class}`~CADETProcess.optimization.SequentialBackend`: This backend is designed for cases where parallel execution is not desired or not possible.
   It evaluates the target function sequentially, one individual at a time, making it useful for single-core processors or when parallelization is not beneficial.
-- {class}`~CADETProcess.optimization.Joblib`, and {class}`~CADETProcess.optimization.Pathos`: Parallel backends allowing users to leverage multiple cores efficiently for function evaluations.
+- {class}`~CADETProcess.optimization.Joblib`: Parallel backend allowing users to leverage multiple cores efficiently for function evaluations.
 
 All backends implement a {meth}`~CADETProcess.optimization.ParallelizationBackendBase.evaluate` method which takes a function (callable) and a population (Iterable) as input.
 This method maps the provided function over the elements of the population array and returns a list containing the results of the function evaluations for each element.

--- a/tests/simulator/test_parallelization_adapter.py
+++ b/tests/simulator/test_parallelization_adapter.py
@@ -157,6 +157,18 @@ class TestBackendShutdown(unittest.TestCase):
             backend.shutdown()
 
 
+class TestPathosDeprecation(unittest.TestCase):
+    """Pathos is deprecated in favor of Joblib and slated for removal in v0.14."""
+
+    def test_instantiation_warns(self):
+        try:
+            from CADETProcess.optimization import Pathos
+        except ImportError:
+            self.skipTest("pathos not installed")
+        with self.assertWarns(DeprecationWarning):
+            Pathos()
+
+
 class TestOptimizerParallelizationBackend(unittest.TestCase):
     """Test parallel backends in optimizer.
 


### PR DESCRIPTION
Joblib is the default backend and covers the same ground, and Pathos was the deterministic teardown-hang source (its cached pool was never cleared), so it is the first to go. Instantiating `Pathos` now emits a `DeprecationWarning`; removal is targeted for v0.14, which drops the `pathos` dependency (and `dill`/`multiprocess` transitively).