### PR TITLE
Sample the parameter polytope in unit-box coordinates

### DIFF
--- a/CADETProcess/parameter_space/sampling.py
+++ b/CADETProcess/parameter_space/sampling.py
@@ -31,12 +31,24 @@ class _LogSpaceModel:
     """hopsy log-space model for parameters with nonlinear normalizers (e.g. LogNormalizer).
 
     Injects a Jacobian correction so hopsy draws are uniform in transformed space.
+
+    The polytope handed to hopsy lives in unit-box coordinates (see
+    ``HopsySampler._candidates``), so the callback first recovers the physical
+    value ``x = lb + scale * u``.  The correction is a property of the point,
+    not of the coordinates naming it: the constant scale factor cancels in the
+    normalization, so the target density is the one that would be obtained
+    sampling ``x`` directly.
     """
 
-    def __init__(self, log_indices: list[int]) -> None:
+    def __init__(
+        self, log_indices: list[int], lb: np.ndarray, scale: np.ndarray
+    ) -> None:
         self.log_space_indices = log_indices
+        self.lb = lb
+        self.scale = scale
 
-    def compute_negative_log_likelihood(self, x: np.ndarray) -> float:
+    def compute_negative_log_likelihood(self, u: np.ndarray) -> float:
+        x = self.lb + self.scale * u
         return float(np.sum(np.log(x[self.log_space_indices])))
 
 
@@ -183,6 +195,11 @@ class HopsySampler(SamplerBase):
     The only correct choice when linear inequality or equality constraints are
     present. Uses a log-space model for parameters with nonlinear normalizers.
 
+    The polytope is built in unit-box coordinates and the draws are mapped back
+    to physical units, so bounds of any magnitude sample correctly; hopsy's
+    rounding step otherwise rejects narrow-in-absolute-units spaces (e.g.
+    ``ub=1e-9``) as degenerate.
+
     Inequality constraints referencing dependent parameters are excluded from
     the polytope (a relaxation); SamplerBase enforces them by rejection.
     Equality constraints referencing dependent parameters raise, because an
@@ -220,22 +237,44 @@ class HopsySampler(SamplerBase):
             dtype=bool,
         )
 
+        lb_num = np.array([p.lb for p in numeric], dtype=float)
+        ub_num = np.array([p.ub for p in numeric], dtype=float)
+
+        # Sample in unit-box coordinates u = (x - lb) / (ub - lb) rather than in
+        # physical units.  PolyRound rejects any polytope narrower than an
+        # absolute threshold (thresh / accepted_tol_violation = 1e-9) as
+        # degenerate, so a legitimate but small-scale bound (ub=1e-9) fails to
+        # round.  The map is a shift and a per-parameter scale, so linear
+        # constraints stay linear and transform exactly; it is deliberately
+        # independent of each parameter's declared normalizer, since a
+        # nonlinear one would bend constraints into curves the polytope cannot
+        # represent.  Draws are mapped back to physical units before returning.
+        width = ub_num - lb_num
+        scale = np.where(width > 0, width, 1.0)
+        # 1.0 for a normal parameter, 0.0 for a degenerate one (lb == ub),
+        # which keeps the point-polytope a point instead of widening it.
+        ub_unit = width / scale
+
         log_indices = [
             i for i, p in enumerate(numeric) if not p.normalizer.is_linear
         ]
-        model = _LogSpaceModel(log_indices) if log_indices else None
+        model = (
+            _LogSpaceModel(log_indices, lb_num, scale) if log_indices else None
+        )
 
-        lb_num = np.array([p.lb for p in numeric], dtype=float)
-        ub_num = np.array([p.ub for p in numeric], dtype=float)
+        A = space.A_independent[independent_rows][:, numeric_idx]
         problem = hopsy.Problem(
-            space.A_independent[independent_rows][:, numeric_idx],
-            space.b[independent_rows],
+            A * scale,
+            space.b[independent_rows] - A @ lb_num,
             model,
         )
-        problem = hopsy.add_box_constraints(problem, lb_num, ub_num, simplify=False)
+        problem = hopsy.add_box_constraints(
+            problem, np.zeros_like(lb_num), ub_unit, simplify=False
+        )
         if space._linear_equality_constraints:
+            A_eq = space.A_eq_independent[:, numeric_idx]
             problem = hopsy.add_equality_constraints(
-                problem, space.A_eq_independent[:, numeric_idx], space.b_eq
+                problem, A_eq * scale, space.b_eq - A_eq @ lb_num
             )
 
         with warnings.catch_warnings():
@@ -248,7 +287,8 @@ class HopsySampler(SamplerBase):
             _, states = hopsy.sample(
                 mc, rng_hopsy, n_samples=self.pool_size, thinning=2
             )
-        return states[0]  # shape (pool_size, n_numeric)
+        # back to physical units; shape (pool_size, n_numeric)
+        return lb_num + states[0] * scale
 
 
 class LatinHypercubeSampler(SamplerBase):

--- a/tests/parameter_space/test_sampling.py
+++ b/tests/parameter_space/test_sampling.py
@@ -250,6 +250,100 @@ def test_sample_candidates_drawn_without_replacement(column):
     assert len(set(values)) == len(values)
 
 
+# ── extreme parameter scales ──────────────────────────────────────────────────
+
+
+def test_sample_tiny_bounds(column):
+    # hopsy's rounding step rejects polytopes narrower than an absolute
+    # threshold (1e-9) as degenerate; the sampler must build the polytope in
+    # unit-box coordinates so a legitimate small-scale bound still samples
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=0.0, ub=1e-9), path="length"
+    )
+    samples = space.sample(10, seed=0, pool_size=BURN_IN)
+    assert len(samples) == 10
+    assert all(0.0 <= s["length"] <= 1e-9 for s in samples)
+
+
+def test_sample_narrow_bounds_far_from_origin(column):
+    # narrow *and* offset: only rescaling by the width and shifting by the
+    # lower bound conditions this box
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=1e6, ub=1e6 + 1e-9), path="length"
+    )
+    samples = space.sample(10, seed=0, pool_size=BURN_IN)
+    assert all(1e6 <= s["length"] <= 1e6 + 1e-9 for s in samples)
+
+
+def test_sample_is_scale_invariant(column):
+    # the same seed must place draws at the same relative position in the box
+    # regardless of the units the bounds are expressed in
+    def relative(ub):
+        space = ParameterSpace()
+        space.add_evaluation_object(Column())
+        space.add_parameter(
+            RangedParameter("length", float, lb=0.0, ub=ub), path="length"
+        )
+        return [s["length"] / ub for s in space.sample(5, seed=7, pool_size=BURN_IN)]
+
+    np.testing.assert_allclose(relative(1e-12), relative(1.0), rtol=1e-9)
+    np.testing.assert_allclose(relative(1e12), relative(1.0), rtol=1e-9)
+
+
+def test_sample_tiny_bounds_with_linear_constraint(column):
+    # the constraint must be rescaled together with the parameters, or the
+    # unit-box polytope enforces the wrong half-space
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=1e-9)
+    b = RangedParameter("b", float, lb=0.0, ub=1e-9)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_linear_constraint(LinearConstraint([a, b], lhs=[1.0, 1.0], b=1e-9))
+    samples = space.sample(20, seed=0, pool_size=BURN_IN)
+    assert len(samples) == 20
+    assert all(s["a"] + s["b"] <= 1e-9 * (1 + 1e-9) for s in samples)
+    # the constraint must bind, not be trivially satisfied by a collapsed box
+    assert any(s["a"] + s["b"] > 0.5e-9 for s in samples)
+
+
+def test_sample_narrow_bounds_with_equality_constraint(column):
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    a = RangedParameter("a", float, lb=0.0, ub=1e-9)
+    b = RangedParameter("b", float, lb=0.0, ub=1e-9)
+    space.add_parameter(a, path="length")
+    space.add_parameter(b, path="diameter")
+    space.add_linear_equality_constraint(
+        LinearEqualityConstraint([a, b], lhs=[1.0, -1.0], b=0.0)
+    )
+    samples = space.sample(10, seed=0, pool_size=BURN_IN)
+    assert all(abs(s["a"] - s["b"]) <= 1e-9 * 1e-6 for s in samples)
+
+
+def test_sample_log_normalized_parameter_spreads_over_decades(column):
+    # the log-space weighting lives on the physical value, so it must survive
+    # the unit-box reparametrization: every decade keeps a comparable share of
+    # the draws.  Sampling in physical units without the weighting would put
+    # ~90% of the mass in the top decade alone.
+    space = ParameterSpace()
+    space.add_evaluation_object(column)
+    space.add_parameter(
+        RangedParameter("length", float, lb=1.0, ub=1e4, normalization="log"),
+        path="length",
+    )
+    values = np.array(
+        [s["length"] for s in space.sample(500, seed=0, pool_size=20_000)]
+    )
+    decade = np.floor(np.log10(values)).astype(int)
+    shares = [float((decade == k).mean()) for k in range(4)]
+    assert min(shares) > 0.15, shares  # uniform would be 0.25 each
+
+
 # ── linear constraints referencing dependent parameters ──────────────────────
 
 


### PR DESCRIPTION
Drawing initial values failed with `Rounding transformation not full dimensional` for any parameter whose bounds span less than about 1e-9, because hopsy's rounding step applies a degeneracy threshold that is absolute in the caller's units. `HopsySampler` now builds the polytope in unit-box coordinates and maps the draws back to physical units, so bounds of any magnitude sample correctly and the sampled distribution is unchanged. This is a regression against pre-refactor releases, where `OptimizationProblem` lowered the global `hopsy.LP()` threshold to 1e-15; that workaround mutated process-wide state and only moved the failure from 1e-9 to 1e-17, so it is not restored.