### PR TITLE
Fix LWE and StepElution never injecting their sample loop

### DIFF
--- a/CADETProcess/instruments/base.py
+++ b/CADETProcess/instruments/base.py
@@ -753,8 +753,9 @@ class StepElution(PhasedProcess):
     """
     Load/Wash/Elute process with a step to high salt instead of a gradient.
 
-    Three phases: wash (100 % buffer A), step to elute (100 % buffer B,
-    constant), final wash (100 % buffer A).
+    The sample loop is injected at t=0, then three phases follow: wash
+    (100 % buffer A), step to elute (100 % buffer B, constant), final wash
+    (100 % buffer A).
 
     Parameters
     ----------
@@ -806,12 +807,13 @@ class StepElution(PhasedProcess):
         if flow_rate_final_wash is None:
             flow_rate_final_wash = flow_rate_elute
 
-        phases = [
+        steps = [
+            ValveEvent("inject"),
             Phase(delta_t_wash, flow_rate_wash, {"A": 1.0}),
             Phase(delta_t_elute, flow_rate_elute, {"B": 1.0}),
             Phase(delta_t_final_wash, flow_rate_final_wash, {"A": 1.0}),
         ]
-        super().__init__(name, flow_sheet, phases)
+        super().__init__(name, flow_sheet, steps)
 
         for unit in self.flow_sheet.units:
             if "c" in unit.parameters:
@@ -917,9 +919,10 @@ class LWE(PhasedProcess):
     """
     Load/Wash/Elute process on an LC system.
 
-    The system is pre-equilibrated with buffer A. After the wash phase a linear
-    salt gradient ramps buffer A down to zero while buffer B ramps up. A final
-    wash phase holds at 100 % buffer B.
+    The system is pre-equilibrated with buffer A. The sample loop is injected
+    at t=0, then the wash phase runs; after it, a linear salt gradient ramps
+    buffer A down to zero while buffer B ramps up. A final wash phase holds
+    at 100 % buffer B.
 
     Parameters
     ----------
@@ -971,12 +974,13 @@ class LWE(PhasedProcess):
         if flow_rate_final_wash is None:
             flow_rate_final_wash = flow_rate_elute
 
-        phases = [
+        steps = [
+            ValveEvent("inject"),
             Phase(delta_t_wash, flow_rate_wash, {"A": 1.0}),
             Phase(delta_t_elute, flow_rate_elute, {"A": 1.0}, {"B": 1.0}),
             Phase(delta_t_final_wash, flow_rate_final_wash, {"B": 1.0}),
         ]
-        super().__init__(name, flow_sheet, phases)
+        super().__init__(name, flow_sheet, steps)
 
         for unit in self.flow_sheet.units:
             if "c" in unit.parameters:

--- a/docs/source/user_guide/experimental/instruments.md
+++ b/docs/source/user_guide/experimental/instruments.md
@@ -247,7 +247,8 @@ step.plot_events();
 ### LWE
 
 Load-wash-elute with a linear salt gradient.
-After the wash phase, buffer B ramps up linearly while buffer A ramps down.
+The sample loop is injected at t=0, then the wash phase runs; after it, buffer B
+ramps up linearly while buffer A ramps down.
 
 ```{code-cell} ipython3
 from CADETProcess.instruments import LWE

--- a/tests/instruments/test_base.py
+++ b/tests/instruments/test_base.py
@@ -469,6 +469,14 @@ def test_step_elution_has_three_phase_events(step_elution):
     assert {"phase_0_A", "phase_1_B", "phase_2_A"}.issubset(event_names)
 
 
+def test_step_elution_injects_sample_loop_at_t0(step_elution):
+    inject_events = [
+        e for e in step_elution.events if e.name.endswith("_inject")
+    ]
+    assert inject_events
+    assert all(e.time == pytest.approx(0.0) for e in inject_events)
+
+
 def test_step_elution_elute_phase_is_constant(step_elution):
     # phase_1_B should be a step (scalar), not a gradient (list)
     ev = next(e for e in step_elution.events if e.name == "phase_1_B")
@@ -565,7 +573,16 @@ def test_lwe_cycle_time_is_sum_of_phases(lwe_process):
 def test_lwe_has_events_for_all_three_phases(lwe_process):
     event_names = {e.name for e in lwe_process.events}
     assert event_names == {
+        "valve_tubing_pre_injection_inject", "valve_sample_loop_inject",
         "phase_0_A", "phase_0_B",
         "phase_1_A", "phase_1_B",
         "phase_2_A", "phase_2_B",
     }
+
+
+def test_lwe_injects_sample_loop_at_t0(lwe_process):
+    inject_events = [
+        e for e in lwe_process.events if e.name.endswith("_inject")
+    ]
+    assert inject_events
+    assert all(e.time == pytest.approx(0.0) for e in inject_events)


### PR DESCRIPTION
`LWE` and `StepElution` build their step list from plain `Phase` objects and never emit a `ValveEvent`, so `LCFlowSheet`'s default `"run"` valve position holds for the whole simulation: the sample loop stays out of the flow path and the protocol simulates a wash of nothing. `PulseInjection` already prepends `ValveEvent("inject")`; `StepElution`'s docstring already claimed to inject the loop contents but the code never did. Both now inject at `t=0`, mirroring `PulseInjection` — neither class has a separate load phase with its own duration, so the loop content is already in place by construction. A `ValveEvent` carries no duration and does not advance the phase clock, so `cycle_time` and all phase boundaries are unchanged; the valve event and the first phase's flow-rate events coexist at t=0 on disjoint parameter paths.