### PR TITLE
Restore Individual.id lost in the Population columnar rewrite

### DIFF
--- a/CADETProcess/characterization.py
+++ b/CADETProcess/characterization.py
@@ -208,7 +208,7 @@ class CharacterizeBase(OptimizationProblem):
             comparator_map[evaluation_object.name].plot_comparison(
                 simulation_results,
                 file_name=(
-                    f"{callbacks_dir}/{individual.id}"
+                    f"{callbacks_dir}/{individual.id_short}"
                     f"_{evaluation_object}_comparison.png"
                 ),
                 show=False,

--- a/CADETProcess/optimization/population.py
+++ b/CADETProcess/optimization/population.py
@@ -15,6 +15,7 @@ data.
 
 from __future__ import annotations
 
+import hashlib
 from collections.abc import Iterable, Iterator, Mapping
 from typing import Any, Optional
 
@@ -54,6 +55,21 @@ def _decode(value: Any) -> Any:
     return value
 
 
+def _hash_row(row: npt.ArrayLike) -> str:
+    """Deterministic sha256 hex digest of one parameter row's values.
+
+    Numeric rows hash the raw float64 bytes; object-dtype rows (categorical
+    parameters) hash a stable text encoding instead, since ``ndarray.tobytes``
+    on an object array serializes pointers, not values.
+    """
+    row = np.asarray(row)
+    if row.dtype.kind in "fiub":
+        payload = row.astype(np.float64).tobytes()
+    else:
+        payload = repr(row.tolist()).encode()
+    return hashlib.sha256(payload).hexdigest()
+
+
 class IndividualView:
     """Row lens over canonical ``Population`` storage.
 
@@ -91,6 +107,22 @@ class IndividualView:
         if metadata is None:
             return {}
         return {name: values[self._idx] for name, values in metadata.items()}
+
+    @property
+    def id(self) -> str:
+        """Content-derived id: sha256 digest of this row's parameter values.
+
+        Identical parameter values always produce the same id, including
+        across repeated evaluations in different generations, which is what
+        lets callback output files be traced back to a row in the results
+        table.
+        """
+        return _hash_row(self._population.x[self._idx])
+
+    @property
+    def id_short(self) -> str:
+        """First seven characters of :attr:`id`, for filenames and display."""
+        return self.id[0:7]
 
     def as_record(self) -> dict[str, Any]:
         """Return this row as a ``{"X": ..., "metrics": ..., "metadata": ...}`` record."""
@@ -550,6 +582,16 @@ class Population:
         if all(col.dtype.kind in "fiub" for col in columns):
             return np.column_stack([col.astype(float) for col in columns])
         return np.column_stack([col.astype(object) for col in columns])
+
+    @property
+    def ids(self) -> list[str]:
+        """Content-derived id per row: sha256 digest of the parameter values.
+
+        Rows with identical parameter values, in this or any other
+        population, get the same id.
+        """
+        x = self.x
+        return [_hash_row(x[i]) for i in range(self._n)]
 
     def _require_parameter_space(self) -> ParameterSpace:
         if self._parameter_space is None:

--- a/CADETProcess/optimization/results.py
+++ b/CADETProcess/optimization/results.py
@@ -963,6 +963,7 @@ class OptimizationResults(Structure):
             Results file name without file extension.
         """
         header = [
+            "id",
             *self.optimization_problem.variable_names,
             *self.optimization_problem.objective_labels,
         ]
@@ -972,7 +973,7 @@ class OptimizationResults(Structure):
         if self.optimization_problem.n_meta_scores > 0:
             header += [*self.optimization_problem.meta_score_labels]
 
-        with open(f"{self.results_directory / file_name}.csv", "w") as csvfile:
+        with open(f"{self.results_directory / file_name}.csv", "w", newline="") as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
             writer.writerow(header)
 
@@ -1003,15 +1004,16 @@ class OptimizationResults(Structure):
             self._setup_csv(file_name)
             mode = "a"
 
-        with open(f"{self.results_directory / file_name}.csv", mode) as csvfile:
+        with open(f"{self.results_directory / file_name}.csv", mode, newline="") as csvfile:
             writer = csv.writer(csvfile, delimiter=",")
 
+            ids = population.ids
             x = population.x
             f = population.f
             g = population.g
             m = population.plain_metrics
             for i in range(len(population)):
-                row = [*np.asarray(x[i]).tolist(), *f[i].tolist()]
+                row = [ids[i], *np.asarray(x[i]).tolist(), *f[i].tolist()]
                 if g.shape[1] > 0:
                     row += g[i].tolist()
                 if m.shape[1] > 0:

--- a/tests/optimization/test_optimization_results.py
+++ b/tests/optimization/test_optimization_results.py
@@ -1,3 +1,4 @@
+import csv
 import shutil
 import unittest
 from pathlib import Path
@@ -182,6 +183,20 @@ class TestOptimizationResults(unittest.TestCase):
                 optimization_results_new.to_dict()
             ),
         )
+
+    def test_save_results_csv_includes_id_column(self):
+        self.optimization_results.save_results("checkpoint")
+
+        csv_path = self.optimization_results.results_directory / "results_last.csv"
+        with open(csv_path) as f:
+            reader = csv.reader(f)
+            header = next(reader)
+            rows = list(reader)
+
+        self.assertEqual(header[0], "id")
+
+        expected_ids = self.optimization_results.population_last.ids
+        self.assertEqual([row[0] for row in rows], expected_ids)
 
 
 if __name__ == "__main__":

--- a/tests/optimization/test_population.py
+++ b/tests/optimization/test_population.py
@@ -177,6 +177,67 @@ def test_iteration_yields_views(population):
     assert all(isinstance(v, IndividualView) for v in views)
 
 
+# ── Identity (id) ─────────────────────────────────────────────────────────────
+
+
+def test_id_matches_between_view_and_population(population):
+    """IndividualView.id and Population.ids must agree for the same row."""
+    for i, view in enumerate(population):
+        assert view.id == population.ids[i]
+
+
+def test_id_is_deterministic(objective_space):
+    """Identical parameter values, even across separate populations, share an id."""
+    pop_a = Population(
+        X={"var_0": [1.0], "var_1": [2.0]},
+        metrics={"f": [-1.0]},
+        metric_space=objective_space,
+    )
+    pop_b = Population(
+        X={"var_0": [1.0], "var_1": [2.0]},
+        metrics={"f": [-9.0]},
+        metric_space=objective_space,
+    )
+    assert pop_a[0].id == pop_b[0].id
+
+
+def test_id_differs_for_different_rows(population):
+    assert population[0].id != population[1].id
+
+
+def test_id_short_is_prefix_of_id(population):
+    view = population[0]
+    assert view.id_short == view.id[:7]
+    assert len(view.id_short) == 7
+
+
+def test_id_handles_categorical_columns(mixed_population):
+    """Object-dtype (categorical) parameter columns must not hash pointer bytes."""
+    assert mixed_population[0].id != mixed_population[1].id
+
+
+def test_id_is_deterministic_for_categorical_columns(mixed_space):
+    """Same categorical value in two independently-built populations must
+    yield the same id.
+
+    A naive ``ndarray.tobytes()`` on an object-dtype row hashes Python object
+    pointers rather than values, which would pass within a single population
+    (same underlying objects) but fail here, since the two rows are distinct
+    Python string objects with the same value.
+    """
+    pop_a = Population.from_records(
+        [{"X": {"flow": 1.2, "resin": "A"},
+          "metrics": {"yield": [0.8, 0.9], "purity": 0.97, "cost": 3.0}}],
+        metric_space=mixed_space,
+    )
+    pop_b = Population.from_records(
+        [{"X": {"flow": 1.2, "resin": "A"},
+          "metrics": {"yield": [0.1, 0.2], "purity": 0.50, "cost": 9.0}}],
+        metric_space=mixed_space,
+    )
+    assert pop_a[0].id == pop_b[0].id
+
+
 # ── Value matching ────────────────────────────────────────────────────────────
 
 

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -309,6 +309,33 @@ def test_characterize_base_names_unnamed_comparator_after_its_process(
     assert comp.name == pulse_process.name
 
 
+def test_characterize_base_callback_writes_plot_file(
+    pulse_process, comparator, mock_simulator, tmp_path, caplog
+):
+    """Regression test: the registered callback used to reference
+    ``individual.id``, which doesn't exist on ``IndividualView``.  The
+    AttributeError was swallowed by evaluate_callbacks into a logged
+    warning, so no comparison plot was ever written and nobody noticed.
+
+    Uses CharacterizeBed (rather than a bare CharacterizeBase) because a
+    zero-variable problem can't build a one-row population: with no
+    parameter columns, Population has nothing to infer its row count from.
+    """
+    prob = CharacterizeBed("test", pulse_process, comparator, mock_simulator)
+
+    calls = []
+    comparator.plot_comparison = lambda *args, **kwargs: calls.append(kwargs)
+
+    pop = prob.create_population([[0.4, 1e-7]])
+    prob.evaluate_callbacks(pop, current_iteration=0, callbacks_dir=tmp_path)
+
+    assert "failed" not in caplog.text
+    assert len(calls) == 1
+    file_name = calls[0]["file_name"]
+    assert file_name.endswith("_pulse_comparison.png")
+    assert pop[0].id_short in file_name
+
+
 # ---------------------------------------------------------------------------
 # CharacterizeTubing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The columnar rewrite (`3343e225`) deleted `hash_array`/`Individual.id`/`id_short` along with `individual.py`, and dropped the `id` column from `results.py`'s CSVs, but left `CharacterizeBase`'s plotting callback referencing `individual.id`. Every `CharacterizeBase` run since has raised `AttributeError` inside the callback, silently swallowed by `evaluate_callbacks` into a logged warning: no comparison plots were ever written, and the results CSVs lost the column that would have let a plot be traced back to its row. Restores the same content-derived id (sha256 digest of the row's parameter values) as a vectorized `Population.ids` property with `IndividualView.id`/`.id_short` delegating by row index, puts `id` back as the CSV's first column, and switches the callback to the short form. Row-wise digests now branch on dtype: categorical (object-dtype) columns hash a stable text encoding instead of raw bytes, since `ndarray.tobytes()` on an object array serializes pointers, not values, a gap the historic implementation never had to handle.