### PR TITLE
Add optional equilibration phase to LC process templates

### DIFF
--- a/CADETProcess/instruments/base.py
+++ b/CADETProcess/instruments/base.py
@@ -732,6 +732,10 @@ class Breakthrough(PhasedProcess):
     sample_buffer : str, optional
         Buffer key carrying the sample. Default ``"F"`` (feed inlet).
         Any key ``"A"``–``"D"`` or ``"F"`` is valid.
+    delta_t_equilibration : float, optional
+        Equilibration phase duration in seconds, run at ``flow_rate`` with
+        buffer A before the breakthrough phase. Default 0 omits this phase.
+        Added to ``cycle_time``.
     """
 
     def __init__(
@@ -742,8 +746,12 @@ class Breakthrough(PhasedProcess):
         flow_rate: float,
         cycle_time: float,
         sample_buffer: str = "F",
+        delta_t_equilibration: float = 0.0,
     ) -> None:
-        phases = [Phase(cycle_time, flow_rate, {sample_buffer: 1.0})]
+        phases = []
+        if delta_t_equilibration > 0:
+            phases.append(Phase(delta_t_equilibration, flow_rate, {"A": 1.0}))
+        phases.append(Phase(cycle_time, flow_rate, {sample_buffer: 1.0}))
         super().__init__(name, flow_sheet, phases)
         buf_name = _BUFFER_KEYS[sample_buffer]
         getattr(self.flow_sheet, buf_name).c = c_sample
@@ -781,6 +789,10 @@ class StepElution(PhasedProcess):
         Flow rate during elution. Defaults to ``flow_rate_wash``.
     flow_rate_final_wash : float, optional
         Flow rate during final wash. Defaults to ``flow_rate_elute``.
+    delta_t_equilibration : float, optional
+        Equilibration phase duration in seconds, run at ``flow_rate_wash``
+        with buffer A before the sample loop is injected. Default 0 omits
+        this phase. Added to ``cycle_time``.
     """
 
     def __init__(
@@ -796,6 +808,7 @@ class StepElution(PhasedProcess):
         flow_rate_wash: float,
         flow_rate_elute: float | None = None,
         flow_rate_final_wash: float | None = None,
+        delta_t_equilibration: float = 0.0,
     ) -> None:
         if not flow_sheet.has_sample_loop:
             raise ValueError(
@@ -807,7 +820,10 @@ class StepElution(PhasedProcess):
         if flow_rate_final_wash is None:
             flow_rate_final_wash = flow_rate_elute
 
-        steps = [
+        steps = []
+        if delta_t_equilibration > 0:
+            steps.append(Phase(delta_t_equilibration, flow_rate_wash, {"A": 1.0}))
+        steps += [
             ValveEvent("inject"),
             Phase(delta_t_wash, flow_rate_wash, {"A": 1.0}),
             Phase(delta_t_elute, flow_rate_elute, {"B": 1.0}),
@@ -846,6 +862,10 @@ class PulseInjection(PhasedProcess):
         Experiment duration in seconds.
     flow_rate : float
         Volumetric flow rate in m³/s.
+    delta_t_equilibration : float, optional
+        Equilibration phase duration in seconds, run at ``flow_rate`` with
+        buffer A before the sample loop is injected. Default 0 omits this
+        phase. Added to ``cycle_time``.
     """
 
     def __init__(
@@ -856,13 +876,17 @@ class PulseInjection(PhasedProcess):
         c_sample: list[float],
         cycle_time: float,
         flow_rate: float,
+        delta_t_equilibration: float = 0.0,
     ) -> None:
         if not flow_sheet.has_sample_loop:
             raise ValueError(
                 "PulseInjection requires a sample loop. "
                 "Pass sample_loop_volume to LCFlowSheet."
             )
-        steps = [ValveEvent("inject"), Phase(cycle_time, flow_rate, {"A": 1.0})]
+        steps = []
+        if delta_t_equilibration > 0:
+            steps.append(Phase(delta_t_equilibration, flow_rate, {"A": 1.0}))
+        steps += [ValveEvent("inject"), Phase(cycle_time, flow_rate, {"A": 1.0})]
         super().__init__(name, flow_sheet, steps)
 
         for unit in self.flow_sheet.units:
@@ -894,6 +918,10 @@ class Step(PhasedProcess):
         Experiment duration in seconds.
     flow_rate : float
         Volumetric flow rate in m³/s.
+    delta_t_equilibration : float, optional
+        Equilibration phase duration in seconds, run at ``flow_rate`` with
+        buffer A before the step to buffer B. Default 0 omits this phase.
+        Added to ``cycle_time``.
     """
 
     def __init__(
@@ -904,8 +932,12 @@ class Step(PhasedProcess):
         c_buffer_b: list[float],
         cycle_time: float,
         flow_rate: float,
+        delta_t_equilibration: float = 0.0,
     ) -> None:
-        phases = [Phase(cycle_time, flow_rate, {"B": 1.0})]
+        phases = []
+        if delta_t_equilibration > 0:
+            phases.append(Phase(delta_t_equilibration, flow_rate, {"A": 1.0}))
+        phases.append(Phase(cycle_time, flow_rate, {"B": 1.0}))
         super().__init__(name, flow_sheet, phases)
 
         for unit in self.flow_sheet.units:
@@ -948,6 +980,10 @@ class LWE(PhasedProcess):
         Flow rate during elution. Defaults to ``flow_rate_wash``.
     flow_rate_final_wash : float, optional
         Flow rate during final wash. Defaults to ``flow_rate_elute``.
+    delta_t_equilibration : float, optional
+        Equilibration phase duration in seconds, run at ``flow_rate_wash``
+        with buffer A before the sample loop is injected. Default 0 omits
+        this phase. Added to ``cycle_time``.
     """
 
     def __init__(
@@ -963,6 +999,7 @@ class LWE(PhasedProcess):
         flow_rate_wash: float,
         flow_rate_elute: float | None = None,
         flow_rate_final_wash: float | None = None,
+        delta_t_equilibration: float = 0.0,
     ) -> None:
         if not flow_sheet.has_sample_loop:
             raise ValueError(
@@ -974,7 +1011,10 @@ class LWE(PhasedProcess):
         if flow_rate_final_wash is None:
             flow_rate_final_wash = flow_rate_elute
 
-        steps = [
+        steps = []
+        if delta_t_equilibration > 0:
+            steps.append(Phase(delta_t_equilibration, flow_rate_wash, {"A": 1.0}))
+        steps += [
             ValveEvent("inject"),
             Phase(delta_t_wash, flow_rate_wash, {"A": 1.0}),
             Phase(delta_t_elute, flow_rate_elute, {"A": 1.0}, {"B": 1.0}),

--- a/docs/source/user_guide/experimental/instruments.md
+++ b/docs/source/user_guide/experimental/instruments.md
@@ -209,6 +209,8 @@ Each takes a pre-constructed {class}`~CADETProcess.instruments.LCFlowSheet` as i
 
 The system is pre-equilibrated with buffer A.
 The sample loop content is injected at t=0 and washed through with buffer A.
+Pass `delta_t_equilibration` to prepend an explicit buffer-A phase before the injection instead of assuming it is already equilibrated; this pushes the inject event later by that amount and adds it to `cycle_time`.
+Every template below accepts the same parameter for the same purpose.
 
 ```{code-cell} ipython3
 from CADETProcess.instruments import PulseInjection

--- a/tests/instruments/test_base.py
+++ b/tests/instruments/test_base.py
@@ -425,6 +425,17 @@ def test_breakthrough_cycle_time(breakthrough):
     assert breakthrough.cycle_time == pytest.approx(600.0)
 
 
+def test_breakthrough_equilibration_extends_cycle_time(no_column_fs):
+    proc = Breakthrough(
+        "bt_eq", no_column_fs,
+        c_sample=[100.0],
+        flow_rate=flow_rate,
+        cycle_time=600.0,
+        delta_t_equilibration=10.0,
+    )
+    assert proc.cycle_time == pytest.approx(610.0)
+
+
 def test_breakthrough_with_regular_buffer(salt_cs):
     fs = LCFlowSheet(
         salt_cs,
@@ -491,6 +502,24 @@ def test_step_elution_a_zero_during_elute(step_elution):
     assert v == pytest.approx(0.0)
 
 
+def test_step_elution_equilibration_delays_inject_and_extends_cycle_time(column_fs):
+    proc = StepElution(
+        "se_eq", column_fs,
+        c_buffer_a=[20.0],
+        c_buffer_b=[1000.0],
+        c_sample=[20.0],
+        delta_t_wash=200.0,
+        delta_t_elute=400.0,
+        delta_t_final_wash=100.0,
+        flow_rate_wash=flow_rate,
+        delta_t_equilibration=30.0,
+    )
+    assert proc.cycle_time == pytest.approx(730.0)
+    inject_events = [e for e in proc.events if e.name.endswith("_inject")]
+    assert inject_events
+    assert all(e.time == pytest.approx(30.0) for e in inject_events)
+
+
 # --- PulseInjection ---
 
 @pytest.fixture
@@ -525,6 +554,21 @@ def test_pulse_cycle_time(pulse_injection):
     assert pulse_injection.cycle_time == 600.0
 
 
+def test_pulse_equilibration_delays_inject_and_extends_cycle_time(no_column_fs):
+    proc = PulseInjection(
+        "pulse_eq", no_column_fs,
+        c_buffer_a=[0.0],
+        c_sample=[100.0],
+        cycle_time=600.0,
+        flow_rate=flow_rate,
+        delta_t_equilibration=50.0,
+    )
+    assert proc.cycle_time == pytest.approx(650.0)
+    inject_events = [e for e in proc.events if e.name.endswith("_inject")]
+    assert inject_events
+    assert all(e.time == pytest.approx(50.0) for e in inject_events)
+
+
 # --- Step ---
 
 @pytest.fixture
@@ -548,6 +592,20 @@ def test_step_buffer_a_has_no_flow(step_process):
 
 def test_step_buffer_b_concentration(step_process):
     assert step_process.flow_sheet.buffer_b.c[0, 0] == pytest.approx(1000.0)
+
+
+def test_step_equilibration_extends_cycle_time(no_column_fs):
+    proc = Step(
+        "step_eq", no_column_fs,
+        c_buffer_a=[0.0],
+        c_buffer_b=[1000.0],
+        cycle_time=800.0,
+        flow_rate=flow_rate,
+        delta_t_equilibration=20.0,
+    )
+    assert proc.cycle_time == pytest.approx(820.0)
+    ev = next(e for e in proc.events if e.name == "phase_1_B")
+    assert ev.time == pytest.approx(20.0)
 
 
 # --- LWE ---
@@ -586,3 +644,21 @@ def test_lwe_injects_sample_loop_at_t0(lwe_process):
     ]
     assert inject_events
     assert all(e.time == pytest.approx(0.0) for e in inject_events)
+
+
+def test_lwe_equilibration_delays_inject_and_extends_cycle_time(column_fs):
+    proc = LWE(
+        "lwe_eq", column_fs,
+        c_buffer_a=[20.0],
+        c_buffer_b=[1000.0],
+        c_sample=[20.0],
+        delta_t_wash=200.0,
+        delta_t_elute=400.0,
+        delta_t_final_wash=100.0,
+        flow_rate_wash=flow_rate,
+        delta_t_equilibration=40.0,
+    )
+    assert proc.cycle_time == pytest.approx(740.0)
+    inject_events = [e for e in proc.events if e.name.endswith("_inject")]
+    assert inject_events
+    assert all(e.time == pytest.approx(40.0) for e in inject_events)


### PR DESCRIPTION
PulseInjection, StepElution, and LWE injected the sample loop at t=0 with no way to model a preceding equilibration run; Step and Breakthrough claimed pre-equilibration in their docstrings without ever building the phase. This adds an optional delta_t_equilibration parameter (default 0, no behavior change) to all five templates that prepends a buffer-A phase at each template's own flow rate before the existing sequence, extending cycle_time accordingly. Quick follow-up to #423.

## Test plan
- [x] tests/instruments/test_base.py (68 passed)
- [x] ruff check clean