### PR TITLE
Fix duplicate metric name when CharacterizeBase registers more than one process

### DIFF
--- a/CADETProcess/characterization.py
+++ b/CADETProcess/characterization.py
@@ -190,6 +190,7 @@ class CharacterizeBase(OptimizationProblem):
         for process, comparator in zip(processes, comparators):
             self.add_objective(
                 comparator,
+                name=process.name,
                 n_objectives=comparator.n_metrics,
                 requires=[simulator],
                 evaluation_objects=process,

--- a/CADETProcess/characterization.py
+++ b/CADETProcess/characterization.py
@@ -22,6 +22,7 @@ import numpy as np
 from CADETProcess.comparison import Comparator
 from CADETProcess.instruments import LCProcess
 from CADETProcess.optimization import OptimizationProblem
+from CADETProcess.optimization.optimization_problem import _sanitize_name
 from CADETProcess.reference import ReferenceIO
 from CADETProcess.simulator import SimulatorBase
 
@@ -188,9 +189,11 @@ class CharacterizeBase(OptimizationProblem):
         self.add_evaluator(simulator)
 
         for process, comparator in zip(processes, comparators):
+            if comparator.name is None:
+                comparator.name = process.name
             self.add_objective(
                 comparator,
-                name=process.name,
+                name=_sanitize_name(process.name),
                 n_objectives=comparator.n_metrics,
                 requires=[simulator],
                 evaluation_objects=process,

--- a/CADETProcess/optimization/optimization_problem.py
+++ b/CADETProcess/optimization/optimization_problem.py
@@ -215,6 +215,18 @@ def _adapt_root_input(parameter_space: ParameterSpace, value: Any) -> Any:
     return value
 
 
+def _sanitize_name(name: str) -> str:
+    """Coerce *name* into a valid Python identifier.
+
+    Names that are derived on the caller's behalf rather than supplied by the
+    user still become pipeline node names, so they must be identifiers:
+    ``"pulse 30 CV"`` becomes ``"pulse_30_CV"`` and a leading digit is
+    prefixed with an underscore.  Names passed explicitly as ``name=`` are
+    validated instead of rewritten, see ``_check_metric_name``.
+    """
+    return re.sub(r"\W|^(?=\d)", "_", name)
+
+
 def _derive_name(func: Callable) -> str:
     """Derive a default node name for a callable.
 
@@ -228,7 +240,7 @@ def _derive_name(func: Callable) -> str:
         name = func.__name__
     else:
         name = type(func).__name__
-    return re.sub(r"\W|^(?=\d)", "_", name)
+    return _sanitize_name(name)
 
 
 def _approximate_jac(

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -250,6 +250,27 @@ def test_characterize_base_mismatched_comparators_raises(
         )
 
 
+def test_characterize_base_multi_process_registers_unique_objectives(
+    pulse_process, comparator, mock_simulator
+):
+    """Two processes must not collide on the shared 'Comparator' metric name."""
+    p2 = PulseInjection(
+        "pulse2",
+        pulse_process.flow_sheet,
+        c_buffer_a=[100.0],
+        c_sample=[0.0],
+        cycle_time=600.0,
+        flow_rate=FLOW_RATE,
+    )
+    prob = CharacterizeBase(
+        "test",
+        [pulse_process, p2],
+        [comparator, comparator],
+        mock_simulator,
+    )
+    assert prob.n_objectives == 2 * comparator.n_metrics
+
+
 # ---------------------------------------------------------------------------
 # CharacterizeTubing
 # ---------------------------------------------------------------------------

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -271,6 +271,44 @@ def test_characterize_base_multi_process_registers_unique_objectives(
     assert prob.n_objectives == 2 * comparator.n_metrics
 
 
+@pytest.mark.parametrize(
+    "process_name, expected_objective_name",
+    [
+        ("ok_name", "ok_name"),
+        ("pulse 30 CV", "pulse_30_CV"),
+        ("pulse-30", "pulse_30"),
+        ("5", "_5"),
+    ],
+)
+def test_characterize_base_sanitizes_process_name_for_objective(
+    column_fs, comparator, mock_simulator, process_name, expected_objective_name
+):
+    """Process names are free-form, but objective names must be identifiers."""
+    process = PulseInjection(
+        process_name,
+        column_fs,
+        c_buffer_a=[100.0],
+        c_sample=[0.0],
+        cycle_time=600.0,
+        flow_rate=FLOW_RATE,
+    )
+    prob = CharacterizeBase("test", process, comparator, mock_simulator)
+
+    assert prob.objective_names == [expected_objective_name]
+
+
+def test_characterize_base_names_unnamed_comparator_after_its_process(
+    pulse_process, flat_reference, mock_simulator
+):
+    comp = Comparator()
+    comp.add_reference(flat_reference)
+    comp.add_difference_metric("NRMSE", flat_reference, "column.outlet.outlet[0]")
+
+    CharacterizeBase("test", pulse_process, comp, mock_simulator)
+
+    assert comp.name == pulse_process.name
+
+
 # ---------------------------------------------------------------------------
 # CharacterizeTubing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
CharacterizeBase.__init__ called add_objective for each process/comparator pair without a name=, so OptimizationProblem.add_objective fell back to deriving the name from the objective's class, Comparator, for every pair. Any CharacterizeBase (or subclass) constructed with more than one process raised Metric 'Comparator' is already registered before it could run. Passing name=process.name gives each objective a unique, per-process metric name. Added a regression test that constructs a two-process CharacterizeBase and checks n_objectives; verified it fails without the fix and passes with it.