### PR TITLE
Extend CharacterizeBed with an optional particle porosity fit

### DIFF
--- a/CADETProcess/characterization.py
+++ b/CADETProcess/characterization.py
@@ -329,6 +329,13 @@ class CharacterizeBed(CharacterizeBase):
     """
     Fit column bed porosity and axial dispersion.
 
+    Optionally also fits particle porosity.
+    A single tracer run cannot separate the two porosities, so this requires at
+    least two processes whose tracers differ in size: a small tracer accesses the
+    total void volume, a large one only the interstitial void volume.
+    Use :class:`CharacterizeParticles` instead when particle porosity is to be
+    determined together with the particle-phase transport parameters.
+
     Parameters
     ----------
     name : str
@@ -339,13 +346,33 @@ class CharacterizeBed(CharacterizeBase):
         One comparator per process.
     simulator : SimulatorBase
         Configured simulator instance.
+    include_particle_porosity : bool
+        Also fit particle porosity (scalar). Default False.
     **kwargs
         Per-variable override dicts (e.g. ``bed_porosity={"lb": 0.35, "ub": 0.45}``)
         and remaining keyword arguments forwarded to :class:`CharacterizeBase`.
     """
 
+    def __init__(
+        self,
+        name: str,
+        processes: LCProcess | list[LCProcess],
+        comparators: Comparator | list[Comparator],
+        simulator: SimulatorBase,
+        include_particle_porosity: bool = False,
+        **kwargs: object,
+    ) -> None:
+        self._include_particle_porosity = include_particle_porosity
+        super().__init__(
+            name=name,
+            processes=processes,
+            comparators=comparators,
+            simulator=simulator,
+            **kwargs,
+        )
+
     def _default_variables(self) -> list[dict]:
-        return [
+        variables = [
             {
                 "name": "bed_porosity",
                 "parameter_path": "flow_sheet.column.bed_porosity",
@@ -361,6 +388,16 @@ class CharacterizeBed(CharacterizeBase):
                 "transform": "auto",
             },
         ]
+        if self._include_particle_porosity:
+            variables.append({
+                "name": "particle_porosity",
+                "parameter_path": "flow_sheet.column.particle_porosity",
+                "lb": 0.6,
+                "ub": 0.9,
+                "transform": "auto",
+            })
+
+        return variables
 
 
 class CharacterizeParticles(CharacterizeBase):

--- a/docs/source/user_guide/experimental/characterization.md
+++ b/docs/source/user_guide/experimental/characterization.md
@@ -177,6 +177,27 @@ print(char.variable_names)
 # ['bed_porosity', 'axial_dispersion']
 ```
 
+Setting `include_particle_porosity=True` adds particle porosity $\varepsilon_p \in [0.6, 0.9]$ to the fit.
+This requires an experimental design that separates the two void volumes, since a single tracer run cannot resolve both porosities: a small tracer accesses the total void volume, a large one only the interstitial void volume.
+Pass one process per tracer, each with its own comparator, so that both runs constrain the same set of variables.
+
+```{code-cell} ipython3
+:tags: [skip-execution]
+
+char = CharacterizeBed(
+    "void_volume",
+    [process_small_tracer, process_large_tracer],
+    [comparator_small_tracer, comparator_large_tracer],
+    simulator,
+    include_particle_porosity=True,
+)
+print(char.variable_names)
+# ['bed_porosity', 'axial_dispersion', 'particle_porosity']
+```
+
+{class}`~CADETProcess.characterization.CharacterizeParticles` exposes a `particle_porosity` flag as well.
+Use that class when particle porosity is determined together with the particle-phase transport parameters, and this one when it follows from tracers of different size.
+
 
 ### CharacterizeParticles
 

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -389,6 +389,33 @@ def test_characterize_bed_bounds(pulse_process, comparator, mock_simulator):
     assert bp.ub == pytest.approx(0.6)
 
 
+def test_characterize_bed_excludes_particle_porosity(
+    pulse_process, comparator, mock_simulator
+):
+    prob = CharacterizeBed("bed", pulse_process, comparator, mock_simulator)
+    assert "particle_porosity" not in prob.variable_names
+
+
+def test_characterize_bed_particle_porosity(pulse_process, comparator, mock_simulator):
+    prob = CharacterizeBed(
+        "bed", pulse_process, comparator, mock_simulator,
+        include_particle_porosity=True,
+    )
+    assert "particle_porosity" in prob.variable_names
+
+
+def test_characterize_bed_particle_porosity_bounds(
+    pulse_process, comparator, mock_simulator
+):
+    prob = CharacterizeBed(
+        "bed", pulse_process, comparator, mock_simulator,
+        include_particle_porosity=True,
+    )
+    pp = prob.variables_dict["particle_porosity"]
+    assert pp.lb == pytest.approx(0.6)
+    assert pp.ub == pytest.approx(0.9)
+
+
 # ---------------------------------------------------------------------------
 # CharacterizeParticles
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Determining bed porosity and particle porosity separately needs pulse-tracer runs with tracers of different size, since a small tracer reports the total void volume and a large one only the interstitial volume. Neither existing class covered that: `CharacterizeBed` fits bed porosity, `CharacterizeParticles` fits particle porosity alongside the particle-phase transport parameters, and the joint void-volume case fell between them. This adds an `include_particle_porosity` flag to `CharacterizeBed`, following the flag pattern `CharacterizeParticles` already uses, so the case is covered without a third class that would differ by one variable. Defaults are unchanged, and the user guide states which of the two classes to reach for.